### PR TITLE
PLNSRVCE-452: add anyuid to cache deployment to get past startup errors

### DIFF
--- a/deploy/cache/base/deployment.yaml
+++ b/deploy/cache/base/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         - name: hacbs-jvm-cache
           image: hacbs-jvm-cache
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
           env:
             - name: CACHE_PATH
               value: "cache"
@@ -55,3 +57,4 @@ spec:
             limits:
               memory: "700Mi"
               cpu: "500m"
+      serviceAccountName: hacbs-jvm-cache

--- a/deploy/cache/base/kustomization.yaml
+++ b/deploy/cache/base/kustomization.yaml
@@ -6,3 +6,5 @@ commonLabels:
 resources:
   - deployment.yaml
   - service.yaml
+  - rbac.yaml
+  - sa.yaml

--- a/deploy/cache/base/rbac.yaml
+++ b/deploy/cache/base/rbac.yaml
@@ -1,0 +1,25 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-anyuid-role
+  namespace: jvm-build-service
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["anyuid"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-anyuid-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: hacbs-jvm-cache
+    namespace: jvm-build-service
+roleRef:
+  kind: Role
+  name: pipeline-anyuid-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/cache/base/sa.yaml
+++ b/deploy/cache/base/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hacbs-jvm-cache
+  namespace: jvm-build-service


### PR DESCRIPTION
Started seeing 

```
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2022-07-12 18:13:11,752 WARN  [io.qua.run.con.ConfigRecorder] (main) Build time property cannot be changed at runtime:
 - quarkus.container-image.group is set to 'gabemontero' but it is build time fixed to 'redhat-appstudio'. Did you change the property quarkus.container-image.group after building the application?
2022-07-12 18:13:14,147 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) S3 repository rebuilt added with bucket artifact-store and prefixes [default]
2022-07-12 18:13:14,148 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) Maven repository redhat added with URI https://maven.repository.redhat.com/ga
2022-07-12 18:13:14,347 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) Maven repository central added with URI https://repo.maven.apache.org/maven2
2022-07-12 18:13:14,348 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) Maven repository jboss added with URI https://repository.jboss.org/nexus/content/groups/public/
2022-07-12 18:13:14,350 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) Maven repository jitpack added with URI https://jitpack.io
2022-07-12 18:13:14,351 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) Maven repository confluent added with URI https://packages.confluent.io/maven
2022-07-12 18:13:14,352 INFO  [com.red.hac.art.ser.BuildPolicyManager] (main) Maven repository gradle added with URI https://repo.gradle.org/artifactory/libs-releases
2022-07-12 18:13:14,353 INFO  [com.red.hac.art.ser.LocalCache] (main) Creating cache with path /home/jboss/cache
2022-07-12 18:13:14,549 ERROR [io.qua.run.Application] (main) Failed to start application (with profile prod): java.nio.file.AccessDeniedException: /home/jboss/cache
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:397)
	at java.base/java.nio.file.Files.createDirectory(Files.java:700)
	at java.base/java.nio.file.Files.createAndCheckIsDirectory(Files.java:807)
	at java.base/java.nio.file.Files.createDirectories(Files.java:793)
	at com.redhat.hacbs.artifactcache.services.LocalCache.<init>(LocalCache.java:50)
	at com.redhat.hacbs.artifactcache.services.LocalCache_Bean.create(Unknown Source)
	at com.redhat.hacbs.artifactcache.services.LocalCache_Bean.create(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:111)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:32)
	at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:26)
	at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
	at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:32)
	at com.redhat.hacbs.artifactcache.services.LocalCache_Bean.get(Unknown Source)
	at com.redhat.hacbs.artifactcache.services.LocalCache_Bean.get(Unknown Source)
	at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:428)
	at io.quarkus.arc.impl.ArcContainerImpl.beanInstanceHandle(ArcContainerImpl.java:441)
	at io.quarkus.arc.impl.ArcContainerImpl.instance(ArcContainerImpl.java:277)
	at com.redhat.hacbs.artifactcache.services.LocalCache_Observer_Synthetic_d70cd75bf32ab6598217b9a64a8473d65e248c05.notify(Unknown Source)
	at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:320)
	at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:302)
	at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:73)
	at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:128)
	at io.quarkus.arc.runtime.ArcRecorder.handleLifecycleEvents(ArcRecorder.java:97)
	at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy_0(Unknown Source)
	at io.quarkus.deployment.steps.LifecycleEventsBuildStep$startupEvent1144526294.deploy(Unknown Source)
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:103)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:67)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:41)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:120)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:60)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:31)
```

in the hacbs-jvm-cache pod when running in openshift / jvm-build-service namespace after #96 merged (though maybe something prior to that triggered it.

