### PR TITLE
PLNSRVCE-363: create dir that is required for openshift/release CI image build

### DIFF
--- a/java-components/cache/src/main/docker/Dockerfile.all-in-one
+++ b/java-components/cache/src/main/docker/Dockerfile.all-in-one
@@ -3,6 +3,8 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:1.13 AS builder
 WORKDIR /work
 COPY ./ .
 
+RUN mkdir -p /work/cache/target/classes
+
 RUN mvn -B package -pl cache -am -Dmaven.test.skip
 
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13


### PR DESCRIPTION
see https://github.com/openshift/release/pull/29369#issuecomment-1152593604

@stuartwdouglas FYI ... I took a bit of a guess as to which Dockerfile was best.

If need be switch this in openshift/release while I am on PTO (@psturc can approve and lgtm your PRs there, help you with these type changes).

Though looking at https://console-openshift-console.apps.appstudio-stage.x99m.p1.openshiftapps.com/api/kubernetes/api/v1/namespaces/jvm-build-service/pods/jvm-build-cache-on-pull-request-x98hg-build-container-pod/log?cluster=local-cluster&container=step-build I saw the dockerfile I changed was the one that was used (the mkdir I added was there) so I think I picked correctly.