### PR TITLE
PLNSRVCE-363: preliminary e2e-test integration (will get verification once openshift/release is updated to consume)

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,22 @@
+# Build Service CI documentation
+
+Currently in build-service all tests are running in [Openshift CI](https://prow.ci.openshift.org/?job=*jvm-build*service*).
+
+## Openshift CI
+
+Openshift CI is a Kubernetes based CI/CD system. Jobs can be triggered by various types of events and report their status to many different services. In addition to job execution, Openshift CI provides GitHub automation in a form of policy enforcement, chat-ops via /foo style commands and automatic PR merging.
+
+A documentation around onboarding components in Openshift CI can be found in the Openshift CI jobs [repository](https://github.com/openshift/release). All build-service jobs configurations are defined in https://github.com/openshift/release/tree/master/ci-operator/config/redhat-appstudio/build-service.
+
+- `build-service-e2e`: Run build suite from [e2e-tests](https://github.com/redhat-appstudio/e2e-tests/pkg/tests/build) repository.
+
+The test container to run the e2e tests in Openshift Ci is built from: https://github.com/redhat-appstudio/jvm-build-service/blob/main/.ci/openshift-ci/Dockerfile
+
+The following environments are used to launch the CI tests in Openshift CI:
+
+| Variable | Required | Explanation | Default Value |
+|---|---|---|---|
+| `BUILD_SERVICE_IMAGE` | no | A valid build service container without tag. | `quay.io/redhat-appstudio/hacbs-jvm-controller` |
+| `BUILD_SERVICE_IMAGE_TAG` | no | A valid build service container tag. | `next` |
+| `GITHUB_TOKEN` | yes | A github token used to create AppStudio applications in GITHUB  | ''  |
+| `QUAY_TOKEN` | yes | A quay token to push components images to quay.io | '' |

--- a/.ci/oci-e2e-jvm-build-service.sh
+++ b/.ci/oci-e2e-jvm-build-service.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed. Aborting."; exit 1; }
+
+export WORKSPACE BUILD_SERVICE_PR_OWNER BUILD_SERVICE_PR_SHA
+
+WORKSPACE=$(dirname "$(dirname "$(readlink -f "$0")")");
+export TEST_SUITE="jvm-build-service-suite"
+export APPLICATION_NAMESPACE="openshift-gitops"
+export APPLICATION_NAME="all-components-staging"
+
+# BUILD_SERVICE_IMAGE - build-service image built in openshift CI job workflow. More info about how image dependencies work in ci: https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
+# Container env defined at: https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/jvm-build-service/redhat-appstudio-jvm-build-service-main.yaml
+# Openshift CI generates the build service container image value with values like registry.build01.ci.openshift.org/ci-op-83gwcnmk/pipeline@sha256:8812e26b50b262d0cc45da7912970a205add4bd4e4ff3fed421baf3120027206. Need to get the image without sha.
+# the repository like 'ci-op-83gwcnmk' corresponds to they dynamically generated namespace OpenShift CI creates for a particular PR's set of jobs.  That name will always start
+# with 'ci-op-" but the last part will change per PR.  The image 'pipeline' refers to the 'pipeline' OpenShift ImageStream, and the SHA is the specific instance of the Image
+# corresponding to an OpenShift ImageStreamTag, where likely, that SHA will change image build to image build.
+export BUILD_SERVICE_IMAGE=${BUILD_SERVICE_IMAGE%@*}
+##TODO over time we will want to add additional images for all the java based components: hacbs-jvm-cache, hacbs-jvm-build-request-processor, hacbs-jvm-sidecar, hacbs-jvm-dependency-analyser
+export BUILD_SERVICE_IMAGE_REPO=${BUILD_SERVICE_IMAGE:-"quay.io/redhat-appstudio/hacbs-jvm-controller"}
+# Tag defined at: https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/build-service/redhat-appstudio-build-service-main.yaml
+export BUILD_SERVICE_IMAGE_TAG=${BUILD_SERVICE_IMAGE_TAG:-"redhat-appstudio-jvm-build-service-image"}
+
+if [[ -n "${JOB_SPEC}" && "${REPO_NAME}" == "jvm-build-service" ]]; then
+    # Extract PR author and commit SHA to also override default kustomization in infra-deployments repo
+    # https://github.com/redhat-appstudio/infra-deployments/blob/d3b56adc1bd2a7cf500793a7863660ea5117c531/hack/preview.sh#L88
+    BUILD_SERVICE_PR_OWNER=$(jq -r '.refs.pulls[0].author' <<< "$JOB_SPEC")
+    BUILD_SERVICE_PR_SHA=$(jq -r '.refs.pulls[0].sha' <<< "$JOB_SPEC")
+fi
+
+# Available openshift ci environments https://docs.ci.openshift.org/docs/architecture/step-registry/#available-environment-variables
+export ARTIFACT_DIR=${ARTIFACT_DIR:-"/tmp/appstudio"}
+
+function waitHASApplicationToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io has -n openshift-gitops -o jsonpath='{.status.health.status}')" != "Healthy" ]; do
+        echo "[INFO] Waiting for HAS to be ready."
+        sleep 30s
+    done
+}
+
+function waitAppStudioToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ] ||
+          [ "$(kubectl get applications.argoproj.io ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.sync.status}')" != "Synced" ]; do
+        echo "[INFO] Waiting for AppStudio to be ready."
+        sleep 1m
+    done
+}
+
+function waitBuildToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io build -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ] ||
+          [ "$(kubectl get applications.argoproj.io build -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.sync.status}')" != "Synced" ]; do
+        echo "[INFO] Waiting for Build to be ready."
+        sleep 1m
+    done
+}
+
+function executeE2ETests() {
+    # E2E instructions can be found: https://github.com/redhat-appstudio/e2e-tests
+    # The e2e binary is included in Openshift CI test container from the dockerfile: https://github.com/redhat-appstudio/infra-deployments/blob/main/.ci/openshift-ci/Dockerfile
+    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/e2e-openshift-ci.sh | bash -s
+
+    # The bin will be installed in tmp folder after executing e2e-openshift-ci.sh script
+    "${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio" --ginkgo.junit-report="${ARTIFACT_DIR}"/e2e-report.xml --ginkgo.focus="${TEST_SUITE}" --ginkgo.progress --ginkgo.v --ginkgo.no-color
+}
+
+curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/install-appstudio-e2e-mode.sh | bash -s install
+
+export -f waitAppStudioToBeReady
+export -f waitBuildToBeReady
+export -f waitHASApplicationToBeReady
+
+# Install AppStudio Controllers and wait for HAS and other AppStudio application to be running.
+timeout --foreground 10m bash -c waitAppStudioToBeReady
+timeout --foreground 10m bash -c waitBuildToBeReady
+timeout --foreground 10m bash -c waitHASApplicationToBeReady
+
+executeE2ETests

--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
+
+SHELL ["/bin/bash", "-c"]
+
+#TODO installing maven and java 17 from registry.ci.openshift.org/openshift/release:golang-1.17 was very problematic
+# most likely we'll need an additional Dockerfile that is referenced from openshift/release for when we want to start
+# building the java based images and tagging them for testing
+
+# Install yq, kubectl, kustomize
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -O /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && yq --version && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin


### PR DESCRIPTION
the true verification of this will be once I update openshift/release for jvm-build-service a la https://github.com/openshift/release/blob/33aac19fbdcee42298798dc0f69d8873e55e50c2/ci-operator/config/redhat-appstudio/application-service/redhat-appstudio-application-service-main.yaml#L1-L3 and https://github.com/openshift/release/blob/33aac19fbdcee42298798dc0f69d8873e55e50c2/ci-operator/config/redhat-appstudio/application-service/redhat-appstudio-application-service-main.yaml#L21-L60

so quite possibly if the rehearsals in that upcoming openshift/release PR fail, I'll need to come back here and make updates

But minimally, this PR will verify
- that the initial openshift/release bootstrapping done via https://github.com/openshift/release/pull/29191 produced the consequences we want
- that these change do not affect the existing CI

FYI
@stuartwdouglas 
@mmorhun 
@psturc 
@Michkov 

Of course, if anybody in Europe is still online and sees something very obvious before I merge this, let me know and I'll update :-) 