### PR TITLE
Revert "switch to tekton object based pruning in the operator"

### DIFF
--- a/pkg/reconciler/artifactbuild/artifactbuild.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild.go
@@ -172,9 +172,13 @@ func (r *ReconcileArtifactBuild) handleTaskRunReceived(ctx context.Context, tr *
 		}
 	}
 	if os.Getenv(DeleteTaskRunPodsEnv) == "1" {
-		delerr := r.client.Delete(ctx, tr)
-		if delerr != nil {
-			return reconcile.Result{}, delerr
+		pod := corev1.Pod{}
+		poderr := r.client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Status.PodName}, &pod)
+		if poderr == nil {
+			err := r.client.Delete(ctx, &pod)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -444,9 +444,13 @@ func (r *ReconcileDependencyBuild) handleTaskRunReceived(ctx context.Context, tr
 			db.Status.State = v1alpha1.DependencyBuildStateSubmitBuild
 		}
 		if os.Getenv(artifactbuild.DeleteTaskRunPodsEnv) == "1" {
-			delerr := r.client.Delete(ctx, tr)
-			if delerr != nil {
-				return reconcile.Result{}, delerr
+			pod := v1.Pod{}
+			poderr := r.client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Status.PodName}, &pod)
+			if poderr == nil {
+				err := r.client.Delete(ctx, &pod)
+				if err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 		return reconcile.Result{}, r.client.Status().Update(ctx, &db)


### PR DESCRIPTION
This reverts commit d1b637f56c4df350447685655a373943317c84c2.

Hotfix for [PLNSRVCE-519](https://issues.redhat.com//browse/PLNSRVCE-519)