### PR TITLE
PLNSRVCE-455: Use hard coded task spec

### DIFF
--- a/deploy/operator/base/deployment.yaml
+++ b/deploy/operator/base/deployment.yaml
@@ -18,14 +18,8 @@ spec:
           image: hacbs-jvm-operator
           imagePullPolicy: Always
           env:
-            - name: QUARKUS_LOG_LEVEL
-              value: DEBUG
-          # livenessProbe:
-          #   httpGet:
-          #     path: /q/health/live
-          #     port: 8080
-          #   initialDelaySeconds: 10
-          #   periodSeconds: 10
+            - name: RECIPE_DATABASE
+              value: "https://github.com/stuartwdouglas/tempdata2.git"
           resources:
             requests:
               memory: "256Mi"

--- a/deploy/operator/overlays/dev-template/kustomization.yaml
+++ b/deploy/operator/overlays/dev-template/kustomization.yaml
@@ -8,3 +8,6 @@ images:
   - name: hacbs-jvm-operator
     newName: quay.io/QUAY_USERNAME/hacbs-jvm-controller
     newTag: dev
+
+patchesStrategicMerge:
+  - operator-images.yaml

--- a/deploy/operator/overlays/dev-template/operator-images.yaml
+++ b/deploy/operator/overlays/dev-template/operator-images.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hacbs-jvm-operator
+  namespace: jvm-build-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: hacbs-jvm-operator
+          env:
+            - name: JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE
+              value: "quay.io/QUAY_USERNAME/hacbs-jvm-build-request-processor:dev"


### PR DESCRIPTION
This changed the lookup build info task to use a hard coded spec.

If image overrides are required these are now done as environment
variables in the operator.