### PR TITLE
Added Container Registry storage

### DIFF
--- a/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/ContainerRegistryTestResourceManager.java
+++ b/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/ContainerRegistryTestResourceManager.java
@@ -165,7 +165,7 @@ public class ContainerRegistryTestResourceManager implements QuarkusTestResource
         Log.debug("\n\n Test registry catalog:\n" + catalogs.encodePrettily() + "\n");
 
         connCatalog.disconnect();
-        
+
         // Print all the tags
         StringBuilder resultTags = new StringBuilder();
         URL urlTags = new URL(

--- a/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/ContainerRegistryTestResourceManager.java
+++ b/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/ContainerRegistryTestResourceManager.java
@@ -93,9 +93,9 @@ public class ContainerRegistryTestResourceManager implements QuarkusTestResource
         JibContainerBuilder containerBuilder = Jib.fromScratch()
                 .setFormat(ImageFormat.OCI)
                 .addLabel("groupId", ContainerRegistryStorageTest.GROUP)
-                .addLabel("artifactId", "quarkus-parent")
+                .addLabel("artifactId", "foo-parent")
                 .addLabel("version", ContainerRegistryStorageTest.VERSION)
-                .addLabel("description", "Quarkus");
+                .addLabel("description", "Foo");
 
         List<Path> testLayers = createTestLayers();
         for (Path layer : testLayers) {
@@ -164,6 +164,8 @@ public class ContainerRegistryTestResourceManager implements QuarkusTestResource
         JsonObject catalogs = new JsonObject(resultCatalog.toString());
         Log.debug("\n\n Test registry catalog:\n" + catalogs.encodePrettily() + "\n");
 
+        connCatalog.disconnect();
+        
         // Print all the tags
         StringBuilder resultTags = new StringBuilder();
         URL urlTags = new URL(

--- a/java-components/sidecar/pom.xml
+++ b/java-components/sidecar/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>jib-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
@@ -66,6 +70,11 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/DeployResource.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/DeployResource.java
@@ -63,13 +63,14 @@ public class DeployResource {
         this.deployer = getDeployer(deployer);
         this.doNotDeploy = doNotDeploy.orElse(Set.of());
         this.allowedSources = allowedSources.orElse(Set.of());
-        Log.infof("Ignored Artifacts: %s", doNotDeploy);
+        Log.debugf("Using %s deployer", deployer);
+        Log.debugf("Ignored Artifacts: %s", doNotDeploy);
     }
 
     @GET
     @Path("/result")
     public Response contaminates() {
-        Log.infof("Getting contaminates for build: " + contaminates);
+        Log.debugf("Getting contaminates for build: " + contaminates);
         if (deployFailure != null) {
             throw new RuntimeException(deployFailure);
         }
@@ -94,7 +95,7 @@ public class DeployResource {
                 }
                 response.append(i);
             }
-            Log.infof("Contaminates returned: " + response);
+            Log.debugf("Contaminates returned: " + response);
             return Response.ok(response).build();
         }
     }
@@ -118,7 +119,7 @@ public class DeployResource {
             while ((e = in.getNextTarEntry()) != null) {
                 if (e.getName().endsWith(".jar")) {
                     if (!DeployerUtil.shouldIgnore(doNotDeploy, e.getName())) {
-                        Log.infof("Checking %s for contaminants", e.getName());
+                        Log.debugf("Checking %s for contaminants", e.getName());
                         var info = ClassFileTracker.readTrackingDataFromJar(new NoCloseInputStream(in), e.getName());
                         if (info != null) {
                             for (var i : info) {
@@ -140,7 +141,7 @@ public class DeployResource {
                 }
             }
         }
-        Log.infof("Contaminants: %s", contaminatedPaths);
+        Log.debugf("Contaminants: %s", contaminatedPaths);
         this.contaminates.addAll(contaminants);
 
         if (contaminants.isEmpty()) {

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/Deployer.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/Deployer.java
@@ -1,0 +1,9 @@
+package com.redhat.hacbs.sidecar.resources.deploy;
+
+import java.nio.file.Path;
+
+public interface Deployer {
+
+    public void deployArchive(Path tarGzFile) throws Exception;
+
+}

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/DeployerUtil.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/DeployerUtil.java
@@ -1,0 +1,51 @@
+package com.redhat.hacbs.sidecar.resources.deploy;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DeployerUtil {
+
+    private static final String SHA_256 = "SHA-256";
+    private static final String GAV_FORMAT = "%s:%s:%s";
+    private static final Pattern ARTIFACT_PATH = Pattern.compile(".*/([^/]+)/([^/]+)/([^/]+)");
+
+    private DeployerUtil() {
+    }
+
+    public static boolean shouldIgnore(Set<String> doNotDeploy, String name) {
+        Matcher m = ARTIFACT_PATH.matcher(name);
+        if (!m.matches()) {
+            return false;
+        }
+        return doNotDeploy.contains(m.group(1));
+    }
+
+    public static String sha256sum(String group, String artifact, String version) {
+        String gav = String.format(GAV_FORMAT, group, artifact, version);
+        return sha256sum(gav);
+    }
+
+    public static String sha256sum(String gav) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(SHA_256);
+            byte[] hashedGav = digest.digest(gav.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hexString = new StringBuilder(2 * hashedGav.length);
+            for (int i = 0; i < hashedGav.length; i++) {
+                String hex = Integer.toHexString(0xff & hashedGav[i]);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+
+        } catch (NoSuchAlgorithmException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ContainerRegistryDeployer.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ContainerRegistryDeployer.java
@@ -67,7 +67,7 @@ public class ContainerRegistryDeployer implements Deployer {
 
     @Override
     public void deployArchive(Path tarGzFile) throws Exception {
-        Log.infof("Using Container registry %s:%d/%s/%s", host, port, owner, repository);
+        Log.debugf("Using Container registry %s:%d/%s/%s", host, port, owner, repository);
 
         // Read the tar to get the gavs and files
         ImageData imageData = getImageData(tarGzFile);
@@ -103,7 +103,7 @@ public class ContainerRegistryDeployer implements Deployer {
             containerBuilder = containerBuilder.addLayer(List.of(layer), imageRoot);
         }
 
-        Log.infof("Image %s created", imageName);
+        Log.debugf("Image %s created", imageName);
 
         containerBuilder.containerize(containerizer);
     }
@@ -121,7 +121,7 @@ public class ContainerRegistryDeployer implements Deployer {
         Path layer1Path = Files.createTempFile("source", ".txt");
         Path layer2Path = Files.createTempFile("logs", ".txt");
 
-        Log.info("\n Container details:\n"
+        Log.debug("\n Container details:\n"
                 + "\t layer 1 (source) " + layer1Path.toString() + "\n"
                 + "\t layer 2 (logs) " + layer2Path.toString() + "\n"
                 + "\t layer 3 (artifacts) " + artifacts.toString());
@@ -133,15 +133,10 @@ public class ContainerRegistryDeployer implements Deployer {
         Path outputPath = Paths.get(Files.createTempDirectory(HACBS).toString(), ARTIFACTS);
         Files.createDirectories(outputPath);
 
-        ImageData imageData = new ImageData();
-
         try (InputStream tarInput = Files.newInputStream(tarGzFile)) {
-            imageData.setGavs(extractTarArchive(tarInput, outputPath.toString()));
+            ImageData imageData = new ImageData(outputPath, extractTarArchive(tarInput, outputPath.toString()));
+            return imageData;
         }
-
-        imageData.setArtifactsPath(outputPath);
-
-        return imageData;
     }
 
     private Set<Gav> extractTarArchive(InputStream tarInput, String folder) throws IOException {

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ContainerRegistryDeployer.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ContainerRegistryDeployer.java
@@ -1,0 +1,212 @@
+package com.redhat.hacbs.sidecar.resources.deploy.containerregistry;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.GZIPInputStream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
+import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.Jib;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryException;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
+import com.redhat.hacbs.sidecar.resources.deploy.Deployer;
+import com.redhat.hacbs.sidecar.resources.deploy.DeployerUtil;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+@Named("ContainerRegistryDeployer")
+public class ContainerRegistryDeployer implements Deployer {
+
+    private final String host;
+    private final int port;
+    private final String owner;
+    private final String repository;
+    private final boolean insecure;
+    private final Set<String> doNotDeploy;
+
+    public ContainerRegistryDeployer(
+            @ConfigProperty(name = "containerregistrydeployer.host", defaultValue = "quay.io") String host,
+            @ConfigProperty(name = "containerregistrydeployer.port", defaultValue = "443") int port,
+            @ConfigProperty(name = "containerregistrydeployer.owner", defaultValue = "hacbs") String owner,
+            @ConfigProperty(name = "containerregistrydeployer.repository", defaultValue = "artifact-deployments") String repository,
+            @ConfigProperty(name = "containerregistrydeployer.insecure", defaultValue = "false") boolean insecure,
+            @ConfigProperty(name = "ignored-artifacts", defaultValue = "") Optional<Set<String>> doNotDeploy) {
+
+        this.host = host;
+        this.port = port;
+        this.owner = owner;
+        this.repository = repository;
+        this.insecure = insecure;
+        this.doNotDeploy = doNotDeploy.orElse(Set.of());
+    }
+
+    @Override
+    public void deployArchive(Path tarGzFile) throws Exception {
+        Log.infof("Using Container registry %s:%d/%s/%s", host, port, owner, repository);
+
+        // Read the tar to get the gavs and files
+        ImageData imageData = getImageData(tarGzFile);
+
+        // Create the image layers
+        createImages(tarGzFile, imageData);
+    }
+
+    private void createImages(Path tarGzFile, ImageData imageData)
+            throws InvalidImageReferenceException, InterruptedException, RegistryException, IOException,
+            CacheDirectoryCreationException, ExecutionException {
+
+        String imageName = createImageName(imageData);
+        Containerizer containerizer = Containerizer
+                .to(RegistryImage.named(imageName))
+                .setAllowInsecureRegistries(insecure);
+
+        Set<Gav> gavs = imageData.getGavs();
+
+        for (Gav gav : gavs) {
+            containerizer = containerizer.withAdditionalTag(gav.getTag());
+        }
+
+        AbsoluteUnixPath imageRoot = AbsoluteUnixPath.get(SLASH);
+        JibContainerBuilder containerBuilder = Jib.fromScratch()
+                .setFormat(ImageFormat.OCI)
+                .addLabel("groupId", imageData.getGroupIds())
+                .addLabel("version", imageData.getVersions())
+                .addLabel("artifactId", imageData.getArtifactIds());
+
+        List<Path> layers = getLayers(imageData.getArtifactsPath());
+        for (Path layer : layers) {
+            containerBuilder = containerBuilder.addLayer(List.of(layer), imageRoot);
+        }
+
+        Log.infof("Image %s created", imageName);
+
+        containerBuilder.containerize(containerizer);
+    }
+
+    private String createImageName(ImageData imageData) {
+        String imageName = UUID.randomUUID().toString();
+        return host + DOUBLE_POINT + port + SLASH + owner + SLASH + repository + SLASH + imageName
+                + DOUBLE_POINT + imageData.getVersions();
+    }
+
+    private List<Path> getLayers(Path artifacts)
+            throws IOException {
+
+        // TODO: For now we create dummy source and logs
+        Path layer1Path = Files.createTempFile("source", ".txt");
+        Path layer2Path = Files.createTempFile("logs", ".txt");
+
+        Log.info("\n Container details:\n"
+                + "\t layer 1 (source) " + layer1Path.toString() + "\n"
+                + "\t layer 2 (logs) " + layer2Path.toString() + "\n"
+                + "\t layer 3 (artifacts) " + artifacts.toString());
+
+        return List.of(layer1Path, layer2Path, artifacts);
+    }
+
+    private ImageData getImageData(Path tarGzFile) throws IOException {
+        Path outputPath = Paths.get(Files.createTempDirectory(HACBS).toString(), ARTIFACTS);
+        Files.createDirectories(outputPath);
+
+        ImageData imageData = new ImageData();
+
+        try (InputStream tarInput = Files.newInputStream(tarGzFile)) {
+            imageData.setGavs(extractTarArchive(tarInput, outputPath.toString()));
+        }
+
+        imageData.setArtifactsPath(outputPath);
+
+        return imageData;
+    }
+
+    private Set<Gav> extractTarArchive(InputStream tarInput, String folder) throws IOException {
+
+        Set<Gav> gavs = new HashSet<>();
+
+        try (GZIPInputStream inputStream = new GZIPInputStream(tarInput);
+                TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(inputStream)) {
+
+            for (TarArchiveEntry entry = tarArchiveInputStream.getNextTarEntry(); entry != null; entry = tarArchiveInputStream
+                    .getNextTarEntry()) {
+                if (!DeployerUtil.shouldIgnore(doNotDeploy, entry.getName())) {
+                    Optional<Gav> maybeGav = extractEntry(entry, tarArchiveInputStream, folder);
+                    if (maybeGav.isPresent()) {
+                        gavs.add(maybeGav.get());
+                    }
+                }
+            }
+        }
+        return gavs;
+    }
+
+    private Optional<Gav> extractEntry(ArchiveEntry entry, InputStream tar, String folder) throws IOException {
+        final String path = folder + File.separator + entry.getName();
+        if (entry.isDirectory()) {
+            new File(path).mkdirs();
+        } else {
+            new File(path).getParentFile().mkdirs();
+            int count;
+            byte[] data = new byte[BUFFER_SIZE];
+            try (FileOutputStream os = new FileOutputStream(path);
+                    BufferedOutputStream dest = new BufferedOutputStream(os, BUFFER_SIZE)) {
+                while ((count = tar.read(data, 0, BUFFER_SIZE)) != -1) {
+                    dest.write(data, 0, count);
+                }
+            }
+            return getGav(entry.getName());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Gav> getGav(String entryName) {
+        if (entryName.endsWith(DOT_JAR) || entryName.endsWith(DOT_POM)) {
+
+            List<String> pathParts = List.of(entryName.split(SLASH));
+            int numberOfParts = pathParts.size();
+
+            String version = pathParts.get(numberOfParts - 2);
+            String artifactId = pathParts.get(numberOfParts - 3);
+            List<String> groupIdList = pathParts.subList(0, numberOfParts - 3);
+            String groupId = String.join(DOT, groupIdList);
+
+            String tag = DeployerUtil.sha256sum(groupId, artifactId, version);
+
+            return Optional.of(new Gav(groupId, artifactId, version, tag));
+        }
+        return Optional.empty();
+    }
+
+    private static final String DOUBLE_POINT = ":";
+    private static final String SLASH = "/";
+    private static final String DOT_JAR = ".jar";
+    private static final String DOT_POM = ".pom";
+    private static final String DOT = ".";
+    private static final String HACBS = "hacbs";
+    private static final String ARTIFACTS = "artifacts";
+    private static final int BUFFER_SIZE = 4096;
+}

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/Gav.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/Gav.java
@@ -2,14 +2,11 @@ package com.redhat.hacbs.sidecar.resources.deploy.containerregistry;
 
 import java.util.Objects;
 
-public class Gav {
-    private String groupId;
-    private String artifactId;
-    private String version;
-    private String tag;
-
-    public Gav() {
-    }
+public final class Gav {
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    private final String tag;
 
     public Gav(String groupId, String artifactId, String version, String tag) {
         this.groupId = groupId;
@@ -22,32 +19,16 @@ public class Gav {
         return groupId;
     }
 
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
-
     public String getArtifactId() {
         return artifactId;
-    }
-
-    public void setArtifactId(String artifactId) {
-        this.artifactId = artifactId;
     }
 
     public String getVersion() {
         return version;
     }
 
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
     public String getTag() {
         return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
     }
 
     @Override

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/Gav.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/Gav.java
@@ -1,0 +1,91 @@
+package com.redhat.hacbs.sidecar.resources.deploy.containerregistry;
+
+import java.util.Objects;
+
+public class Gav {
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String tag;
+
+    public Gav() {
+    }
+
+    public Gav(String groupId, String artifactId, String version, String tag) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.tag = tag;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 23 * hash + Objects.hashCode(this.groupId);
+        hash = 23 * hash + Objects.hashCode(this.artifactId);
+        hash = 23 * hash + Objects.hashCode(this.version);
+        hash = 23 * hash + Objects.hashCode(this.tag);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Gav other = (Gav) obj;
+        if (!Objects.equals(this.groupId, other.groupId)) {
+            return false;
+        }
+        if (!Objects.equals(this.artifactId, other.artifactId)) {
+            return false;
+        }
+        if (!Objects.equals(this.version, other.version)) {
+            return false;
+        }
+        return Objects.equals(this.tag, other.tag);
+    }
+
+    @Override
+    public String toString() {
+        return "GAV{" + "groupId=" + groupId + ", artifactId=" + artifactId + ", version=" + version + ", tag=" + tag + '}';
+    }
+}

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ImageData.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ImageData.java
@@ -1,0 +1,93 @@
+package com.redhat.hacbs.sidecar.resources.deploy.containerregistry;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ImageData {
+
+    private Path artifactsPath;
+    private Set<Gav> gavs;
+
+    public ImageData() {
+    }
+
+    public ImageData(Path artifactsPath, Set<Gav> gavs) {
+        this.artifactsPath = artifactsPath;
+        this.gavs = gavs;
+    }
+
+    public Path getArtifactsPath() {
+        return artifactsPath;
+    }
+
+    public void setArtifactsPath(Path artifactsPath) {
+        this.artifactsPath = artifactsPath;
+    }
+
+    public Set<Gav> getGavs() {
+        return gavs;
+    }
+
+    public void setGavs(Set<Gav> gavs) {
+        this.gavs = gavs;
+    }
+
+    public String getVersions() {
+        if (this.gavs == null || this.gavs.isEmpty())
+            return null;
+        Set<String> versionList = this.gavs.stream().map(Gav::getVersion)
+                .collect(Collectors.toSet());
+        return String.join(COMMA, versionList);
+    }
+
+    public String getGroupIds() {
+        if (this.gavs == null || this.gavs.isEmpty())
+            return null;
+        Set<String> groupIdList = this.gavs.stream().map(Gav::getGroupId)
+                .collect(Collectors.toSet());
+        return String.join(COMMA, groupIdList);
+    }
+
+    public String getArtifactIds() {
+        if (this.gavs == null || this.gavs.isEmpty())
+            return null;
+        Set<String> artifactIdList = this.gavs.stream().map(Gav::getArtifactId)
+                .collect(Collectors.toSet());
+        return String.join(COMMA, artifactIdList);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 73 * hash + Objects.hashCode(this.artifactsPath);
+        hash = 73 * hash + Objects.hashCode(this.gavs);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ImageData other = (ImageData) obj;
+        if (!Objects.equals(this.artifactsPath, other.artifactsPath)) {
+            return false;
+        }
+        return Objects.equals(this.gavs, other.gavs);
+    }
+
+    @Override
+    public String toString() {
+        return "ImageData{" + "artifactsPath=" + artifactsPath + ", gavs=" + gavs + '}';
+    }
+
+    private static final String COMMA = ", ";
+}

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ImageData.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/containerregistry/ImageData.java
@@ -5,13 +5,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ImageData {
+public final class ImageData {
 
-    private Path artifactsPath;
-    private Set<Gav> gavs;
-
-    public ImageData() {
-    }
+    private final Path artifactsPath;
+    private final Set<Gav> gavs;
 
     public ImageData(Path artifactsPath, Set<Gav> gavs) {
         this.artifactsPath = artifactsPath;
@@ -22,16 +19,8 @@ public class ImageData {
         return artifactsPath;
     }
 
-    public void setArtifactsPath(Path artifactsPath) {
-        this.artifactsPath = artifactsPath;
-    }
-
     public Set<Gav> getGavs() {
         return gavs;
-    }
-
-    public void setGavs(Set<Gav> gavs) {
-        this.gavs = gavs;
     }
 
     public String getVersions() {

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/s3/S3Deployer.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/deploy/s3/S3Deployer.java
@@ -1,0 +1,66 @@
+package com.redhat.hacbs.sidecar.resources.deploy.s3;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.redhat.hacbs.sidecar.resources.deploy.Deployer;
+import com.redhat.hacbs.sidecar.resources.deploy.DeployerUtil;
+
+import io.quarkus.logging.Log;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ApplicationScoped
+@Named("S3Deployer")
+public class S3Deployer implements Deployer {
+
+    final S3Client client;
+    final String deploymentBucket;
+    final String deploymentPrefix;
+    final Set<String> doNotDeploy;
+
+    public S3Deployer(S3Client client,
+            @ConfigProperty(name = "deployment-bucket") String deploymentBucket,
+            @ConfigProperty(name = "deployment-prefix") String deploymentPrefix,
+            @ConfigProperty(name = "ignored-artifacts", defaultValue = "") Optional<Set<String>> doNotDeploy) {
+        this.client = client;
+        this.deploymentBucket = deploymentBucket;
+        this.deploymentPrefix = deploymentPrefix;
+        this.doNotDeploy = doNotDeploy.orElse(Set.of());
+    }
+
+    @Override
+    public void deployArchive(Path tarGzFile) throws Exception {
+        try (TarArchiveInputStream in = new TarArchiveInputStream(
+                new GzipCompressorInputStream(Files.newInputStream(tarGzFile)))) {
+            TarArchiveEntry e;
+            while ((e = in.getNextTarEntry()) != null) {
+                if (!DeployerUtil.shouldIgnore(doNotDeploy, e.getName())) {
+                    Log.infof("Received %s", e.getName());
+                    byte[] fileData = in.readAllBytes();
+                    String name = e.getName();
+                    if (name.startsWith("./")) {
+                        name = name.substring(2);
+                    }
+                    String targetPath = deploymentPrefix + "/" + name;
+                    client.putObject(PutObjectRequest.builder()
+                            .bucket(deploymentBucket)
+                            .key(targetPath)
+                            .build(), RequestBody.fromBytes(fileData));
+                    Log.infof("Deployed to: %s", targetPath);
+                }
+            }
+        }
+    }
+}

--- a/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/resources/deploy/DeployResourceTest.java
+++ b/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/resources/deploy/DeployResourceTest.java
@@ -1,4 +1,4 @@
-package com.redhat.hacbs.sidecar.resources;
+package com.redhat.hacbs.sidecar.resources.deploy;
 
 import java.util.Set;
 
@@ -9,7 +9,7 @@ public class DeployResourceTest {
 
     @Test
     public void testShouldIgnore() {
-        Assertions.assertTrue(DeployResource.shouldIgnore(Set.of("quarkus-cli"),
+        Assertions.assertTrue(DeployerUtil.shouldIgnore(Set.of("quarkus-cli"),
                 "./io/quarkus/quarkus-cli/2.7.6.Final/quarkus-cli-2.7.6.Final-runner.jar"));
     }
 }

--- a/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTest.java
+++ b/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTest.java
@@ -1,0 +1,219 @@
+package com.redhat.hacbs.sidecar.test.resources;
+
+import static io.restassured.RestAssured.given;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+@QuarkusTest
+@QuarkusTestResource(value = ContainerRegistryDeployerTestResource.class, restrictToAnnotatedClass = true)
+public class ContainerRegistryDeployerTest {
+
+    @ConfigProperty(name = "containerregistrydeployer.host", defaultValue = "quay.io")
+    String host;
+    @ConfigProperty(name = "containerregistrydeployer.port", defaultValue = "443")
+    int port;
+    @ConfigProperty(name = "containerregistrydeployer.owner", defaultValue = "hacbs")
+    String owner;
+    @ConfigProperty(name = "containerregistrydeployer.repository", defaultValue = "artifact-deployments")
+    String repository;
+    @ConfigProperty(name = "containerregistrydeployer.insecure", defaultValue = "false")
+    boolean insecure;
+
+    private static final String GROUP = "com.company.foo";
+    private static final String VERSION = "3.25.8";
+    private static final Map<String, String> ARTIFACT_FILE_MAP = Map.of(
+            "foo-bar", "foobar-3.25.8.jar",
+            "foo-baz", "foobaz-3.25.8.jar");
+    private static final String DOT = ".";
+    private static final String SHA_1 = "sha1";
+
+    private static final String EXPECTED_TAG_1 = "ddb962f47b1e1b33a3c59ce0e5a4a403c4e01373eca7fc6e992281f0c6324cc2";
+    private static final String EXPECTED_TAG_2 = "f697132e6cc3e55c91e070ac80eabe7ff4a79ac336323fdadfaa191876d2b0d0";
+
+    @Test
+    public void testDeployArchive() throws IOException {
+
+        // Here we just make sure we can create images.
+        Path createTestTarGz = createTestTarGz();
+        Log.infof("Using test tar.gz: " + createTestTarGz);
+        try (InputStream inputStream = Files.newInputStream(createTestTarGz)) {
+
+            given().body(inputStream).contentType(ContentType.BINARY)
+                    .when().post("/deploy")
+                    .then()
+                    .statusCode(204);
+
+        }
+
+        // Now we validate that the image and tags exist in the registry
+        ContainerRegistryDetails containerRegistryDetails = getContainerRegistryDetails();
+
+        Assert.assertTrue(containerRegistryDetails.repoName.startsWith(owner + "/" + repository));
+        Assert.assertTrue(containerRegistryDetails.tags.contains(EXPECTED_TAG_1));
+        Assert.assertTrue(containerRegistryDetails.tags.contains(EXPECTED_TAG_2));
+    }
+
+    private Path createTestTarGz() throws IOException {
+        Path artifacts = Paths.get("target/test-data/artifacts").toAbsolutePath();
+        Files.createDirectories(artifacts);
+
+        // Add data to artifacts folder
+        for (Map.Entry<String, String> artifactFile : ARTIFACT_FILE_MAP.entrySet()) {
+            String groupPath = GROUP.replace(DOT, File.separator);
+            Path testDir = Paths.get(artifacts.toString(), groupPath, artifactFile.getKey(),
+                    VERSION);
+            Files.createDirectories(testDir);
+            Path testFile = Paths.get(testDir.toString(), artifactFile.getValue());
+
+            if (!Files.exists(testFile)) {
+                Files.createFile(testFile);
+            }
+            String testContent = "Just some data for " + artifactFile.getKey();
+            Files.writeString(testFile, testContent);
+
+            Path shaFile = Paths.get(testFile.toString() + DOT + SHA_1);
+            if (!Files.exists(shaFile)) {
+                Files.createFile(shaFile);
+            }
+
+            String sha1 = sha1(testContent);
+            Files.writeString(shaFile, sha1);
+        }
+
+        // Now tar.gz the folder
+        String tarFileName = "target/" + artifacts.getFileName().toString() + ".tar.gz";
+
+        try (OutputStream fOut = Files.newOutputStream(Paths.get(tarFileName));
+                BufferedOutputStream buffOut = new BufferedOutputStream(fOut);
+                GzipCompressorOutputStream gzOut = new GzipCompressorOutputStream(buffOut);
+                TarArchiveOutputStream tOut = new TarArchiveOutputStream(gzOut)) {
+
+            Files.walkFileTree(artifacts, new SimpleFileVisitor<>() {
+
+                @Override
+                public FileVisitResult visitFile(Path file,
+                        BasicFileAttributes attributes) throws IOException {
+
+                    if (!attributes.isSymbolicLink()) {
+                        Path targetFile = artifacts.relativize(file);
+
+                        TarArchiveEntry tarEntry = new TarArchiveEntry(
+                                file.toFile(), targetFile.toString());
+
+                        tOut.putArchiveEntry(tarEntry);
+                        Files.copy(file, tOut);
+                        tOut.closeArchiveEntry();
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+            });
+
+            tOut.finish();
+            fOut.flush();
+        }
+        return Paths.get(tarFileName);
+    }
+
+    private ContainerRegistryDetails getContainerRegistryDetails() throws IOException {
+        URL urlCatalog = getRegistryURL("_catalog");
+        String catalogs = readHTTPData(urlCatalog);
+
+        JsonObject catalogJson = new JsonObject(catalogs);
+        JsonArray repositories = catalogJson.getJsonArray("repositories");
+
+        String repo = repositories.getString(0);
+        URL urlTags = getRegistryURL(repo + "/tags/list");
+        String tagList = readHTTPData(urlTags);
+        JsonObject tagListJson = new JsonObject(tagList);
+
+        JsonArray tagsJson = tagListJson.getJsonArray("tags");
+        List<String> tags = tagsJson.getList();
+
+        ContainerRegistryDetails containerRegistryDetails = new ContainerRegistryDetails();
+        containerRegistryDetails.repoName = repo;
+        containerRegistryDetails.tags = tags;
+
+        return containerRegistryDetails;
+    }
+
+    private String readHTTPData(URL url) throws IOException {
+        StringBuilder result = new StringBuilder();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(conn.getInputStream()))) {
+            for (String line; (line = reader.readLine()) != null;) {
+                result.append(line);
+            }
+        } finally {
+            conn.disconnect();
+        }
+        return result.toString();
+    }
+
+    private URL getRegistryURL(String path) throws IOException {
+        return new URL("http://" + host + ":" + port + "/v2/" + path);
+    }
+
+    private String sha1(String value) {
+        return sha1(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String sha1(byte[] value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] digest = md.digest(value);
+            StringBuilder sb = new StringBuilder(40);
+            for (int i = 0; i < digest.length; ++i) {
+                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    class ContainerRegistryDetails {
+        String repoName;
+        List<String> tags;
+    }
+}

--- a/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTestResource.java
+++ b/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTestResource.java
@@ -28,8 +28,7 @@ public class ContainerRegistryDeployerTestResource implements QuarkusTestResourc
     private int startTestRegistry() {
         this.container = new GenericContainer("registry:2.8.1")
                 .withReuse(true)
-                .withExposedPorts(5000)
-                .withEnv("TESTCONTAINERS_RYUK_DISABLED", "true");
+                .withExposedPorts(5000);
 
         this.container.start();
 

--- a/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTestResource.java
+++ b/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTestResource.java
@@ -1,0 +1,53 @@
+package com.redhat.hacbs.sidecar.test.resources;
+
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class ContainerRegistryDeployerTestResource implements QuarkusTestResourceLifecycleManager {
+
+    GenericContainer container;
+
+    @Override
+    public Map<String, String> start() {
+
+        int port = startTestRegistry();
+
+        return Map.of(
+                "deployer", "ContainerRegistryDeployer",
+                "containerregistrydeployer.host", this.container.getHost(),
+                "containerregistrydeployer.port", String.valueOf(port),
+                "containerregistrydeployer.repository", REPOSITORY,
+                "containerregistrydeployer.owner", OWNER,
+                "containerregistrydeployer.insecure", "true");
+    }
+
+    private int startTestRegistry() {
+        this.container = new GenericContainer("registry:2.7")
+                .withReuse(true)
+                .withExposedPorts(5000);
+
+        this.container.start();
+
+        Integer port = this.container.getMappedPort(5000);
+
+        Log.info("\n Test registry details:\n"
+                + "\t container name: " + this.container.getContainerName() + "\n"
+                + "\t host: " + this.container.getHost() + "\n"
+                + "\t port: " + port + "\n"
+                + "\t image: " + this.container.getDockerImageName() + "\n");
+
+        return port;
+    }
+
+    @Override
+    public void stop() {
+        this.container.stop();
+    }
+
+    private static final String REPOSITORY = "artifact-deployments";
+    private static final String OWNER = "hacbs-test";
+}

--- a/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTestResource.java
+++ b/java-components/sidecar/src/test/java/com/redhat/hacbs/sidecar/test/resources/ContainerRegistryDeployerTestResource.java
@@ -26,9 +26,10 @@ public class ContainerRegistryDeployerTestResource implements QuarkusTestResourc
     }
 
     private int startTestRegistry() {
-        this.container = new GenericContainer("registry:2.7")
+        this.container = new GenericContainer("registry:2.8.1")
                 .withReuse(true)
-                .withExposedPorts(5000);
+                .withExposedPorts(5000)
+                .withEnv("TESTCONTAINERS_RYUK_DISABLED", "true");
 
         this.container.start();
 


### PR DESCRIPTION
This PR change the Deployer in hacbs-sidecar to load the deployer from a factory and then have the ability to add more deployer.
The current default is still S3 for now, but this PR also adds a Container Registry Storage option.

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>