### PR TITLE
update envtest for recent changes, add depenencybuild test; get working and prep for openshift/release integration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- stuartwdouglas
+- gabemontero
+- goldmann
+- mmorhun
+- psturc
+
+approvers:
+- stuartwdouglas
+- gabemontero
+- goldmann
+- mmorhun
+- psturc

--- a/pkg/reconciler/artifactbuild/artifactbuildrequest.go
+++ b/pkg/reconciler/artifactbuild/artifactbuildrequest.go
@@ -89,7 +89,10 @@ func (r *ReconcileArtifactBuild) Reconcile(ctx context.Context, request reconcil
 	}
 
 	if trerr != nil && dberr != nil && abrerr != nil {
-		log.Info("Reconcile key %s received not found errors for taskruns, dependencybuilds, artifactbuilds (probably deleted)", request.NamespacedName.String())
+		//TODO weird - during envtest the logging code panicked on the commented out log.Info call: 'com.acme.example.1.0-scm-discovery-5vjvmpanic: odd number of arguments passed as key-value pairs for logging'
+		msg := "Reconcile key received not found errors for taskruns, dependencybuilds, artifactbuilds (probably deleted): " + request.NamespacedName.String()
+		log.Info(msg)
+		//log.Info("Reconcile key %s received not found errors for taskruns, dependencybuilds, artifactbuilds (probably deleted)", request.NamespacedName.String())
 		return ctrl.Result{}, nil
 	}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"context"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuild"
 	"go/build"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -36,6 +35,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuild"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/dependencybuild"
 	taskrunapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
@@ -102,7 +104,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(err).ToNot(HaveOccurred())
-	err = artifactbuild.SetupNewReconcilerWithManager(k8sManager, k8sClient)
+	err = artifactbuild.SetupNewReconcilerWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+	err = dependencybuild.SetupNewReconcilerWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
the behavior of the logger in the envtest scenario seems a bit odd  ... added a TODO around my workaround

once this merges I'll be able to run `make e2etests` from the rehearsal for the https://github.com/openshift/release/ PR I'll create to wire in jvm-build-service into prow, a la the build-service, so we can invoke unit tests and envtests.

technically speaking, we could probably use github actions for those 2 ^^ but we have to set up openshift/release to ultimately invoke the e2e-test repo https://github.com/redhat-appstudio/e2e-tests and allow for adding more jvm-build-service updates there over time.