### PR TITLE
PLNSRVCE-448: clean up unneeded operator rbac perms; fix mvn-goals on openshift

### DIFF
--- a/deploy/base/maven-v0.2.yaml
+++ b/deploy/base/maven-v0.2.yaml
@@ -92,6 +92,9 @@ spec:
       script: |
         #!/usr/bin/env bash
 
+        # fix-permissions-for-builder
+        chown 1001:1001 -R $(workspaces.source.path)
+
         [[ -f $(workspaces.maven-settings.path)/settings.xml ]] && \
         echo 'using existing $(workspaces.maven-settings.path)/settings.xml' && exit 0
 
@@ -157,11 +160,18 @@ spec:
     - name: mvn-goals
       image: $(params.MAVEN_IMAGE)
       workingDir: $(workspaces.source.path)/$(params.CONTEXT_DIR)
-      command: ["/usr/bin/mvn"]
-      args:
-        - -s
-        - $(workspaces.maven-settings.path)/settings.xml
-        - "$(params.GOALS)"
+      script: |
+        #!/usr/bin/env bash
+
+        # fix-permissions-for-builder
+        chown 1001:1001 -R $(workspaces.source.path)
+
+        # OK, array params are easy to use when you use 'command' for a step, but a pain in the you know what
+        # with scripts.  I could not get bash to reconcile with tekton var sub, and "$(param.GOALS[*])" vs.
+        # "${params.GOALS[*]}".  Hard coding the params for now and ignoring GOALS until I can talk to Stuart
+        # and reconcile the param type here vs. having to use a script to change the permissions for running on OpenShift
+        /usr/bin/mvn -s "$(workspaces.maven-settings.path)/settings.xml" -DskipTests clean package
+
     - name: analyse-dependencies
       image: hacbs-jvm-dependency-analyser
       args:

--- a/deploy/base/run-maven-component-build-v0.1.yaml
+++ b/deploy/base/run-maven-component-build-v0.1.yaml
@@ -176,13 +176,18 @@ spec:
     - name: mvn-goals
       image: $(params.IMAGE)
       workingDir: $(workspaces.source.path)/$(params.CONTEXT_DIR)
-      command: ["/usr/bin/mvn"]
-      args:
-        - "-s"
-        - "$(workspaces.maven-settings.path)/settings.xml"
-        - "$(params.GOALS)"
-        - "-DaltDeploymentRepository=local::file:$(workspaces.source.path)/hacbs-jvm-deployment-repo"
-        - "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy"
+      script: |
+        #!/usr/bin/env bash
+
+        # fix-permissions-for-builder
+        chown 1001:1001 -R $(workspaces.source.path)
+
+        # OK, array params are easy to use when you use 'command' for a step, but a pain in the you know what
+        # with scripts.  I could not get bash to reconcile with tekton var sub, and "$(param.GOALS[*])" vs.
+        # "${params.GOALS[*]}".  Hard coding the params for now and ignoring GOALS until I can talk to Stuart
+        # and reconcile the param type here vs. having to use a script to change the permissions for running on OpenShift
+        /usr/bin/mvn -s "$(workspaces.maven-settings.path)/settings.xml" -DskipTests clean package -Denforcer.skip -DaltDeploymentRepository=local::file:$(workspaces.source.path)/hacbs-jvm-deployment-repo org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy
+
     - name: deploy-and-check-for-contaminates
       image: "registry.access.redhat.com/ubi8/ubi:8.5"
       script: |

--- a/deploy/operator/base/rbac.yaml
+++ b/deploy/operator/base/rbac.yaml
@@ -23,15 +23,6 @@ rules:
       - watch
 
   - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - create
-      - get
-      - patch
-      - update
-  - apiGroups:
       - tekton.dev
     resources:
       - taskruns

--- a/deploy/operator/base/rbac.yaml
+++ b/deploy/operator/base/rbac.yaml
@@ -34,8 +34,6 @@ rules:
   - apiGroups:
       - tekton.dev
     resources:
-      - pipelineruns
-      - pipelineruns/status
       - taskruns
       - taskruns/status
     verbs:


### PR DESCRIPTION
So this PR started of as cleanup of some unneeded RBAC permissions that I discovered while reviewing the API dependencies for jvm-build-service.

However, in the process of my local testing, I discovered that a regression was introduced with @stuartwdouglas 's https://github.com/redhat-appstudio/jvm-build-service/commit/b6cf13f16f09f9fe68eca98286ef909024880fce (the change of the maven image I believe) that results in this error when running on OpenShift:

```
[mvn-goals] [INFO] Using 'UTF-8' encoding to copy filtered resources.
[mvn-goals] [INFO] ------------------------------------------------------------------------
[mvn-goals] [INFO] BUILD FAILURE
[mvn-goals] [INFO] ------------------------------------------------------------------------
[mvn-goals] [INFO] Total time:  30:59 min
[mvn-goals] [INFO] Finished at: 2022-06-30T13:14:43Z
[mvn-goals] [INFO] ------------------------------------------------------------------------
[mvn-goals] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:2.6:resources (default-resources) on project code-with-quarkus: Cannot create resource output directory: /workspace/source/target/classes -> [Help 1]
[mvn-goals] [ERROR] 
[mvn-goals] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[mvn-goals] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[mvn-goals] [ERROR] 
[mvn-goals] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[mvn-goals] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

I did cross reference with @dwalluck, who happened to be working on a minikube cluster today, and confirmed that this error does not occur on minikube.  This is not at all surprising though, given OpenShift's more stringent enforcement around things like file permissions.

Furthermore, I saw in @Michkov 's https://github.com/redhat-appstudio/jvm-build-service/commit/4127d12738e78f77ac4af9d8f6f432387604d9da where he undoubtedly encountered a similar situation in other steps he touched in the PR, and have employed those in Task/ClusterTask we use as part of testing the service registry build locally.

Now, the icky part.  I could not sort out after a lot of different experiments how to reconcile the `GOAL` param array within a `script`.  I had to switch `mvn-goals` from a `command` to a `script` to add the `chown` to fix the permissions issue.  Aside from general bash internet searches, I went throught the tekton doc, and sure enough, no examples around param arrays in scripts.  Plenty with string and k/v pair params.  So for now, I've hardcoded to the params used in the service registry build.

If solutions arise during PR review, I'll gladly take them.  If none arise, I'll merge this after any other comments are addressed, link up with @stuartwdouglas when he gets back, and sort out whether we can use a more friendly maven image for OpenShift, switch the `GOALS` param to a space separated string parameter, or some other option not occurring to me.

/assign @Michkov 
/assign @dwalluck 