### PR TITLE
Unit tests, e2e test reorg

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,6 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
-github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-critic/go-critic v0.6.1/go.mod h1:SdNCfU0yF3UBjtaZGw6586/WocupMOJuiqgom5DsQxM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -511,14 +509,10 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
-github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -697,6 +691,7 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -771,8 +766,6 @@ github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOj
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
@@ -1039,6 +1032,8 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1048,7 +1043,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
@@ -1167,8 +1161,6 @@ github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:r
 github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e h1:Vx7tzbgpkwr2vyLoAhPi7Qrv/Pul1b4z7i4cNqhkMuo=
-github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1407,8 +1399,6 @@ go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.19.1 h1:ue41HOKd1vGURxrmeKIgELGb3jPW9DMUDGtsinblHwI=
 go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=
-go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
-go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180501155221-613d6eafa307/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1548,7 +1538,6 @@ golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220127074510-2fabfed7e28f h1:o66Bv9+w/vuk7Krcig9jZqD01FP7BL8OliFqqw0xzPI=
 golang.org/x/net v0.0.0-20220127074510-2fabfed7e28f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
@@ -1707,8 +1696,6 @@ golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1892,8 +1879,6 @@ google.golang.org/api v0.62.0/go.mod h1:dKmwPCydfsad4qCH08MSdgWjfHOyfpd4VtDGgRFd
 google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tDuPo=
 google.golang.org/api v0.65.0 h1:MTW9c+LIBAbwoS1Gb+YV7NjFBt2f7GtAS5hIzh2NjgQ=
 google.golang.org/api v0.65.0/go.mod h1:ArYhxgGadlWmqO1IqVujw6Cs8IdD33bTmzKo2Sh+cbg=
-google.golang.org/api v0.67.0 h1:lYaaLa+x3VVUhtosaK9xihwQ9H9KRa557REHwwZ2orM=
-google.golang.org/api v0.67.0/go.mod h1:ShHKP8E60yPsKNw/w8w+VYaj9H6buA5UqDp8dhbQZ6g=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1988,8 +1973,6 @@ google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350 h1:YxHp5zqIcAShDEvRr5/0rVESVS+njYF68PSdazrNLJo=
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220207185906-7721543eae58 h1:i67FGOy2/zGfhE3YgHdrOrcFbOBhqdcRoBrsDqSQrOI=
-google.golang.org/genproto v0.0.0-20220207185906-7721543eae58/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -2111,8 +2094,6 @@ k8s.io/api v0.20.6/go.mod h1:X9e8Qag6JV/bL5G6bU8sdVRltWKmdHsFUGS3eVndqE8=
 k8s.io/api v0.22.5/go.mod h1:mEhXyLaSD1qTOf40rRiKXkc+2iCem09rWLlFwhCEiAs=
 k8s.io/api v0.23.0 h1:WrL1gb73VSC8obi8cuYETJGXEoFNEh3LU0Pt+Sokgro=
 k8s.io/api v0.23.0/go.mod h1:8wmDdLBHBNxtOIytwLstXt5E9PddnZb0GaMcqsvDBpg=
-k8s.io/api v0.23.5 h1:zno3LUiMubxD/V1Zw3ijyKO3wxrhbUF1Ck+VjBvfaoA=
-k8s.io/api v0.23.5/go.mod h1:Na4XuKng8PXJ2JsploYYrivXrINeTaycCGcYgF91Xm8=
 k8s.io/apiextensions-apiserver v0.22.5/go.mod h1:tIXeZ0BrDxUb1PoAz+tgOz43Zi1Bp4BEEqVtUccMJbE=
 k8s.io/apiextensions-apiserver v0.23.0 h1:uii8BYmHYiT2ZTAJxmvc3X8UhNYMxl2A0z0Xq3Pm+WY=
 k8s.io/apiextensions-apiserver v0.23.0/go.mod h1:xIFAEEDlAZgpVBl/1VSjGDmLoXAWRG40+GsWhKhAxY4=
@@ -2123,8 +2104,6 @@ k8s.io/apimachinery v0.20.6/go.mod h1:ejZXtW1Ra6V1O5H8xPBGz+T3+4gfkTCeExAHKU57MA
 k8s.io/apimachinery v0.22.5/go.mod h1:xziclGKwuuJ2RM5/rSFQSYAj0zdbci3DH8kj+WvyN0U=
 k8s.io/apimachinery v0.23.0 h1:mIfWRMjBuMdolAWJ3Fd+aPTMv3X9z+waiARMpvvb0HQ=
 k8s.io/apimachinery v0.23.0/go.mod h1:fFCTTBKvKcwTPFzjlcxp91uPFZr+JA0FubU4fLzzFYc=
-k8s.io/apimachinery v0.23.5 h1:Va7dwhp8wgkUPWsEXk6XglXWU4IKYLKNlv8VkX7SDM0=
-k8s.io/apimachinery v0.23.5/go.mod h1:BEuFMMBaIbcOqVIJqNZJXGFTP4W6AycEpb5+m/97hrM=
 k8s.io/apiserver v0.20.1/go.mod h1:ro5QHeQkgMS7ZGpvf4tSMx6bBOgPfE+f52KwvXfScaU=
 k8s.io/apiserver v0.20.4/go.mod h1:Mc80thBKOyy7tbvFtB4kJv1kbdD0eIH8k8vianJcbFM=
 k8s.io/apiserver v0.20.6/go.mod h1:QIJXNt6i6JB+0YQRNcS0hdRHJlMhflFmsBDeSgT1r8Q=
@@ -2201,8 +2180,6 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.0 h1:kDvPBbnPk+qYmkHmSo8vKGp438IASWofnbbUKDE/bv0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/java-components/resource-model/src/main/java/com/redhat/hacbs/resources/model/v1alpha1/DependencyBuildStatus.java
+++ b/java-components/resource-model/src/main/java/com/redhat/hacbs/resources/model/v1alpha1/DependencyBuildStatus.java
@@ -3,6 +3,7 @@ package com.redhat.hacbs.resources.model.v1alpha1;
 public class DependencyBuildStatus {
 
     private String state;
+    private String[] contaminates;
 
     public String getState() {
         return state;
@@ -10,6 +11,15 @@ public class DependencyBuildStatus {
 
     public DependencyBuildStatus setState(String state) {
         this.state = state;
+        return this;
+    }
+
+    public String[] getContaminates() {
+        return contaminates;
+    }
+
+    public DependencyBuildStatus setContaminates(String[] contaminates) {
+        this.contaminates = contaminates;
         return this;
     }
 }

--- a/pkg/reconciler/artifactbuildrequest/artifactbuildrequest.go
+++ b/pkg/reconciler/artifactbuildrequest/artifactbuildrequest.go
@@ -3,26 +3,32 @@ package artifactbuildrequest
 import (
 	"context"
 	"crypto/md5"
+	"crypto/sha1"
 	"encoding/hex"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/dependencybuild"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 )
 
 const (
 	//TODO eventually we'll need to decide if we want to make this tuneable
-	contextTimeout           = 300 * time.Second
-	TaskRunLabel             = "jvmbuildservice.io/artifactbuildrequest-taskrun"
-	ArtifactBuildRequestKind = "ArtifactBuildRequest"
+	contextTimeout = 300 * time.Second
+	TaskRunLabel   = "jvmbuildservice.io/artifactbuildrequest-taskrun"
+	RequestKind    = "ArtifactBuildRequest"
+	// DependencyBuildContaminatedBy label prefix that indicates that a dependency build was contaminated by this artifact
+	DependencyBuildContaminatedBy = "jvmbuildservice.io/contaminated-"
+	DependencyBuildIdLabel        = "jvmbuildservice.io/dependencybuild-id"
 )
 
 type ReconcileArtifactBuildRequest struct {
@@ -53,102 +59,164 @@ func (r *ReconcileArtifactBuildRequest) Reconcile(ctx context.Context, request r
 
 	switch abr.Status.State {
 	case v1alpha1.ArtifactBuildRequestStateNew, "":
-		// create task run
-		tr := pipelinev1beta1.TaskRun{}
-		tr.Spec.TaskRef = &pipelinev1beta1.TaskRef{Name: "lookup-artifact-location", Kind: pipelinev1beta1.NamespacedTaskKind}
-		tr.Namespace = abr.Namespace
-		tr.GenerateName = abr.Name + "-scm-discovery-"
-		tr.Labels = map[string]string{TaskRunLabel: ""}
-		tr.Spec.Params = append(tr.Spec.Params, pipelinev1beta1.Param{Name: "GAV", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: abr.Spec.GAV}})
-		if err := controllerutil.SetOwnerReference(&abr, &tr, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
-		if err = r.client.Create(ctx, &tr); err != nil {
-			return reconcile.Result{}, err
-		}
-		abr.Status.State = v1alpha1.ArtifactBuildRequestStateDiscovering
-		if err = r.client.Status().Update(ctx, &abr); err != nil {
-			return reconcile.Result{}, err
-		}
+		return r.handleStateNew(ctx, abr)
 	case v1alpha1.ArtifactBuildRequestStateDiscovered:
-		//now let's create the dependency build object
-		//once this object has been created its resolver takes over
-		if abr.Status.Tag == "" {
-			//this is a failure
-			abr.Status.State = v1alpha1.ArtifactBuildRequestStateMissing
-			return reconcile.Result{}, r.client.Status().Update(ctx, &abr)
-		}
-		//we generate a hash of the url, tag and path for
-		//our unique identifier
-		hash := md5.Sum([]byte(abr.Status.SCMURL + abr.Status.Tag + abr.Status.Path))
-		depId := hex.EncodeToString(hash[:])
-		//now lets look for an existing build object
-		list := &v1alpha1.DependencyBuildList{}
-		lbls := map[string]string{
-			dependencybuild.IdLabel: depId,
-		}
-		listOpts := &client.ListOptions{
-			Namespace:     abr.Namespace,
-			LabelSelector: labels.SelectorFromSet(lbls),
-		}
+		return r.handleStateDiscovered(ctx, abr)
+	case v1alpha1.ArtifactBuildRequestStateComplete:
+		return r.handleStateComplete(ctx, abr)
+	}
+	return reconcile.Result{}, nil
+}
 
-		if err = r.client.List(ctx, list, listOpts); err != nil {
+func (r *ReconcileArtifactBuildRequest) handleStateNew(ctx context.Context, abr v1alpha1.ArtifactBuildRequest) (reconcile.Result, error) {
+	// create task run
+	tr := pipelinev1beta1.TaskRun{}
+	tr.Spec.TaskRef = &pipelinev1beta1.TaskRef{Name: "lookup-artifact-location", Kind: pipelinev1beta1.NamespacedTaskKind}
+	tr.Namespace = abr.Namespace
+	tr.GenerateName = abr.Name + "-scm-discovery-"
+	tr.Labels = map[string]string{TaskRunLabel: ""}
+	tr.Spec.Params = append(tr.Spec.Params, pipelinev1beta1.Param{Name: "GAV", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: abr.Spec.GAV}})
+	if err := controllerutil.SetOwnerReference(&abr, &tr, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := r.client.Create(ctx, &tr); err != nil {
+		return reconcile.Result{}, err
+	}
+	abr.Status.State = v1alpha1.ArtifactBuildRequestStateDiscovering
+	if err := r.client.Status().Update(ctx, &abr); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileArtifactBuildRequest) handleStateDiscovered(ctx context.Context, abr v1alpha1.ArtifactBuildRequest) (reconcile.Result, error) {
+	//now let's create the dependency build object
+	//once this object has been created its resolver takes over
+	if abr.Status.Tag == "" {
+		//this is a failure
+		abr.Status.State = v1alpha1.ArtifactBuildRequestStateMissing
+		return reconcile.Result{}, r.client.Status().Update(ctx, &abr)
+	}
+	//we generate a hash of the url, tag and path for
+	//our unique identifier
+	hash := md5.Sum([]byte(abr.Status.SCMURL + abr.Status.Tag + abr.Status.Path))
+	depId := hex.EncodeToString(hash[:])
+	//now lets look for an existing build object
+	list := &v1alpha1.DependencyBuildList{}
+	lbls := map[string]string{
+		DependencyBuildIdLabel: depId,
+	}
+	listOpts := &client.ListOptions{
+		Namespace:     abr.Namespace,
+		LabelSelector: labels.SelectorFromSet(lbls),
+	}
+
+	if err := r.client.List(ctx, list, listOpts); err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(list.Items) == 0 {
+		//no existing build object found, lets create one
+		db := &v1alpha1.DependencyBuild{}
+		db.Namespace = abr.Namespace
+		db.Labels = lbls
+		//TODO: name should be based on the git repo, not the abr, but needs
+		//a sanitization algorithm
+		db.GenerateName = abr.Name + "-"
+		db.Spec = v1alpha1.DependencyBuildSpec{
+			SCMURL:  abr.Status.SCMURL,
+			SCMType: abr.Status.SCMType,
+			Tag:     abr.Status.Tag,
+			Path:    abr.Status.Path,
+		}
+		if err := controllerutil.SetOwnerReference(&abr, db, r.scheme); err != nil {
 			return reconcile.Result{}, err
 		}
-		if len(list.Items) == 0 {
-			//no existing build object found, lets create one
-			db := &v1alpha1.DependencyBuild{}
-			db.Namespace = abr.Namespace
-			db.Labels = lbls
-			//TODO: name should be based on the git repo, not the abr, but needs
-			//a sanitization algorithm
-			db.GenerateName = abr.Name + "-"
-			db.Spec = v1alpha1.DependencyBuildSpec{
-				SCMURL:  abr.Status.SCMURL,
-				SCMType: abr.Status.SCMType,
-				Tag:     abr.Status.Tag,
-				Path:    abr.Status.Path,
-			}
-			if err := controllerutil.SetOwnerReference(&abr, db, r.scheme); err != nil {
-				return reconcile.Result{}, err
-			}
 
-			if err = r.client.Create(ctx, db); err != nil {
-				return reconcile.Result{}, err
+		if err := r.client.Create(ctx, db); err != nil {
+			return reconcile.Result{}, err
+		}
+	} else {
+		//build already exists, add us to the owner references
+		for _, db := range list.Items {
+			found := false
+			for _, owner := range db.OwnerReferences {
+				if owner.UID == abr.UID {
+					found = true
+					break
+				}
 			}
-		} else {
-			//build already exists, add us to the owner references
-			for _, db := range list.Items {
-				found := false
-				for _, owner := range db.OwnerReferences {
-					if owner.UID == abr.UID {
-						found = true
-						break
-					}
-				}
-				if !found {
-					if err := controllerutil.SetOwnerReference(&abr, &db, r.scheme); err != nil {
-						return reconcile.Result{}, err
-					}
-				}
-				if err = r.client.Update(ctx, &db); err != nil {
+			if !found {
+				if err := controllerutil.SetOwnerReference(&abr, &db, r.scheme); err != nil {
 					return reconcile.Result{}, err
 				}
 			}
+			if err := r.client.Update(ctx, &db); err != nil {
+				return reconcile.Result{}, err
+			}
 		}
-		//add the dependency build label to the abr as well
-		//so you can easily look them up
-		if abr.Labels == nil {
-			abr.Labels = map[string]string{}
-		}
-		abr.Labels[dependencybuild.IdLabel] = depId
-		if err := r.client.Update(ctx, &abr); err != nil {
-			return reconcile.Result{}, err
-		}
-		//move the state to building
-		abr.Status.State = v1alpha1.ArtifactBuildRequestStateBuilding
-		return reconcile.Result{}, r.client.Status().Update(ctx, &abr)
+	}
+	//add the dependency build label to the abr as well
+	//so you can easily look them up
+	if abr.Labels == nil {
+		abr.Labels = map[string]string{}
+	}
+	abr.Labels[DependencyBuildIdLabel] = depId
+	if err := r.client.Update(ctx, &abr); err != nil {
+		return reconcile.Result{}, err
+	}
+	//move the state to building
+	abr.Status.State = v1alpha1.ArtifactBuildRequestStateBuilding
+	return reconcile.Result{}, r.client.Status().Update(ctx, &abr)
+}
 
+func (r *ReconcileArtifactBuildRequest) handleStateComplete(ctx context.Context, abr v1alpha1.ArtifactBuildRequest) (reconcile.Result, error) {
+	for key, value := range abr.Annotations {
+		if strings.HasPrefix(key, DependencyBuildContaminatedBy) {
+			db := v1alpha1.DependencyBuild{}
+			if err := r.client.Get(ctx, types.NamespacedName{Name: value, Namespace: abr.Namespace}, &db); err != nil {
+				//TODO: logging?
+				//this was not found
+				continue
+			}
+			if db.Status.State != v1alpha1.DependencyBuildStateContaminated {
+				continue
+			}
+			var newContaminates []string
+			for _, contaminant := range db.Status.Contaminants {
+				if contaminant != value {
+					newContaminates = append(newContaminates, contaminant)
+				}
+			}
+			db.Status.Contaminants = newContaminates
+			if err := r.client.Status().Update(ctx, &db); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 	}
 	return reconcile.Result{}, nil
+}
+
+func CreateABRName(gav string) string {
+	hashedBytes := sha1.Sum([]byte(gav))
+	hash := hex.EncodeToString(hashedBytes[:])[0:8]
+	namePart := gav[strings.Index(gav, ":")+1:]
+
+	//generate names based on the artifact name + version, and part of a hash
+	//we only use the first 8 characters from the hash to make the name small
+	var newName = strings.Builder{}
+	lastDot := false
+	for _, i := range []rune(namePart) {
+		if unicode.IsLetter(i) || unicode.IsDigit(i) {
+			newName.WriteRune(i)
+			lastDot = false
+		} else {
+			if !lastDot {
+				newName.WriteString(".")
+			}
+			lastDot = true
+		}
+	}
+	newName.WriteString("-")
+	newName.WriteString(hash)
+	return newName.String()
 }

--- a/pkg/reconciler/artifactbuildrequest/artifactbuildrequest_test.go
+++ b/pkg/reconciler/artifactbuildrequest/artifactbuildrequest_test.go
@@ -1,0 +1,217 @@
+package artifactbuildrequest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Client, *ReconcileArtifactBuildRequest) {
+	scheme := runtime.NewScheme()
+	v1alpha1.AddToScheme(scheme)
+	pipelinev1beta1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	reconciler := &ReconcileArtifactBuildRequest{client: client, scheme: scheme}
+	return client, reconciler
+}
+
+func TestReconcileNew(t *testing.T) {
+	abr := v1alpha1.ArtifactBuildRequest{}
+	abr.Namespace = metav1.NamespaceDefault
+	abr.Name = "test"
+	abr.Status.State = v1alpha1.ArtifactBuildRequestStateNew
+
+	ctx := context.TODO()
+	client, reconciler := setupClientAndReconciler(&abr)
+
+	_, err := reconciler.handleStateNew(ctx, abr)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	err = client.Get(ctx, types.NamespacedName{
+		Namespace: metav1.NamespaceDefault,
+		Name:      "test",
+	}, &abr)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	if abr.Status.State != v1alpha1.ArtifactBuildRequestStateDiscovering {
+		t.Fatalf("abr at incorrect state: %s", abr.Status.State)
+	}
+
+	trList := &pipelinev1beta1.TaskRunList{}
+	err = client.List(ctx, trList)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	for _, tr := range trList.Items {
+		if !strings.HasPrefix(tr.Name, abr.Name) {
+			t.Fatalf("tr/abr name mismatch: %s and %s", tr.Name, abr.Name)
+		}
+		for _, or := range tr.OwnerReferences {
+			if or.Kind != abr.Kind || or.Name != abr.Name {
+				t.Fatalf("tr/abr owner ref mismatch: %s %s %s %s", or.Kind, abr.Kind, or.Name, abr.Name)
+			}
+		}
+	}
+	if len(trList.Items) == 0 {
+		t.Fatalf("no tr found")
+	}
+}
+
+func getABR(t *testing.T, client runtimeclient.Client, abr *v1alpha1.ArtifactBuildRequest) *v1alpha1.ArtifactBuildRequest {
+	ctx := context.TODO()
+	err := client.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test"}, abr)
+	if err != nil {
+		t.Errorf("%s", err.Error())
+	}
+	return abr
+}
+
+func TestReconcileDiscovered(t *testing.T) {
+	fullValidation := func(t *testing.T, client runtimeclient.Client, abr *v1alpha1.ArtifactBuildRequest) {
+		abr = getABR(t, client, abr)
+		if abr.Status.State != v1alpha1.ArtifactBuildRequestStateBuilding {
+			t.Errorf("incorrect no dependency builds yet state: %s", abr.Status.State)
+		}
+
+		val, ok := abr.Labels[DependencyBuildIdLabel]
+		if !ok || len(val) == 0 {
+			t.Errorf("missing label: %s %v", val, ok)
+		}
+
+		dbList := v1alpha1.DependencyBuildList{}
+		err := client.List(context.TODO(), &dbList)
+		if err != nil {
+			t.Errorf("db list err: %s", err.Error())
+		}
+		for _, db := range dbList.Items {
+			if !strings.HasPrefix(db.Name, abr.Name) {
+				t.Errorf("db / abr name mismatch: %s and %s", db.Name, abr.Name)
+			}
+			for _, or := range db.OwnerReferences {
+				if or.Kind != abr.Kind || or.Name != abr.Name {
+					t.Errorf("db / abr owner ref mismatch: %s %s %s %s", or.Kind, abr.Kind, or.Name, abr.Name)
+				}
+			}
+			if db.Spec.SCMURL != abr.Status.SCMURL ||
+				db.Spec.SCMType != abr.Status.SCMType ||
+				db.Spec.Tag != abr.Status.Tag ||
+				db.Spec.Path != abr.Status.Path {
+				t.Errorf("db spec / abr status mismatch: %#v vs. %#v", db.Spec, abr.Status)
+			}
+		}
+		if len(dbList.Items) == 0 {
+			t.Errorf("no dbs present")
+		}
+	}
+
+	tests := []struct {
+		name       string
+		abr        *v1alpha1.ArtifactBuildRequest
+		db         *v1alpha1.DependencyBuild
+		validation func(t *testing.T, client runtimeclient.Client, abr *v1alpha1.ArtifactBuildRequest)
+	}{
+		{
+			name: "missing tag",
+			abr: &v1alpha1.ArtifactBuildRequest{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.ArtifactBuildRequestSpec{},
+				Status: v1alpha1.ArtifactBuildRequestStatus{
+					State: v1alpha1.ArtifactBuildRequestStateDiscovered,
+				},
+			},
+			validation: func(t *testing.T, client runtimeclient.Client, abr *v1alpha1.ArtifactBuildRequest) {
+				abr = getABR(t, client, abr)
+				if abr.Status.State != v1alpha1.ArtifactBuildRequestStateMissing {
+					t.Errorf("incorrect missing tag state: %s", abr.Status.State)
+				}
+			},
+		},
+		{
+			name: "no dependency builds yet",
+			abr: &v1alpha1.ArtifactBuildRequest{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.ArtifactBuildRequestSpec{},
+				Status: v1alpha1.ArtifactBuildRequestStatus{
+					State:   v1alpha1.ArtifactBuildRequestStateDiscovered,
+					Tag:     "foo",
+					SCMURL:  "goo",
+					SCMType: "hoo",
+					Path:    "ioo",
+				},
+			},
+			validation: fullValidation,
+		},
+		{
+			name: "dependency builds already exist",
+			abr: &v1alpha1.ArtifactBuildRequest{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.ArtifactBuildRequestSpec{},
+				Status: v1alpha1.ArtifactBuildRequestStatus{
+					State:   v1alpha1.ArtifactBuildRequestStateDiscovered,
+					Tag:     "foo",
+					SCMURL:  "goo",
+					SCMType: "hoo",
+					Path:    "ioo",
+				},
+			},
+			db: &v1alpha1.DependencyBuild{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-generated",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.DependencyBuildSpec{
+					Tag:     "foo",
+					SCMURL:  "goo",
+					SCMType: "hoo",
+					Path:    "ioo",
+				},
+			},
+			validation: fullValidation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtimeclient.Object{}
+			if tt.abr != nil {
+				objs = append(objs, tt.abr)
+			}
+			if tt.db != nil {
+				objs = append(objs, tt.db)
+			}
+			client, reconciler := setupClientAndReconciler(objs...)
+			ctx := context.TODO()
+			_, err := reconciler.handleStateDiscovered(ctx, *tt.abr)
+			if err != nil {
+				t.Errorf("handleStateDiscovered error: %s", err.Error())
+			}
+			tt.validation(t, client, tt.abr)
+		})
+	}
+}

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuildrequest"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,8 +24,8 @@ import (
 
 const (
 	//TODO eventually we'll need to decide if we want to make this tuneable
-	contextTimeout   = 300 * time.Second
-	IdLabel          = "jvmbuildservice.io/dependencybuild-id"
+	contextTimeout = 300 * time.Second
+
 	PipelineRunLabel = "jvmbuildservice.io/dependencybuild-pipelinerun"
 )
 
@@ -57,83 +58,97 @@ func (r *ReconcileDependencyBuild) Reconcile(ctx context.Context, request reconc
 	//we validate that our dep id hash is still valid
 	//if a field has been modified we need to update the label
 	//which may result in a new build
-	hash := md5.Sum([]byte(db.Spec.SCMURL + db.Spec.Tag + db.Spec.Path))
-	depId := hex.EncodeToString(hash[:])
-	if depId != db.Labels[IdLabel] {
+	depId := hashToString(db.Spec.SCMURL + db.Spec.Tag + db.Spec.Path)
+	if depId != db.Labels[artifactbuildrequest.DependencyBuildIdLabel] {
 		//if our id has changed we just update the label and set our state back to new
 		//this will kick off a new build
-		db.Labels[IdLabel] = depId
+		db.Labels[artifactbuildrequest.DependencyBuildIdLabel] = depId
 		db.Status.State = v1alpha1.DependencyBuildStateNew
 		return reconcile.Result{}, r.client.Update(ctx, &db)
 	}
 
 	switch db.Status.State {
-
 	case "", v1alpha1.DependencyBuildStateNew:
-		//new build, kick off a pipeline run to run the build
-		//TODO: this state flow will change when we start analysing the required images etc
-		//for now just to a super basic build and change the state to building
-		// create task run
-		tr := pipelinev1beta1.PipelineRun{}
-		tr.Namespace = db.Namespace
-		tr.GenerateName = db.Name + "-build-"
-		tr.Labels = map[string]string{IdLabel: db.Labels[IdLabel], PipelineRunLabel: ""}
-		tr.Spec.PipelineRef = &pipelinev1beta1.PipelineRef{Name: "run-component-build"}
-		tr.Spec.Params = []pipelinev1beta1.Param{
-			{Name: "url", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.SCMURL}},
-			{Name: "tag", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.Tag}},
-			{Name: "context", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.Path}},
-		}
-		quantity, err := resource.ParseQuantity("1Gi")
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		tr.Spec.Workspaces = []pipelinev1beta1.WorkspaceBinding{
-			{Name: "maven-settings", EmptyDir: &v1.EmptyDirVolumeSource{}},
-			{Name: "shared-workspace", VolumeClaimTemplate: &v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
-				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-				Resources:   v1.ResourceRequirements{Requests: map[v1.ResourceName]resource.Quantity{v1.ResourceStorage: quantity}}}}},
-		}
-		if err := controllerutil.SetOwnerReference(&db, &tr, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
-		err = r.client.Create(ctx, &tr)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		db.Status.State = v1alpha1.DependencyBuildStateBuilding
-		return reconcile.Result{}, r.client.Status().Update(ctx, &db)
+		return r.handleStateNew(ctx, db)
 	case v1alpha1.DependencyBuildStateComplete:
 		return reconcile.Result{}, r.updateArtifactRequestState(ctx, db, v1alpha1.ArtifactBuildRequestStateComplete)
 	case v1alpha1.DependencyBuildStateFailed:
 		return reconcile.Result{}, r.updateArtifactRequestState(ctx, db, v1alpha1.ArtifactBuildRequestStateFailed)
 	case v1alpha1.DependencyBuildStateBuilding:
-		//make sure we still have a linked pr
-		list := &pipelinev1beta1.PipelineRunList{}
-		lbls := map[string]string{
-			IdLabel: depId,
-		}
-		listOpts := &client.ListOptions{
-			Namespace:     db.Namespace,
-			LabelSelector: labels.SelectorFromSet(lbls),
-		}
-		if err = r.client.List(ctx, list, listOpts); err != nil {
-			return reconcile.Result{}, err
-		}
-		if len(list.Items) == 0 {
-			//no linked pr, back to new
-			db.Status.State = v1alpha1.DependencyBuildStateNew
-			return reconcile.Result{}, r.client.Update(ctx, &db)
-		}
-		return reconcile.Result{}, nil
+		return r.handleStateBuilding(ctx, depId, db)
+	case v1alpha1.DependencyBuildStateContaminated:
+		return r.handleStateContaminated(ctx, db)
 	}
 
 	return reconcile.Result{}, nil
 }
 
+func hashToString(unique string) string {
+	hash := md5.Sum([]byte(unique))
+	depId := hex.EncodeToString(hash[:])
+	return depId
+}
+
+func (r *ReconcileDependencyBuild) handleStateNew(ctx context.Context, db v1alpha1.DependencyBuild) (reconcile.Result, error) {
+	//new build, kick off a pipeline run to run the build
+	//TODO: this state flow will change when we start analysing the required images etc
+	//for now just to a super basic build and change the state to building
+	// create task run
+	tr := pipelinev1beta1.PipelineRun{}
+	tr.Namespace = db.Namespace
+	tr.GenerateName = db.Name + "-build-"
+	tr.Labels = map[string]string{artifactbuildrequest.DependencyBuildIdLabel: db.Labels[artifactbuildrequest.DependencyBuildIdLabel], PipelineRunLabel: ""}
+	tr.Spec.PipelineRef = &pipelinev1beta1.PipelineRef{Name: "run-component-build"}
+	tr.Spec.Params = []pipelinev1beta1.Param{
+		{Name: "url", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.SCMURL}},
+		{Name: "tag", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.Tag}},
+		{Name: "context", Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.Path}},
+	}
+	quantity, err := resource.ParseQuantity("1Gi")
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	tr.Spec.Workspaces = []pipelinev1beta1.WorkspaceBinding{
+		{Name: "maven-settings", EmptyDir: &v1.EmptyDirVolumeSource{}},
+		{Name: "shared-workspace", VolumeClaimTemplate: &v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources:   v1.ResourceRequirements{Requests: map[v1.ResourceName]resource.Quantity{v1.ResourceStorage: quantity}}}}},
+	}
+	if err := controllerutil.SetOwnerReference(&db, &tr, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+	err = r.client.Create(ctx, &tr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	db.Status.State = v1alpha1.DependencyBuildStateBuilding
+	return reconcile.Result{}, r.client.Status().Update(ctx, &db)
+}
+
+func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, depId string, db v1alpha1.DependencyBuild) (reconcile.Result, error) {
+	//make sure we still have a linked pr
+	list := &pipelinev1beta1.PipelineRunList{}
+	lbls := map[string]string{
+		artifactbuildrequest.DependencyBuildIdLabel: depId,
+	}
+	listOpts := &client.ListOptions{
+		Namespace:     db.Namespace,
+		LabelSelector: labels.SelectorFromSet(lbls),
+	}
+	if err := r.client.List(ctx, list, listOpts); err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(list.Items) == 0 {
+		//no linked pr, back to new
+		db.Status.State = v1alpha1.DependencyBuildStateNew
+		return reconcile.Result{}, r.client.Update(ctx, &db)
+	}
+	return reconcile.Result{}, nil
+}
+
 func (r *ReconcileDependencyBuild) updateArtifactRequestState(ctx context.Context, db v1alpha1.DependencyBuild, state string) error {
 	list := v1alpha1.ArtifactBuildRequestList{}
-	lbls := map[string]string{IdLabel: db.Labels[IdLabel]}
+	lbls := map[string]string{artifactbuildrequest.DependencyBuildIdLabel: db.Labels[artifactbuildrequest.DependencyBuildIdLabel]}
 	listOpts := &client.ListOptions{
 		Namespace:     db.Namespace,
 		LabelSelector: labels.SelectorFromSet(lbls),
@@ -152,4 +167,45 @@ func (r *ReconcileDependencyBuild) updateArtifactRequestState(ctx context.Contex
 		}
 	}
 	return nil
+}
+
+func (r *ReconcileDependencyBuild) handleStateContaminated(ctx context.Context, db v1alpha1.DependencyBuild) (reconcile.Result, error) {
+	contaminants := db.Status.Contaminants
+	if len(contaminants) == 0 {
+		//all fixed, just set the state back to new and try again
+		//this is triggered when contaminants are removed by the ABR controller
+		db.Status.State = v1alpha1.DependencyBuildStateNew
+		return reconcile.Result{}, r.client.Update(ctx, &db)
+	}
+	//we want to rebuild the contaminants from source
+	//so we create ABRs for them
+	//if they already exist we link to the ABR
+	for _, contaminant := range contaminants {
+		abrName := artifactbuildrequest.CreateABRName(contaminant)
+		abr := v1alpha1.ArtifactBuildRequest{}
+		//look for existing ABR
+		err := r.client.Get(ctx, types.NamespacedName{Name: abrName, Namespace: db.Namespace}, &abr)
+		suffix := hashToString(contaminant)[0:20]
+		if err != nil {
+			//we just assume this is because it does not exist
+			//TODO: how to check the type of the error?
+			abr.Spec = v1alpha1.ArtifactBuildRequestSpec{GAV: contaminant}
+			abr.Name = abrName
+			abr.Namespace = db.Namespace
+			abr.Annotations = map[string]string{}
+			//use this annotation to link back to the dependency build
+			abr.Annotations[artifactbuildrequest.DependencyBuildContaminatedBy+suffix] = db.Name
+			err := r.client.Create(ctx, &abr)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		} else {
+			abr.Annotations[artifactbuildrequest.DependencyBuildContaminatedBy+suffix] = db.Name
+			err := r.client.Update(ctx, &abr)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+	return reconcile.Result{}, nil
 }

--- a/pkg/reconciler/taskrun/task_run_controller_test.go
+++ b/pkg/reconciler/taskrun/task_run_controller_test.go
@@ -76,7 +76,7 @@ func createTaskRun(componentLookupKey types.NamespacedName, labels map[string]st
 			Name:            componentLookupKey.Name,
 			Namespace:       componentLookupKey.Namespace,
 			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{{APIVersion: v1alpha1.SchemeGroupVersion.String(), Kind: artifactbuildrequest.ArtifactBuildRequestKind, Name: abr.Name, UID: abr.UID}},
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: v1alpha1.SchemeGroupVersion.String(), Kind: artifactbuildrequest.RequestKind, Name: abr.Name, UID: abr.UID}},
 		},
 	}
 	Expect(k8sClient.Create(ctx, tr)).Should(Succeed())

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package taskrun
+package e2e
 
 import (
 	"context"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/taskrun"
 	"go/build"
 	"path/filepath"
 	"testing"
@@ -103,7 +104,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = SetupNewReconcilerWithManager(k8sManager)
+	err = taskrun.SetupNewReconcilerWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/test/e2e/task_run_controller_test.go
+++ b/test/e2e/task_run_controller_test.go
@@ -14,20 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package taskrun
+package e2e
 
 import (
 	"errors"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuildrequest"
-	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuildrequest"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/taskrun"
+
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	//+kubebuilder:scaffold:imports
 )
 
@@ -54,7 +59,6 @@ func createAbr(componentLookupKey types.NamespacedName) {
 			Namespace: componentLookupKey.Namespace,
 		},
 		Spec: v1alpha1.ArtifactBuildRequestSpec{
-			GAV: ABRGav,
 		},
 	}
 	Expect(k8sClient.Create(ctx, abr)).Should(Succeed())
@@ -155,19 +159,19 @@ var _ = Describe("Test discovery TaskRun complete updates ABR state", func() {
 			tr := getTr(abrName)
 			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			tr.Status.TaskRunResults = []tektonapi.TaskRunResult{{
-				Name:  TaskResultScmTag,
+				Name:  taskrun.TaskResultScmTag,
 				Value: "tag1",
 			}, {
-				Name:  TaskResultScmUrl,
+				Name:  taskrun.TaskResultScmUrl,
 				Value: "url1",
 			}, {
-				Name:  TaskResultScmType,
+				Name:  taskrun.TaskResultScmType,
 				Value: "git",
 			}, {
-				Name:  TaskResultContextPath,
+				Name:  taskrun.TaskResultContextPath,
 				Value: "/path1",
 			}, {
-				Name:  TaskResultMessage,
+				Name:  taskrun.TaskResultMessage,
 				Value: "OK",
 			}}
 			Expect(k8sClient.Status().Update(ctx, tr)).Should(Succeed())

--- a/test/e2e/task_run_controller_test.go
+++ b/test/e2e/task_run_controller_test.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	//+kubebuilder:scaffold:imports
 )
 
@@ -58,8 +57,7 @@ func createAbr(componentLookupKey types.NamespacedName) {
 			Name:      componentLookupKey.Name,
 			Namespace: componentLookupKey.Namespace,
 		},
-		Spec: v1alpha1.ArtifactBuildRequestSpec{
-		},
+		Spec: v1alpha1.ArtifactBuildRequestSpec{},
 	}
 	Expect(k8sClient.Create(ctx, abr)).Should(Succeed())
 

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -553,6 +553,7 @@ k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch
@@ -794,6 +795,7 @@ sigs.k8s.io/controller-runtime/pkg/certwatcher
 sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/config
+sigs.k8s.io/controller-runtime/pkg/client/fake
 sigs.k8s.io/controller-runtime/pkg/cluster
 sigs.k8s.io/controller-runtime/pkg/config
 sigs.k8s.io/controller-runtime/pkg/config/v1alpha1

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -1,0 +1,765 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+type versionedTracker struct {
+	testing.ObjectTracker
+	scheme *runtime.Scheme
+}
+
+type fakeClient struct {
+	tracker         versionedTracker
+	scheme          *runtime.Scheme
+	restMapper      meta.RESTMapper
+	schemeWriteLock sync.Mutex
+}
+
+var _ client.WithWatch = &fakeClient{}
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
+
+// NewFakeClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+//
+// Deprecated: Please use NewClientBuilder instead.
+func NewFakeClient(initObjs ...runtime.Object) client.WithWatch {
+	return NewClientBuilder().WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewFakeClientWithScheme creates a new fake client with the given scheme
+// for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+//
+// Deprecated: Please use NewClientBuilder instead.
+func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.WithWatch {
+	return NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewClientBuilder returns a new builder to create a fake client.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// ClientBuilder builds a fake client.
+type ClientBuilder struct {
+	scheme             *runtime.Scheme
+	restMapper         meta.RESTMapper
+	initObject         []client.Object
+	initLists          []client.ObjectList
+	initRuntimeObjects []runtime.Object
+}
+
+// WithScheme sets this builder's internal scheme.
+// If not set, defaults to client-go's global scheme.Scheme.
+func (f *ClientBuilder) WithScheme(scheme *runtime.Scheme) *ClientBuilder {
+	f.scheme = scheme
+	return f
+}
+
+// WithRESTMapper sets this builder's restMapper.
+// The restMapper is directly set as mapper in the Client. This can be used for example
+// with a meta.DefaultRESTMapper to provide a static rest mapping.
+// If not set, defaults to an empty meta.DefaultRESTMapper.
+func (f *ClientBuilder) WithRESTMapper(restMapper meta.RESTMapper) *ClientBuilder {
+	f.restMapper = restMapper
+	return f
+}
+
+// WithObjects can be optionally used to initialize this fake client with client.Object(s).
+func (f *ClientBuilder) WithObjects(initObjs ...client.Object) *ClientBuilder {
+	f.initObject = append(f.initObject, initObjs...)
+	return f
+}
+
+// WithLists can be optionally used to initialize this fake client with client.ObjectList(s).
+func (f *ClientBuilder) WithLists(initLists ...client.ObjectList) *ClientBuilder {
+	f.initLists = append(f.initLists, initLists...)
+	return f
+}
+
+// WithRuntimeObjects can be optionally used to initialize this fake client with runtime.Object(s).
+func (f *ClientBuilder) WithRuntimeObjects(initRuntimeObjs ...runtime.Object) *ClientBuilder {
+	f.initRuntimeObjects = append(f.initRuntimeObjects, initRuntimeObjs...)
+	return f
+}
+
+// Build builds and returns a new fake client.
+func (f *ClientBuilder) Build() client.WithWatch {
+	if f.scheme == nil {
+		f.scheme = scheme.Scheme
+	}
+	if f.restMapper == nil {
+		f.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	}
+
+	tracker := versionedTracker{ObjectTracker: testing.NewObjectTracker(f.scheme, scheme.Codecs.UniversalDecoder()), scheme: f.scheme}
+	for _, obj := range f.initObject {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add object %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initLists {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add list %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initRuntimeObjects {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add runtime object %v to fake client: %w", obj, err))
+		}
+	}
+	return &fakeClient{
+		tracker:    tracker,
+		scheme:     f.scheme,
+		restMapper: f.restMapper,
+	}
+}
+
+const trackerAddResourceVersion = "999"
+
+func (t versionedTracker) Add(obj runtime.Object) error {
+	var objects []runtime.Object
+	if meta.IsListType(obj) {
+		var err error
+		objects, err = meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+	} else {
+		objects = []runtime.Object{obj}
+	}
+	for _, obj := range objects {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return fmt.Errorf("failed to get accessor for object: %w", err)
+		}
+		if accessor.GetResourceVersion() == "" {
+			// We use a "magic" value of 999 here because this field
+			// is parsed as uint and and 0 is already used in Update.
+			// As we can't go lower, go very high instead so this can
+			// be recognized
+			accessor.SetResourceVersion(trackerAddResourceVersion)
+		}
+
+		obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+		if err != nil {
+			return err
+		}
+		if err := t.ObjectTracker.Add(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %v", err)
+	}
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+	if accessor.GetResourceVersion() != "" {
+		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
+	}
+	accessor.SetResourceVersion("1")
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	if err != nil {
+		return err
+	}
+	if err := t.ObjectTracker.Create(gvr, obj, ns); err != nil {
+		accessor.SetResourceVersion("")
+		return err
+	}
+
+	return nil
+}
+
+// convertFromUnstructuredIfNecessary will convert *unstructured.Unstructured for a GVK that is recocnized
+// by the schema into the whatever the schema produces with New() for said GVK.
+// This is required because the tracker unconditionally saves on manipulations, but it's List() implementation
+// tries to assign whatever it finds into a ListType it gets from schema.New() - Thus we have to ensure
+// we save as the very same type, otherwise subsequent List requests will fail.
+func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {
+	u, isUnstructured := o.(*unstructured.Unstructured)
+	if !isUnstructured || !s.Recognizes(u.GroupVersionKind()) {
+		return o, nil
+	}
+
+	typed, err := s.New(u.GroupVersionKind())
+	if err != nil {
+		return nil, fmt.Errorf("scheme recognizes %s but failed to produce an object for it: %w", u.GroupVersionKind().String(), err)
+	}
+
+	unstructuredSerialized, err := json.Marshal(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize %T: %w", unstructuredSerialized, err)
+	}
+	if err := json.Unmarshal(unstructuredSerialized, typed); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the content of %T into %T: %w", u, typed, err)
+	}
+
+	return typed, nil
+}
+
+func (t versionedTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %v", err)
+	}
+
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		gvk, err = apiutil.GVKForObject(obj, t.scheme)
+		if err != nil {
+			return err
+		}
+	}
+
+	oldObject, err := t.ObjectTracker.Get(gvr, ns, accessor.GetName())
+	if err != nil {
+		// If the resource is not found and the resource allows create on update, issue a
+		// create instead.
+		if apierrors.IsNotFound(err) && allowsCreateOnUpdate(gvk) {
+			return t.Create(gvr, obj, ns)
+		}
+		return err
+	}
+
+	oldAccessor, err := meta.Accessor(oldObject)
+	if err != nil {
+		return err
+	}
+
+	// If the new object does not have the resource version set and it allows unconditional update,
+	// default it to the resource version of the existing resource
+	if accessor.GetResourceVersion() == "" && allowsUnconditionalUpdate(gvk) {
+		accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+	}
+	if accessor.GetResourceVersion() != oldAccessor.GetResourceVersion() {
+		return apierrors.NewConflict(gvr.GroupResource(), accessor.GetName(), errors.New("object was modified"))
+	}
+	if oldAccessor.GetResourceVersion() == "" {
+		oldAccessor.SetResourceVersion("0")
+	}
+	intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("can not convert resourceVersion %q to int: %v", oldAccessor.GetResourceVersion(), err)
+	}
+	intResourceVersion++
+	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
+	if !accessor.GetDeletionTimestamp().IsZero() && len(accessor.GetFinalizers()) == 0 {
+		return t.ObjectTracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+	}
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	if err != nil {
+		return err
+	}
+	return t.ObjectTracker.Update(gvr, obj, ns)
+}
+
+func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	o, err := c.tracker.Get(gvr, key.Namespace, key.Name)
+	if err != nil {
+		return err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) Watch(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	gvk, err := apiutil.GVKForObject(list, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.HasSuffix(gvk.Kind, "List") {
+		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return c.tracker.Watch(gvr, listOpts.Namespace)
+}
+
+func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	originalKind := gvk.Kind
+
+	if strings.HasSuffix(gvk.Kind, "List") {
+		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	}
+
+	if _, isUnstructuredList := obj.(*unstructured.UnstructuredList); isUnstructuredList && !c.scheme.Recognizes(gvk) {
+		// We need to register the ListKind with UnstructuredList:
+		// https://github.com/kubernetes/kubernetes/blob/7b2776b89fb1be28d4e9203bdeec079be903c103/staging/src/k8s.io/client-go/dynamic/fake/simple.go#L44-L51
+		c.schemeWriteLock.Lock()
+		c.scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+		c.schemeWriteLock.Unlock()
+	}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(originalKind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return err
+	}
+
+	if listOpts.LabelSelector != nil {
+		objs, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		filteredObjs, err := objectutil.FilterWithLabels(objs, listOpts.LabelSelector)
+		if err != nil {
+			return err
+		}
+		err = meta.SetList(obj, filteredObjs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+func (c *fakeClient) RESTMapper() meta.RESTMapper {
+	return c.restMapper
+}
+
+func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		base := accessor.GetGenerateName()
+		if len(base) > maxGeneratedNameLength {
+			base = base[:maxGeneratedNameLength]
+		}
+		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	}
+
+	return c.tracker.Create(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	delOptions := client.DeleteOptions{}
+	delOptions.ApplyOptions(opts)
+
+	// Check the ResourceVersion if that Precondition was specified.
+	if delOptions.Preconditions != nil && delOptions.Preconditions.ResourceVersion != nil {
+		name := accessor.GetName()
+		dbObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), name)
+		if err != nil {
+			return err
+		}
+		oldAccessor, err := meta.Accessor(dbObj)
+		if err != nil {
+			return err
+		}
+		actualRV := oldAccessor.GetResourceVersion()
+		expectRV := *delOptions.Preconditions.ResourceVersion
+		if actualRV != expectRV {
+			msg := fmt.Sprintf(
+				"the ResourceVersion in the precondition (%s) does not match the ResourceVersion in record (%s). "+
+					"The object might have been modified",
+				expectRV, actualRV)
+			return apierrors.NewConflict(gvr.GroupResource(), name, errors.New(msg))
+		}
+	}
+
+	return c.deleteObject(gvr, accessor)
+}
+
+func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	dcOptions := client.DeleteAllOfOptions{}
+	dcOptions.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(o)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, dcOptions.LabelSelector)
+	if err != nil {
+		return err
+	}
+	for _, o := range filteredObjs {
+		accessor, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		err = c.deleteObject(gvr, accessor)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	return c.tracker.Update(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	patchOptions := &client.PatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range patchOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	reaction := testing.ObjectReaction(c.tracker)
+	handled, o, err := reaction(testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data))
+	if err != nil {
+		return err
+	}
+	if !handled {
+		panic("tracker could not handle patch method")
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) Status() client.StatusWriter {
+	return &fakeStatusWriter{client: c}
+}
+
+func (c *fakeClient) deleteObject(gvr schema.GroupVersionResource, accessor metav1.Object) error {
+	old, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err == nil {
+		oldAccessor, err := meta.Accessor(old)
+		if err == nil {
+			if len(oldAccessor.GetFinalizers()) > 0 {
+				now := metav1.Now()
+				oldAccessor.SetDeletionTimestamp(&now)
+				return c.tracker.Update(gvr, old, accessor.GetNamespace())
+			}
+		}
+	}
+
+	//TODO: implement propagation
+	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+}
+
+func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return gvr, nil
+}
+
+type fakeStatusWriter struct {
+	client *fakeClient
+}
+
+func (sw *fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	// TODO(droot): This results in full update of the obj (spec + status). Need
+	// a way to update status field only.
+	return sw.client.Update(ctx, obj, opts...)
+}
+
+func (sw *fakeStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	// TODO(droot): This results in full update of the obj (spec + status). Need
+	// a way to update status field only.
+	return sw.client.Patch(ctx, obj, patch, opts...)
+}
+
+func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "apps":
+		switch gvk.Kind {
+		case "ControllerRevision", "DaemonSet", "Deployment", "ReplicaSet", "StatefulSet":
+			return true
+		}
+	case "autoscaling":
+		switch gvk.Kind {
+		case "HorizontalPodAutoscaler":
+			return true
+		}
+	case "batch":
+		switch gvk.Kind {
+		case "CronJob", "Job":
+			return true
+		}
+	case "certificates":
+		switch gvk.Kind {
+		case "Certificates":
+			return true
+		}
+	case "flowcontrol":
+		switch gvk.Kind {
+		case "FlowSchema", "PriorityLevelConfiguration":
+			return true
+		}
+	case "networking":
+		switch gvk.Kind {
+		case "Ingress", "IngressClass", "NetworkPolicy":
+			return true
+		}
+	case "policy":
+		switch gvk.Kind {
+		case "PodSecurityPolicy":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "scheduling":
+		switch gvk.Kind {
+		case "PriorityClass":
+			return true
+		}
+	case "settings":
+		switch gvk.Kind {
+		case "PodPreset":
+			return true
+		}
+	case "storage":
+		switch gvk.Kind {
+		case "StorageClass":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "ConfigMap", "Endpoint", "Event", "LimitRange", "Namespace", "Node",
+			"PersistentVolume", "PersistentVolumeClaim", "Pod", "PodTemplate",
+			"ReplicationController", "ResourceQuota", "Secret", "Service",
+			"ServiceAccount", "EndpointSlice":
+			return true
+		}
+	}
+
+	return false
+}
+
+func allowsCreateOnUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "coordination":
+		switch gvk.Kind {
+		case "Lease":
+			return true
+		}
+	case "node":
+		switch gvk.Kind {
+		case "RuntimeClass":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "Endpoint", "Event", "LimitRange", "Service":
+			return true
+		}
+	}
+
+	return false
+}
+
+// zero zeros the value of a pointer.
+func zero(x interface{}) {
+	if x == nil {
+		return
+	}
+	res := reflect.ValueOf(x).Elem()
+	res.Set(reflect.Zero(res.Type()))
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package fake provides a fake client for testing.
+
+A fake client is backed by its simple object store indexed by GroupVersionResource.
+You can create a fake client with optional objects.
+
+	client := NewFakeClientWithScheme(scheme, initObjs...) // initObjs is a slice of runtime.Object
+
+You can invoke the methods defined in the Client interface.
+
+When in doubt, it's almost always better not to use this package and instead use
+envtest.Environment with a real client and API server.
+
+WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
+- This client does not have a way to inject specific errors to test handled vs. unhandled errors.
+- There is some support for sub resources which can cause issues with tests if you're trying to update
+  e.g. metadata and status in the same reconcile.
+- No OpeanAPI validation is performed when creating or updating objects.
+- ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
+operations that rely on these fields will fail, or give false positives.
+
+*/
+package fake


### PR DESCRIPTION
OK @stuartwdouglas I got far enough along today to 
1) move the e2e test files out of the source tree into a separate sub directory structure (basically standard operator procedure with k8s based golang projects)
2) started on the unit tests in the reconcilers; I'll be continuing on these tomorrow, but I wanted to post a bit of what they look like prior to the Tuesday workshop.

I included your current PR's commit in here just to try to work off of as much of your "latest code" as possible. I can drop / rebase once that PR merges.