### PR TITLE
fix(pom): add quarkus-maven-plugin definition to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>${quarkus.platform.group-id}</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
                     <version>${formatter-maven-plugin.version}</version>


### PR DESCRIPTION
This makes it posible to build modules like this: `mvn quarkus:dev -pl build-analyser -am`.