### PR TITLE
PLNSRVCE-452: get run sample build running on openshift using jvm-build-service deployed by appstudio

### DIFF
--- a/deploy/base/maven-v0.2.yaml
+++ b/deploy/base/maven-v0.2.yaml
@@ -89,6 +89,8 @@ spec:
   steps:
     - name: mvn-settings
       image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      securityContext:
+        runAsUser: 0
       script: |
         #!/usr/bin/env bash
         chown 1001:1001 -R $(workspaces.source.path)
@@ -160,6 +162,8 @@ spec:
 
     - name: mvn-goals
       image: $(params.MAVEN_IMAGE)
+      securityContext:
+        runAsUser: 0
       workingDir: $(workspaces.source.path)/$(params.CONTEXT_DIR)
       script: |
         #!/usr/bin/env bash
@@ -174,7 +178,9 @@ spec:
         /usr/bin/mvn -s "$(workspaces.maven-settings.path)/settings.xml" -DskipTests clean package
 
     - name: analyse-dependencies
-      image: hacbs-jvm-dependency-analyser
+      securityContext:
+        runAsUser: 0
+      image: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:3dcd8603061c7ab2cedfe128c80cac9726721a74
       args:
         - path
         - $(workspaces.source.path)/$(params.CONTEXT_DIR)/$(params.DEPENDENCY_ANALYSER_PATH)
@@ -185,11 +191,13 @@ spec:
         - -u
         - "$(results.untrusted-dependencies.path)"
   sidecars:
-    - image: hacbs-jvm-sidecar
+    - image: quay.io/redhat-appstudio/hacbs-jvm-sidecar:3dcd8603061c7ab2cedfe128c80cac9726721a74
+      securityContext:
+        runAsUser: 0
       imagePullPolicy: Always
       env:
         - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
-          value: "http://hacbs-jvm-cache.default.svc.cluster.local"
+          value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
       name: proxy
       livenessProbe:
         httpGet:

--- a/deploy/base/run-maven-component-build-v0.1.yaml
+++ b/deploy/base/run-maven-component-build-v0.1.yaml
@@ -108,6 +108,8 @@ spec:
         - -revision=$(params.TAG)
     - name: settings
       image: "registry.access.redhat.com/ubi8/ubi:8.5"
+      securityContext:
+        runAsUser: 0
       resources:
         requests:
           memory: "128Mi"
@@ -185,6 +187,8 @@ spec:
         fi
     - name: mvn-goals
       image: $(params.IMAGE)
+      securityContext:
+        runAsUser: 0
       workingDir: $(workspaces.source.path)/$(params.CONTEXT_DIR)
       args: [ "$(params.GOALS[*])" ]
       script: |
@@ -204,6 +208,8 @@ spec:
         /usr/bin/mvn -s "$(workspaces.maven-settings.path)/settings.xml" $@ "-DaltDeploymentRepository=local::file:$(workspaces.source.path)/hacbs-jvm-deployment-repo" "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy"
     - name: deploy-and-check-for-contaminates
       image: "registry.access.redhat.com/ubi8/ubi:8.5"
+      securityContext:
+        runAsUser: 0
       script: |
         tar -czf $(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz -C $(workspaces.source.path)/hacbs-jvm-deployment-repo .
         curl --data-binary @$(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz http://localhost:2000/deploy
@@ -219,6 +225,8 @@ spec:
           cpu: "300m"
   sidecars:
     - image: hacbs-jvm-sidecar
+      securityContext:
+        runAsUser: 0
       imagePullPolicy: Always
       env:
         - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL

--- a/deploy/cache/base/deployment.yaml
+++ b/deploy/cache/base/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hacbs-jvm-cache
+  namespace: jvm-build-service
 spec:
   replicas: 1
   selector:

--- a/deploy/cache/base/service.yaml
+++ b/deploy/cache/base/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hacbs-jvm-cache
+  namespace: jvm-build-service
 spec:
   ports:
     - name: http

--- a/deploy/development.sh
+++ b/deploy/development.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-kubectl delete deployments.apps hacbs-jvm-operator
+kubectl delete deployments.apps hacbs-jvm-operator -n jvm-build-service
+kubectl delete deployments.apps hacbs-jvm-cache -n jvm-build-service
+kubectl delete deployments.apps localstack -n jvm-build-service
+
 
 DIR=`dirname $0`
+kubectl apply -f $DIR/namespace.yaml
+kubectl config set-context --current --namespace=jvm-build-service
+find $DIR -name maven-v0.2.yaml -exec sed -i s/redhat-appstudio/${QUAY_USERNAME}/ {} \;
+find $DIR -name maven-v0.2.yaml -exec sed -i s/3dcd8603061c7ab2cedfe128c80cac9726721a74/dev/ {} \;
 find $DIR -name development -exec rm -r {} \;
 find $DIR -name dev-template -exec cp -r {} {}/../development \;
 find $DIR -path \*development\*.yaml -exec sed -i s/QUAY_USERNAME/${QUAY_USERNAME}/ {} \;

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jvm-build-service

--- a/deploy/operator/base/deployment.yaml
+++ b/deploy/operator/base/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hacbs-jvm-operator
+  namespace: jvm-build-service
 spec:
   replicas: 1
   selector:

--- a/deploy/operator/base/sa.yaml
+++ b/deploy/operator/base/sa.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hacbs-jvm-operator
+  namespace: jvm-build-service

--- a/deploy/overlays/dev-template/localstack.yaml
+++ b/deploy/overlays/dev-template/localstack.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: localstack
+  namespace: jvm-build-service
 spec:
   selector:
     matchLabels:
@@ -26,6 +27,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: localstack
+  namespace: jvm-build-service
 spec:
   selector:
     app: localstack

--- a/hack/examples/openshift-specific-rbac.yaml
+++ b/hack/examples/openshift-specific-rbac.yaml
@@ -1,0 +1,23 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-anyuid-role
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["anyuid"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-anyuid-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+roleRef:
+  kind: Role
+  name: pipeline-anyuid-role
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/examples/run-build-discovery.sh
+++ b/hack/examples/run-build-discovery.sh
@@ -9,6 +9,8 @@ echo
 echo "👉 Running the pipeline with a sample project:"
 echo
 
+kubectl apply -f $DIR/openshift-specific-rbac.yaml || true
+
 kubectl create -f $DIR/run-build-discovery-task.yaml
 
 echo

--- a/hack/examples/run-quarkus-security-build.sh
+++ b/hack/examples/run-quarkus-security-build.sh
@@ -9,6 +9,8 @@ echo
 echo "👉 Running the pipeline with a sample project:"
 echo
 
+kubectl apply -f $DIR/openshift-specific-rbac.yaml || true
+
 kubectl create -f $DIR/run-build-quarkus-security.yaml
 
 echo

--- a/hack/examples/run-sample-pipeline.sh
+++ b/hack/examples/run-sample-pipeline.sh
@@ -11,6 +11,8 @@ echo
 
 kubectl apply -f $DIR/pipeline.yaml
 
+kubectl apply -f $DIR/openshift-specific-rbac.yaml || true
+
 echo
 echo "👉 Running the pipeline with a sample project:"
 echo

--- a/hack/examples/run-service-registry.sh
+++ b/hack/examples/run-service-registry.sh
@@ -11,6 +11,8 @@ echo
 
 kubectl apply -f $DIR/pipeline.yaml
 
+kubectl apply -f $DIR/openshift-specific-rbac.yaml || true
+
 echo
 echo "👉 Running the pipeline with a sample project:"
 echo

--- a/hack/examples/run-service-registry.yaml
+++ b/hack/examples/run-service-registry.yaml
@@ -22,6 +22,6 @@ spec:
             requests:
               storage: 5Gi
   serviceAccountNames:
-    - serviceAccountName: hacbs-jvm-operator #TODO: what do we do about this?
+    - serviceAccountName: pipeline
       taskName: maven-run
 

--- a/hack/examples/run.yaml
+++ b/hack/examples/run.yaml
@@ -20,5 +20,5 @@ spec:
             requests:
               storage: 1Gi
   serviceAccountNames:
-    - serviceAccountName: hacbs-jvm-operator #TODO: what do we do about this?
+    - serviceAccountName: pipeline
       taskName: maven-run


### PR DESCRIPTION
Basically, testing against minikube/kind, or against openshift but using the `default` namespace, bypasses all of openshift's basic SCC related pod level security checks.

After this merges, I'll work with @psturc to see if and how we might want or not want to incorporate running our non-component based, example cache population flow (essentially a pre-cursor to doing `java-builder` appstudio builds that leverage the our cache) out of https://github.com/redhat-appstudio/e2e-tests, of we want to contain that element of things to our e2e specific logic in this repo.

I also updated the `make dev` flow to become opinionated on using the `jvm-build-service` namespace to make it consistent enough with appstudio deploying jvm-build-service that we can still share yaml.

/assign @stuartwdouglas 