### PR TITLE
Move quarkus-jgit and quarkus-operator-sdk to dependencyManagement

### DIFF
--- a/build-analyser/pom.xml
+++ b/build-analyser/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>io.quarkiverse.jgit</groupId>
             <artifactId>quarkus-jgit</artifactId>
-            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/build-recipes-database/pom.xml
+++ b/build-recipes-database/pom.xml
@@ -22,8 +22,8 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
+            <groupId>io.quarkiverse.jgit</groupId>
+            <artifactId>quarkus-jgit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logmanager</groupId>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -13,7 +13,6 @@
         <dependency>
             <groupId>io.quarkiverse.operatorsdk</groupId>
             <artifactId>quarkus-operator-sdk</artifactId>
-            <version>3.0.7</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
         <aws-url-connection-client.version>2.17.95</aws-url-connection-client.version>
         <aws-java-sdk-s3.version>1.12.169</aws-java-sdk-s3.version>
-        <jgit.version>6.1.0.202203080745-r</jgit.version>
+        <quarkus-jgit.version>1.2.0</quarkus-jgit.version>
         <gradle-tooling-api.version>7.4.2</gradle-tooling-api.version>
     </properties>
 
@@ -76,9 +76,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.eclipse.jgit</groupId>
-                <artifactId>org.eclipse.jgit</artifactId>
-                <version>${jgit.version}</version>
+                <groupId>io.quarkiverse.jgit</groupId>
+                <artifactId>quarkus-jgit</artifactId>
+                <version>${quarkus-jgit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.gradle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <aws-url-connection-client.version>2.17.95</aws-url-connection-client.version>
         <aws-java-sdk-s3.version>1.12.169</aws-java-sdk-s3.version>
         <quarkus-jgit.version>1.2.0</quarkus-jgit.version>
+        <quarkus-operator-sdk.version>3.0.7</quarkus-operator-sdk.version>
         <gradle-tooling-api.version>7.4.2</gradle-tooling-api.version>
     </properties>
 
@@ -79,6 +80,11 @@
                 <groupId>io.quarkiverse.jgit</groupId>
                 <artifactId>quarkus-jgit</artifactId>
                 <version>${quarkus-jgit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.operatorsdk</groupId>
+                <artifactId>quarkus-operator-sdk</artifactId>
+                <version>${quarkus-operator-sdk.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.gradle</groupId>


### PR DESCRIPTION
 - Move quarkus-jgit and quarkus-operator-sdk to dependencyManagement
 - Replace org.eclipse.jgit with quarkus-jgit to have just one jgit dependency defined

