### PR TITLE
  PLNSRVCE-547 Ability to configure JVM builds 

### DIFF
--- a/.ci/common-ci-settings-and-functions.sh
+++ b/.ci/common-ci-settings-and-functions.sh
@@ -23,6 +23,9 @@ if [ "$PR_RUN" != "notpr" ]; then
   # JVM_BUILD_SERVICE_SIDECAR_IMAGE - sidecar image built in openshift CI job workflow.
   # JVM_BUILD_SERVICE_ANALYZER_IMAGE - dependency analyzer image built in openshift CI workflow.
   # JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE - request processor image built in openshift CI workflow.
+  # JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE - JDK build image built in openshift CI workflow.
+  # JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE - JDK build image built in openshift CI workflow.
+  # JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE - JDK build image built in openshift CI workflow.
 
   # More info about how image dependencies work in ci: https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
   # Container env defined at: https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/jvm-build-service/redhat-appstudio-jvm-build-service-main.yaml
@@ -55,6 +58,18 @@ if [ "$PR_RUN" != "notpr" ]; then
   export JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE=${JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE%@*}
   export JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE_REPO=${JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE:-"quay.io/redhat-appstudio/hacbs-jvm-build-request-processor"}
   export JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE_TAG=${JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE_TAG:-"redhat-appstudio-jvm-build-service-reqprocessor-image"}
+
+  export JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE=${JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE%@*}
+  export JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE_REPO=${JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE:-"quay.io/redhat-appstudio/hacbs-jdk8-builder"}
+  export JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE_TAG=${JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE_TAG:-"redhat-appstudio-jvm-build-service-jdk8-builder-image"}
+
+  export JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE=${JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE%@*}
+  export JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE_REPO=${JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE:-"quay.io/redhat-appstudio/hacbs-jdk11-builder"}
+  export JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE_TAG=${JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE_TAG:-"redhat-appstudio-jvm-build-service-jdk11-builder-image"}
+
+  export JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE=${JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE%@*}
+  export JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE_REPO=${JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE:-"quay.io/redhat-appstudio/hacbs-jdk17-builder"}
+  export JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE_TAG=${JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE_TAG:-"redhat-appstudio-jvm-build-service-jdk17-builder-image"}
 
   if [[ -n "${JOB_SPEC}" && "${REPO_NAME}" == "jvm-build-service" ]]; then
       # Extract PR author and commit SHA to also override default kustomization in infra-deployments repo

--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -28,7 +28,10 @@ spec:
         components/build/jvm-build-service/kustomization.yaml &&
         sed -i 
         -e 's|\(quay.io/redhat-appstudio/[^:]*:\).*|\1{{ revision }}|'
-        components/build/jvm-build-service/operator-images.yaml
+        components/build/jvm-build-service/operator-images.yaml&&
+        sed -i 
+        -e 's|\(quay.io/redhat-appstudio/[^:]*:\).*|\1{{ revision }}|'
+        components/build/jvm-build-service/system-config.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest

--- a/Dockerfile.cache-in-ci
+++ b/Dockerfile.cache-in-ci
@@ -5,6 +5,9 @@ USER 0
 RUN cd java-components/cache && mvn clean package -DskipTests
 
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13
+USER 0
+RUN mkdir /cache && chown 185 /cache
+USER 185
 WORKDIR /work/
 
 COPY --from=builder /work/java-components/cache/target/quarkus-app/lib/ /deployments/lib/
@@ -13,7 +16,6 @@ COPY --from=builder /work/java-components/cache/target/quarkus-app/app/ /deploym
 COPY --from=builder /work/java-components/cache/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
 
 ENV AB_JOLOKIA_OFF=""
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/builder-images/Dockerfile.template
+++ b/builder-images/Dockerfile.template
@@ -52,5 +52,3 @@ RUN microdnf clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
 USER hacbs
 # Define the working directory
 WORKDIR /project
-# Define run cmd
-CMD ["mvn", "-v"]

--- a/builder-images/hacbs-jdk11-builder/Dockerfile
+++ b/builder-images/hacbs-jdk11-builder/Dockerfile
@@ -52,5 +52,3 @@ RUN microdnf clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
 USER hacbs
 # Define the working directory
 WORKDIR /project
-# Define run cmd
-CMD ["mvn", "-v"]

--- a/builder-images/hacbs-jdk17-builder/Dockerfile
+++ b/builder-images/hacbs-jdk17-builder/Dockerfile
@@ -52,5 +52,3 @@ RUN microdnf clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
 USER hacbs
 # Define the working directory
 WORKDIR /project
-# Define run cmd
-CMD ["mvn", "-v"]

--- a/builder-images/hacbs-jdk8-builder/Dockerfile
+++ b/builder-images/hacbs-jdk8-builder/Dockerfile
@@ -52,5 +52,3 @@ RUN microdnf clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
 USER hacbs
 # Define the working directory
 WORKDIR /project
-# Define run cmd
-CMD ["mvn", "-v"]

--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-config
+data:
+  enable-rebuilds: "true"
+  maven-repository-300-jboss: "https://repository.jboss.org/nexus/content/groups/public/"
+  maven-repository-301-jitpack: "https://jitpack.io"
+  maven-repository-302-confluent: "https://packages.confluent.io/maven"
+  maven-repository-303-gradle: "https://repo.gradle.org/artifactory/libs-releases"

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -3,7 +3,8 @@ kind: Kustomization
 
 resources:
   - gradle-v0.1.yaml
-  - https://github.com/tektoncd/pipeline/releases/download/v0.34.1/release.yaml
+#  - https://github.com/tektoncd/pipeline/releases/download/v0.34.1/release.yaml
   - https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml
   - maven-v0.2.yaml
   - rbac.yaml
+  - config.yaml

--- a/deploy/base/maven-v0.2.yaml
+++ b/deploy/base/maven-v0.2.yaml
@@ -174,7 +174,7 @@ spec:
         # with scripts.  I could not get bash to reconcile with tekton var sub, and "$(param.GOALS[*])" vs.
         # "${params.GOALS[*]}".  Hard coding the params for now and ignoring GOALS until I can talk to Stuart
         # and reconcile the param type here vs. having to use a script to change the permissions for running on OpenShift
-        /usr/bin/mvn -s "$(workspaces.maven-settings.path)/settings.xml" -DskipTests clean package
+        /usr/bin/mvn -s "$(workspaces.maven-settings.path)/settings.xml" -DskipTests clean package || { cat $(workspaces.maven-settings.path)/sidecar.log ; false ; }
 
     - name: analyse-dependencies
       securityContext:
@@ -197,7 +197,7 @@ spec:
       imagePullPolicy: Always
       env:
         - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
-          value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
+          value: "http://jvm-build-workspace-artifact-cache.$(context.taskRun.namespace).svc.cluster.local"
         - name: QUARKUS_LOG_FILE_ENABLE
           value: "true"
         - name: QUARKUS_LOG_FILE_PATH

--- a/deploy/base/rbac.yaml
+++ b/deploy/base/rbac.yaml
@@ -17,16 +17,3 @@ kind: ServiceAccount
 metadata:
   name: pipeline
   namespace: jvm-build-service
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: pipeline
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: pipeline
-subjects:
-  - kind: ServiceAccount
-    name: pipeline
-    namespace: jvm-build-service

--- a/deploy/cache/base/deployment.yaml
+++ b/deploy/cache/base/deployment.yaml
@@ -1,3 +1,6 @@
+#====================================================================================================
+#This is no longer required, it should be removed once it is no longer reference by infra-deployments
+#====================================================================================================
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/cache/base/kustomization.yaml
+++ b/deploy/cache/base/kustomization.yaml
@@ -1,3 +1,6 @@
+#====================================================================================================
+#This is no longer required, it should be removed once it is no longer reference by infra-deployments
+#====================================================================================================
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/deploy/cache/base/rbac.yaml
+++ b/deploy/cache/base/rbac.yaml
@@ -1,3 +1,6 @@
+#====================================================================================================
+#This is no longer required, it should be removed once it is no longer reference by infra-deployments
+#====================================================================================================
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/cache/base/sa.yaml
+++ b/deploy/cache/base/sa.yaml
@@ -1,3 +1,6 @@
+#====================================================================================================
+#This is no longer required, it should be removed once it is no longer reference by infra-deployments
+#====================================================================================================
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/cache/base/service.yaml
+++ b/deploy/cache/base/service.yaml
@@ -1,3 +1,6 @@
+#====================================================================================================
+#This is no longer required, it should be removed once it is no longer reference by infra-deployments
+#====================================================================================================
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/development.sh
+++ b/deploy/development.sh
@@ -10,7 +10,7 @@ kubectl delete deployments.apps hacbs-jvm-operator -n jvm-build-service
 
 DIR=`dirname $0`
 kubectl apply -f $DIR/namespace.yaml
-kubectl config set-context --current --namespace=jvm-build-service
+kubectl config set-context --current --namespace=test-jvm-namespace
 find $DIR -name development -exec rm -r {} \;
 find $DIR -name dev-template -exec cp -r {} {}/../development \;
 find $DIR -path \*development\*.yaml -exec sed -i s/QUAY_USERNAME/${QUAY_USERNAME}/ {} \;

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,4 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: test-jvm-namespace
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: jvm-build-service

--- a/deploy/operator/base/rbac.yaml
+++ b/deploy/operator/base/rbac.yaml
@@ -62,6 +62,49 @@ rules:
       - list
       - watch
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - list
+      - watch
+      - delete
+  - apiGroups:
+    - "apps"
+    resources:
+      - deployments
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - create
+      - patch
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - create
+      - patch
+      - list
+      - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/overlays/dev-template/config.yaml
+++ b/deploy/overlays/dev-template/config.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-config
+data:
+  redirect-artifact-quarkus: "io.quarkus:(.*):2\\.7\\\\..*=io.quarkus:$1:2.7.5.Final-redhat-00011"
+  cache-image: "quay.io/QUAY_USERNAME/hacbs-jvm-cache:dev"

--- a/deploy/overlays/dev-template/kustomization.yaml
+++ b/deploy/overlays/dev-template/kustomization.yaml
@@ -4,11 +4,10 @@ kind: Kustomization
 bases:
  - "../../crds/base"
  - "../../base"
- - "../../cache/overlays/dev-template"
  - "../../operator/overlays/dev-template"
 
 resources:
-  - localstack.yaml
+  - system-config.yaml
 
 patches:
  - patch: |-
@@ -25,3 +24,6 @@ patches:
    target:
      kind: Task
      name: maven
+
+patchesStrategicMerge:
+  - config.yaml

--- a/deploy/overlays/dev-template/system-config.yaml
+++ b/deploy/overlays/dev-template/system-config.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-system-config
+  namespace: jvm-build-service
+data:
+  image.cache: quay.io/QUAY_USERNAME/hacbs-jvm-cache:dev
+  builder-image.names: jdk11,jdk8,jdk17
+  builder-image.jdk8.image: quay.io/sdouglas/hacbs-jdk8-builder:dev
+  builder-image.jdk11.image: quay.io/sdouglas/hacbs-jdk11-builder:dev
+  builder-image.jdk17.image: quay.io/sdouglas/hacbs-jdk17-builder:dev
+  #use these if you have built your own local builder images using build-local.sh
+  #builder-image.jdk8.image: quay.io/QUAY_USERNAME/hacbs-jdk8-builder:dev
+  #builder-image.jdk11.image: quay.io/QUAY_USERNAME/hacbs-jdk11-builder:dev
+  #builder-image.jdk17.image: quay.io/QUAY_USERNAME/hacbs-jdk17-builder:dev

--- a/hack/examples/hacbs-config.yaml
+++ b/hack/examples/hacbs-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-pipelines-defaults
+data:
+  default_build_bundle: "quay.io/redhat-appstudio/hacbs-templates-bundle:latest"

--- a/hack/examples/staging-build.yaml
+++ b/hack/examples/staging-build.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: test
+spec:
+  componentName: test
+  application: test-application
+  source:
+    git:
+      url: https://github.com/stuartwdouglas/code-with-quarkus
+

--- a/java-components/cache/src/main/docker/Dockerfile.jvm
+++ b/java-components/cache/src/main/docker/Dockerfile.jvm
@@ -85,7 +85,7 @@ COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
 COPY --chown=185 target/quarkus-app/*.jar /deployments/
 COPY --chown=185 target/quarkus-app/app/ /deployments/app/
 COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
-
+RUN mkdir /cache && chown 185 /cache
 EXPOSE 8080
 USER 185
 ENV AB_JOLOKIA_OFF=""

--- a/pkg/apis/jvmbuildservice/v1alpha1/dependencybuild_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/dependencybuild_types.go
@@ -30,7 +30,7 @@ type DependencyBuildStatus struct {
 	//BuildRecipe the current build recipe. If build is done then this recipe was used
 	//to get to the current state
 	CurrentBuildRecipe *BuildRecipe `json:"currentBuildRecipe,omitempty"`
-	//PotentialBuildRecipes additional recipes to try if the current recipe fails
+	// PotentialBuildRecipes additional recipes to try if the current recipe fails
 	PotentialBuildRecipes []*BuildRecipe `json:"potentialBuildRecipes,omitempty"`
 	//FailedBuildRecipes recipes that resulted in a failure
 	//if the current state is failed this may include the current BuildRecipe

--- a/pkg/reconciler/configmap/configmap.go
+++ b/pkg/reconciler/configmap/configmap.go
@@ -1,0 +1,357 @@
+// This package contains the reconciler for the system and user level config
+// System level config is a single ConfigMap, while the user level config is
+// per namespace
+package configmap
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+	"regexp"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	//TODO eventually we'll need to decide if we want to make this tuneable
+	contextTimeout              = 300 * time.Second
+	UserConfigMapName           = "jvm-build-config"
+	UserConfigAdditionalRecipes = "additional-build-recipes"
+	CacheDeploymentName         = "jvm-build-workspace-artifact-cache"
+	LocalstackDeploymentName    = "jvm-build-workspace-localstack"
+	EnableRebuilds              = "enable-rebuilds"
+	SystemConfigMapName         = "jvm-build-system-config"
+	SystemConfigMapNamespace    = "jvm-build-service"
+	SystemCacheImage            = "image.cache"
+	SystemBuilderImages         = "builder-image.names"
+	SystemBuilderImageFormat    = "builder-image.%s.image"
+)
+
+var (
+	RequiredKeys = map[string]bool{SystemCacheImage: true}
+	log          = ctrl.Log.WithName("configmap")
+)
+
+type ReconcileConfigMap struct {
+	client               client.Client
+	scheme               *runtime.Scheme
+	eventRecorder        record.EventRecorder
+	configuredCacheImage string
+}
+
+func newReconciler(mgr ctrl.Manager, config map[string]string) reconcile.Reconciler {
+	return &ReconcileConfigMap{
+		client:               mgr.GetClient(),
+		scheme:               mgr.GetScheme(),
+		eventRecorder:        mgr.GetEventRecorderFor("ArtifactBuild"),
+		configuredCacheImage: config[SystemCacheImage],
+	}
+}
+
+func (r *ReconcileConfigMap) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+	if request.Name == SystemConfigMapName && request.Namespace == SystemConfigMapNamespace {
+		return r.handleSystemConfigMap(ctx, request)
+	}
+	if request.Name != UserConfigMapName {
+		return reconcile.Result{}, nil
+	}
+	configMap := corev1.ConfigMap{}
+	err := r.client.Get(ctx, request.NamespacedName, &configMap)
+	if err != nil {
+		return reconcile.Result{}, nil
+	}
+	enabled := configMap.Data[EnableRebuilds] == "true"
+
+	log.Info("Setup Cache %s", "name", request.Name)
+	if err = r.setupCache(ctx, request, enabled, configMap); err != nil {
+		return reconcile.Result{}, err
+	}
+	if enabled {
+		log.Info("Setup Rebuilds %s", "name", request.Name)
+		err := r.setupRebuilds(ctx, request)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileConfigMap) setupCache(ctx context.Context, request reconcile.Request, rebuildsEnabled bool, configMap corev1.ConfigMap) error {
+	//first setup the storage
+	deploymentName := types.NamespacedName{Namespace: request.Namespace, Name: CacheDeploymentName}
+
+	pvc := corev1.PersistentVolumeClaim{}
+	err := r.client.Get(ctx, deploymentName, &pvc)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			pvc = corev1.PersistentVolumeClaim{}
+			pvc.Name = CacheDeploymentName
+			pvc.Namespace = request.Namespace
+			pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+			qty, err := resource.ParseQuantity("10Gi")
+			if err != nil {
+				return err
+			}
+			//TODO: make configurable
+			pvc.Spec.Resources.Requests = map[corev1.ResourceName]resource.Quantity{"storage": qty}
+			err = r.client.Create(ctx, &pvc)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	cache := v1.Deployment{}
+	err = r.client.Get(ctx, deploymentName, &cache)
+	create := false
+	if err != nil {
+		if errors.IsNotFound(err) {
+			create = true
+			cache.Name = deploymentName.Name
+			cache.Namespace = deploymentName.Namespace
+			var replicas int32
+			replicas = 1
+			cache.Spec.Replicas = &replicas
+			cache.Spec.Selector = &v12.LabelSelector{MatchLabels: map[string]string{"app": CacheDeploymentName}}
+			cache.Spec.Template.ObjectMeta.Labels = map[string]string{"app": CacheDeploymentName}
+			cache.Spec.Template.Spec.Containers = []corev1.Container{{
+				Name:            CacheDeploymentName,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Ports: []corev1.ContainerPort{{
+					Name:          "http",
+					ContainerPort: 8080,
+					Protocol:      "TCP",
+				}},
+				VolumeMounts: []corev1.VolumeMount{{Name: CacheDeploymentName, MountPath: "/cache"}},
+				Resources: corev1.ResourceRequirements{
+					//TODO: make configurable
+					Requests: map[corev1.ResourceName]resource.Quantity{"memory": resource.MustParse("128Mi"), "cpu": resource.MustParse("250m")},
+					Limits:   map[corev1.ResourceName]resource.Quantity{"memory": resource.MustParse("700Mi"), "cpu": resource.MustParse("500m")},
+				},
+			}}
+			cache.Spec.Template.Spec.Volumes = []corev1.Volume{{Name: CacheDeploymentName, VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: CacheDeploymentName}}}}
+
+		} else {
+			return err
+		}
+	}
+
+	//and setup the service
+	err = r.client.Get(ctx, types.NamespacedName{Name: CacheDeploymentName, Namespace: configMap.Namespace}, &corev1.Service{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			service := corev1.Service{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name:      CacheDeploymentName,
+					Namespace: configMap.Namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.IntOrString{IntVal: 8080},
+						},
+					},
+					Type:     corev1.ServiceTypeClusterIP,
+					Selector: map[string]string{"app": CacheDeploymentName},
+				},
+			}
+			err := r.client.Create(ctx, &service)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	type Repo struct {
+		name     string
+		position int
+	}
+	//TODO: make configurable
+	cache.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+		{Name: "CACHE_PATH", Value: "/cache"},
+		{Name: "QUARKUS_VERTX_EVENT_LOOPS_POOL_SIZE", Value: "4"},
+		{Name: "QUARKUS_THREAD_POOL_MAX_THREADS", Value: "50"},
+	}
+	//central is at the hard coded 200 position
+	repos := []Repo{{name: "central", position: 200}}
+	if rebuildsEnabled {
+		repos = append(repos, Repo{name: "rebuilt", position: 100})
+		cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "QUARKUS_S3_ENDPOINT_OVERRIDE",
+			Value: "http://" + LocalstackDeploymentName + "." + request.Namespace + ".svc.cluster.local:4572",
+		})
+		cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "QUARKUS_S3_AWS_REGION",
+			Value: "us-east-1",
+		})
+		cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "QUARKUS_S3_AWS_CREDENTIALS_TYPE",
+			Value: "static",
+		})
+		cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID",
+			Value: "accesskey",
+		})
+		cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY",
+			Value: "secretkey",
+		})
+	}
+	regex, err := regexp.Compile("maven-repository-(\\d+)-(\\w+)")
+	for k, v := range configMap.Data {
+		if regex.MatchString(k) {
+			results := regex.FindStringSubmatch(k)
+			atoi, err := strconv.Atoi(results[1])
+			name := results[2]
+			if err != nil {
+				return err
+			}
+			cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+				Name:  "STORE_" + strings.ToUpper(name) + "_URL",
+				Value: v,
+			})
+			cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+				Name:  "STORE_" + strings.ToUpper(name) + "_TYPE",
+				Value: "maven2",
+			})
+			repos = append(repos, Repo{position: atoi, name: name})
+		}
+	}
+
+	var sb strings.Builder
+	sort.Slice(repos, func(i, j int) bool {
+		return repos[i].position < repos[j].position
+	})
+	for _, i := range repos {
+		if sb.Len() > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(i.name)
+	}
+	cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+		Name:  "BUILD_POLICY_DEFAULT_STORE_LIST",
+		Value: sb.String(),
+	})
+	cache.Spec.Template.Spec.Containers[0].Image = r.configuredCacheImage
+	if !strings.HasPrefix(r.configuredCacheImage, "quay.io/redhat-appstudio") {
+		// work around for developer mode while we are hard coding the spec in the controller
+		cache.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+	}
+	if create {
+		return r.client.Create(ctx, &cache)
+	} else {
+		return r.client.Update(ctx, &cache)
+	}
+
+}
+
+func (r *ReconcileConfigMap) setupRebuilds(ctx context.Context, request reconcile.Request) error {
+	//setup localstack
+	//this is 100% temporary and needs to go away ASAP
+	localstack := v1.Deployment{}
+	deploymentName := types.NamespacedName{Namespace: request.Namespace, Name: LocalstackDeploymentName}
+	err := r.client.Get(ctx, deploymentName, &localstack)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating localstack deployment", "name", LocalstackDeploymentName, "Namespace", request.Namespace)
+			localstack.Name = deploymentName.Name
+			localstack.Namespace = deploymentName.Namespace
+			var replicas int32
+			replicas = 1
+			localstack.Spec.Replicas = &replicas
+			localstack.Spec.Selector = &v12.LabelSelector{MatchLabels: map[string]string{"app": LocalstackDeploymentName}}
+			localstack.Spec.Template.ObjectMeta.Labels = map[string]string{"app": LocalstackDeploymentName}
+			localstack.Spec.Template.Spec.Containers = []corev1.Container{{
+				Name:            LocalstackDeploymentName,
+				ImagePullPolicy: "Always",
+				Ports: []corev1.ContainerPort{{
+					ContainerPort: 4572,
+				}},
+				Env: []corev1.EnvVar{{Name: "SERVICES", Value: "s3:4572"}},
+			}}
+			localstack.Spec.Template.Spec.Containers[0].Image = "localstack/localstack:0.11.5"
+			err = r.client.Create(ctx, &localstack)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	//and setup the service
+	err = r.client.Get(ctx, types.NamespacedName{Name: LocalstackDeploymentName, Namespace: request.Namespace}, &corev1.Service{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating localstack service", "name", LocalstackDeploymentName, "Namespace", request.Namespace)
+			service := corev1.Service{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name:      LocalstackDeploymentName,
+					Namespace: request.Namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "s3",
+							Port:     4572,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": LocalstackDeploymentName},
+				},
+			}
+			err := r.client.Create(ctx, &service)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func ReadUserConfigMap(client client.Client, ctx context.Context, namespace string) (map[string]string, error) {
+	configMap := corev1.ConfigMap{}
+	err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: UserConfigMapName}, &configMap)
+	if err != nil {
+		return nil, nil
+	}
+	return configMap.Data, nil
+}
+
+func (r *ReconcileConfigMap) handleSystemConfigMap(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	configMap := corev1.ConfigMap{}
+	err := r.client.Get(ctx, request.NamespacedName, &configMap)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if configMap.Data[SystemCacheImage] == "" {
+		log.Info(fmt.Sprintf("System config map missing required key %s, operator will fail to restart if this is not corrected", SystemCacheImage))
+	} else {
+		r.configuredCacheImage = configMap.Data[SystemCacheImage]
+	}
+	return reconcile.Result{}, nil
+}
+
+func i64a(v int64) *int64 {
+	return &v
+}

--- a/pkg/reconciler/configmap/configmap_test.go
+++ b/pkg/reconciler/configmap/configmap_test.go
@@ -1,0 +1,79 @@
+package configmap
+
+import (
+	"context"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v12 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Client, *ReconcileConfigMap) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = pipelinev1beta1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = v12.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	reconciler := &ReconcileConfigMap{client: client, scheme: scheme, eventRecorder: &record.FakeRecorder{}}
+	return client, reconciler
+}
+
+func TestSetupEmptyConfigMap(t *testing.T) {
+	g := NewGomegaWithT(t)
+	configMap := v1.ConfigMap{}
+	configMap.Namespace = metav1.NamespaceDefault
+	configMap.Name = UserConfigMapName
+	value := readConfiguredRepositories(configMap, g)
+	g.Expect(*value).Should(Equal("central"))
+}
+
+func TestSetupRebuildsEnabled(t *testing.T) {
+	g := NewGomegaWithT(t)
+	configMap := v1.ConfigMap{}
+	configMap.Namespace = metav1.NamespaceDefault
+	configMap.Name = UserConfigMapName
+	configMap.Data = map[string]string{EnableRebuilds: "true"}
+	value := readConfiguredRepositories(configMap, g)
+	g.Expect(*value).Should(Equal("rebuilt,central"))
+}
+func TestSetupRebuildsEnabledCustomRepo(t *testing.T) {
+	g := NewGomegaWithT(t)
+	configMap := v1.ConfigMap{}
+	configMap.Namespace = metav1.NamespaceDefault
+	configMap.Name = UserConfigMapName
+	configMap.Data = map[string]string{EnableRebuilds: "true", "maven-repository-302-gradle": "https://repo.gradle.org/artifactory/libs-releases"}
+	value := readConfiguredRepositories(configMap, g)
+	g.Expect(*value).Should(Equal("rebuilt,central,gradle"))
+}
+
+func readConfiguredRepositories(configMap v1.ConfigMap, g *WithT) *string {
+	ctx := context.TODO()
+	client, reconciler := setupClientAndReconciler(&configMap)
+
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}}))
+
+	deployment := v12.Deployment{}
+	g.Expect(client.Get(ctx, types.NamespacedName{
+		Namespace: metav1.NamespaceDefault,
+		Name:      CacheDeploymentName,
+	}, &deployment))
+
+	var value *string
+	for _, val := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if val.Name == "BUILD_POLICY_DEFAULT_STORE_LIST" {
+			value = &val.Value
+			break
+		}
+	}
+	return value
+}

--- a/pkg/reconciler/configmap/controller.go
+++ b/pkg/reconciler/configmap/controller.go
@@ -1,0 +1,12 @@
+package configmap
+
+import (
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupNewReconcilerWithManager(mgr ctrl.Manager, systemConfig map[string]string) error {
+	r := newReconciler(mgr, systemConfig)
+	return ctrl.NewControllerManagedBy(mgr).For(&v1.ConfigMap{}).
+		Complete(r)
+}

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -253,8 +253,6 @@ spec:
         securityContext:
           runAsUser: 0
         env:
-          - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
-            value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
           - name: QUARKUS_LOG_FILE_ENABLE
             value: "true"
           - name: QUARKUS_LOG_FILE_PATH
@@ -610,8 +608,6 @@ spec:
         securityContext:
           runAsUser: 0
         env:
-          - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
-            value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
           - name: QUARKUS_LOG_FILE_ENABLE
             value: "true"
           - name: QUARKUS_LOG_FILE_PATH

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -124,7 +124,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	err = dependencybuild.SetupNewReconcilerWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
-
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)


### PR DESCRIPTION
The presence of the "jvm-build-config" ConfigMap triggers the
environment setup. This config map is used to configure user related
settings in the namespace.

In addition there is the jvm-build-service/jvm-build-system-config that
configures system wide config such as builder images and other system
settings.

Presently this will:
- Create a new cache instance in the local workspace if the `jvm-build-config` configmap is present in the namespace
- Configure this cache from the map
- Configure system wide images from a system config map
- Configure builder images from a system config map

This also resolves the following:

[PLNSRVCE-465](https://issues.redhat.com//browse/PLNSRVCE-465) Java Workspace Setup
[PLNSRVCE-547](https://issues.redhat.com//browse/PLNSRVCE-547) Allow users to configure per namespace recipe repositories


Infra deployments PR: https://github.com/redhat-appstudio/infra-deployments/pull/537
Build Definitions PR: https://github.com/redhat-appstudio/build-definitions/pull/179
