### PR TITLE
Updating java base image to openjdk-17

### DIFF
--- a/java-components/cache/src/main/docker/Dockerfile.jvm
+++ b/java-components/cache/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/java-components/cache/src/main/docker/Dockerfile.legacy-jar
+++ b/java-components/cache/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/java-components/sidecar/src/main/docker/Dockerfile.jvm
+++ b/java-components/sidecar/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/java-components/sidecar/src/main/docker/Dockerfile.legacy-jar
+++ b/java-components/sidecar/src/main/docker/Dockerfile.legacy-jar
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.11
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.12
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 


### PR DESCRIPTION
Required java version is 17, updating base images as well.