### PR TITLE
PLNSRVCE-482: Allow the overriding of the analyzer image in CI runs

### DIFF
--- a/.ci/common-ci-settings-and-functions.sh
+++ b/.ci/common-ci-settings-and-functions.sh
@@ -86,6 +86,8 @@ function waitBuildToBeReady() {
     done
 }
 
+. .ci/override-tekton-bundle.sh
+
 curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/install-appstudio-e2e-mode.sh | bash -s install
 
 export -f waitAppStudioToBeReady

--- a/.ci/override-tekton-bundle.sh
+++ b/.ci/override-tekton-bundle.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This script will generate a new Tekton bundle that allows the overriding of images that are hard-coded into task steps
+TEMP_FOLDER=$WORKSPACE/tmp/bundle-override
+APPSTUDIO_QE_REPO=quay.io/redhat-appstudio-qe/test-images
+TASK_BUNDLE_IMG=$APPSTUDIO_QE_REPO:task-bundle-$JVM_BUILD_SERVICE_PR_SHA
+PIPELINE_BUNDLE_IMG=$APPSTUDIO_QE_REPO:pipeline-bundle-$JVM_BUILD_SERVICE_PR_SHA
+
+function getCurrentBuildBundle() {
+    curl -s -o "$TEMP_FOLDER"/build-kustomization.yaml https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/build/kustomization.yaml
+
+    BUILD_BUNDLE=$(yq e ".configMapGenerator[].literals[]" \
+    "$TEMP_FOLDER"/build-kustomization.yaml \
+    | grep default_build_bundle \
+    | sed "s/default_build_bundle=//")
+
+    echo "New build bundle will be created based on $BUILD_BUNDLE"
+}
+
+function createPipelinesFile() {
+    pipelines=$(tkn bundle list "$BUILD_BUNDLE" | sed "s/pipeline.tekton.dev\///")
+    for pipeline in $pipelines; do
+        echo "---" >> "$TEMP_FOLDER"/pipelines.yaml
+        tkn bundle list -o yaml "$BUILD_BUNDLE" pipeline "$pipeline" >> "$TEMP_FOLDER"/pipelines.yaml
+    done
+}
+
+function createTaskFile() {
+    for bundle in $(grep bundle "$TEMP_FOLDER"/pipelines.yaml | sort -u | awk '{print $2}'); do 
+        tasks=$(tkn bundle list "$bundle" | sed "s/task.tekton.dev\///")
+
+        for task in $tasks; do
+            if [ "$task" == "s2i-java" ]; then
+                tkn bundle list -o yaml "$bundle" task "$task" >> "$TEMP_FOLDER"/task.yaml
+            fi
+        done
+    done
+}
+
+function updateAnalyzerImage() {
+    echo "jvm-build-service analyzer image set to $JVM_BUILD_SERVICE_ANALYZER_IMAGE"
+    yq e -i "select(.metadata.name == \"s2i-java\") \
+    | (.spec.steps[] | select(.name == \"analyse-dependencies-java-sbom\").image) \
+    |= \"$JVM_BUILD_SERVICE_ANALYZER_IMAGE\"" "$TEMP_FOLDER"/task.yaml
+}
+
+function updatePipelineRef() {
+    yq e -i "(.spec.tasks[].taskRef | select (.name == \"s2i-java\").bundle) \
+    |= \"$TASK_BUNDLE_IMG\"" "$TEMP_FOLDER"/pipelines.yaml
+}
+
+function createDockerConfig() {
+    mkdir ~/.docker
+    echo "$QUAY_TOKEN" | base64 -d > ~/.docker/config.json
+}
+
+function createAndPushTaskBundle() {
+    echo "Creating $TASK_BUNDLE_IMG"
+    tkn bundle push "$TASK_BUNDLE_IMG" -f "$TEMP_FOLDER"/task.yaml
+}
+
+function createAndPushPipelineBundle() {
+    echo "Creating $PIPELINE_BUNDLE_IMG"
+    tkn bundle push "$PIPELINE_BUNDLE_IMG" -f "$TEMP_FOLDER"/pipelines.yaml
+}
+
+mkdir -p "$TEMP_FOLDER"
+
+getCurrentBuildBundle
+createPipelinesFile
+createTaskFile
+updateAnalyzerImage
+updatePipelineRef
+createDockerConfig
+createAndPushTaskBundle
+createAndPushPipelineBundle
+
+export DEFAULT_BUILD_BUNDLE="$PIPELINE_BUNDLE_IMG"


### PR DESCRIPTION
We need to override the used dependency analyzer image in order to properly run the CI tests. This PR provides a mechanism that achieves that by:

-  cloning the build-definitions repo
-  overriding the image reference in the task where its being used
-  creating a new Tekton bundle
-  pushing it to a target repository
-  creating a configmap to override the bundle used by Appstudio
-  starting the e2e tests