### PR TITLE
PLNSRVCE-452: switch back to TR pruning, remove TR related tests; test improvements; some code fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ e2etest: fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./test/...
 
 appstudio-installed-on-openshift-e2e:
-	# disable pruning for e2e's to help us debug
-	export JVM_DELETE_TASKRUN_PODS="0"
 	KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 120m -v ./openshift-with-appstudio-test/...
 
 build:

--- a/openshift-with-appstudio-test/e2e/jvm_build_service_test.go
+++ b/openshift-with-appstudio-test/e2e/jvm_build_service_test.go
@@ -14,7 +14,6 @@ import (
 
 	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuild"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -295,44 +294,6 @@ func TestExampleRun(t *testing.T) {
 		})
 		if err != nil {
 			debugAndFailTest(ta, "timed out waiting for generation of artifactbuilds and dependencybuilds")
-		}
-	})
-
-	ta.t.Run("taskruns related to artifactbuilds and dependencybuilds generated", func(t *testing.T) {
-		err = wait.PollImmediate(ta.interval, ta.timeout, func() (done bool, err error) {
-			taskRuns, err := tektonClient.TektonV1beta1().TaskRuns(ta.ns).List(context.TODO(), metav1.ListOptions{})
-			if err != nil {
-				ta.Logf(fmt.Sprintf("taskrun list error: %s", err.Error()))
-				return false, nil
-			}
-			if len(taskRuns.Items) == 0 {
-				ta.Logf("no taskruns yet")
-				return false, nil
-			}
-			foundGenericLabel := false
-			foundABRLabel := false
-			foundDBLabel := false
-			for _, taskRun := range taskRuns.Items {
-				ta.Logf(fmt.Sprintf("taskrun %s has label map of len %d", taskRun.Name, len(taskRun.Labels)))
-				for k := range taskRun.Labels {
-					if k == artifactbuild.TaskRunLabel {
-						foundGenericLabel = true
-					}
-					if k == artifactbuild.ArtifactBuildIdLabel {
-						foundABRLabel = true
-					}
-					if k == artifactbuild.DependencyBuildIdLabel {
-						foundDBLabel = true
-					}
-					if foundABRLabel && foundDBLabel && foundGenericLabel {
-						return true, nil
-					}
-				}
-			}
-			return false, nil
-		})
-		if err != nil {
-			debugAndFailTest(ta, "timed out waiting for artifactbuild and dependencybuild related taskruns")
 		}
 	})
 

--- a/openshift-with-appstudio-test/e2e/jvm_build_service_test.go
+++ b/openshift-with-appstudio-test/e2e/jvm_build_service_test.go
@@ -61,7 +61,8 @@ func dumpPods(ta *testArgs) {
 	podClient := kubeClient.CoreV1().Pods(ta.ns)
 	podList, err := podClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		debugAndFailTest(ta, fmt.Sprintf("error list pods %v", err))
+		ta.Logf(fmt.Sprintf("error list pods %s", err.Error()))
+		return
 	}
 	ta.Logf(fmt.Sprintf("dumpPods have %d items in list", len(podList.Items)))
 	for _, pod := range podList.Items {
@@ -71,11 +72,13 @@ func dumpPods(ta *testArgs) {
 			req := podClient.GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name})
 			readCloser, err := req.Stream(context.TODO())
 			if err != nil {
-				debugAndFailTest(ta, fmt.Sprintf("error getting pod logs for container %s: %s", container.Name, err.Error()))
+				ta.Logf(fmt.Sprintf("error getting pod logs for container %s: %s", container.Name, err.Error()))
+				continue
 			}
 			b, err := ioutil.ReadAll(readCloser)
 			if err != nil {
-				debugAndFailTest(ta, fmt.Sprintf("error reading pod stream %s", err.Error()))
+				ta.Logf(fmt.Sprintf("error reading pod stream %s", err.Error()))
+				continue
 			}
 			podLog := string(b)
 			ta.Logf(fmt.Sprintf("pod logs for container %s in pod %s:  %s", container.Name, pod.Name, podLog))
@@ -85,8 +88,67 @@ func dumpPods(ta *testArgs) {
 	}
 }
 
+func dumpBadEvents(ta *testArgs) {
+	eventClient := kubeClient.EventsV1().Events(ta.ns)
+	eventList, err := eventClient.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		ta.Logf(fmt.Sprintf("error listing events: %s", err.Error()))
+		return
+	}
+	ta.Logf(fmt.Sprintf("dumpBadEvents have %d items in total list", len(eventList.Items)))
+	for _, event := range eventList.Items {
+		if event.Type == corev1.EventTypeNormal {
+			continue
+		}
+		ta.Logf(fmt.Sprintf("non-normal event reason %s about obj %s:%s message %s", event.Reason, event.Regarding.Kind, event.Regarding.Name, event.Note))
+	}
+}
+
+func dumpNodes(ta *testArgs) {
+	nodeClient := kubeClient.CoreV1().Nodes()
+	nodeList, err := nodeClient.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		ta.Logf(fmt.Sprintf("error listin nodes: %s", err.Error()))
+		return
+	}
+	ta.Logf(fmt.Sprintf("dumpNodes found %d nodes in list, but only logging worker nodes", len(nodeList.Items)))
+	for _, node := range nodeList.Items {
+		_, ok := node.Labels["node-role.kubernetes.io/master"]
+		if ok {
+			continue
+		}
+		if node.Status.Allocatable.Cpu() == nil {
+			ta.Logf(fmt.Sprintf("Node %s does not have allocatable cpu", node.Name))
+			continue
+		}
+		if node.Status.Allocatable.Memory() == nil {
+			ta.Logf(fmt.Sprintf("Node %s does not have allocatable mem", node.Name))
+			continue
+		}
+		if node.Status.Capacity.Cpu() == nil {
+			ta.Logf(fmt.Sprintf("Node %s does not have capacity cpu", node.Name))
+			continue
+		}
+		if node.Status.Capacity.Memory() == nil {
+			ta.Logf(fmt.Sprintf("Node %s does not have capacity mem", node.Name))
+			continue
+		}
+		alloccpu := node.Status.Allocatable.Cpu()
+		allocmem := node.Status.Allocatable.Memory()
+		capaccpu := node.Status.Capacity.Cpu()
+		capacmem := node.Status.Capacity.Memory()
+		ta.Logf(fmt.Sprintf("Node %s allocatable CPU %s allocatable mem %s capacity CPU %s capacitymem %s",
+			node.Name,
+			alloccpu.String(),
+			allocmem.String(),
+			capaccpu.String(),
+			capacmem.String()))
+	}
+}
+
 func debugAndFailTest(ta *testArgs, failMsg string) {
 	dumpPods(ta)
+	dumpBadEvents(ta)
 	ta.t.Fatalf(failMsg)
 }
 
@@ -110,6 +172,9 @@ func setup(t *testing.T, ta *testArgs) *testArgs {
 			debugAndFailTest(ta, fmt.Sprintf("%#v", err))
 		}
 	}
+
+	dumpNodes(ta)
+
 	ta.gitClone = &v1beta1.Task{}
 	obj := streamRemoteYamlToTektonObj("https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml", ta.gitClone, ta)
 	var ok bool
@@ -298,7 +363,7 @@ func TestExampleRun(t *testing.T) {
 	})
 
 	ta.t.Run("some artfactbuilds and dependencybuilds complete", func(t *testing.T) {
-		err = wait.PollImmediate(ta.interval, 8*ta.timeout, func() (done bool, err error) {
+		err = wait.PollImmediate(ta.interval, 2*ta.timeout, func() (done bool, err error) {
 			abList, err := jvmClient.JvmbuildserviceV1alpha1().ArtifactBuilds(ta.ns).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				ta.Logf(fmt.Sprintf("error list artifactbuilds: %s", err.Error()))

--- a/pkg/reconciler/artifactbuild/artifactbuild.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild.go
@@ -299,7 +299,7 @@ func (r *ReconcileArtifactBuild) handleStateDiscovering(ctx context.Context, abr
 		switch db.Status.State {
 		case v1alpha1.DependencyBuildStateComplete:
 			abr.Status.State = v1alpha1.ArtifactBuildStateComplete
-		case DependencyBuildContaminatedBy, v1alpha1.DependencyBuildStateFailed:
+		case v1alpha1.DependencyBuildStateContaminated, v1alpha1.DependencyBuildStateFailed:
 			abr.Status.State = v1alpha1.ArtifactBuildStateFailed
 		}
 		if err := r.client.Status().Update(ctx, abr); err != nil {
@@ -354,7 +354,7 @@ func (r *ReconcileArtifactBuild) handleStateComplete(ctx context.Context, abr *v
 		if strings.HasPrefix(key, DependencyBuildContaminatedBy) {
 			db := v1alpha1.DependencyBuild{}
 			if err := r.client.Get(ctx, types.NamespacedName{Name: value, Namespace: abr.Namespace}, &db); err != nil {
-				r.eventRecorder.Eventf(abr, corev1.EventTypeNormal, "CannotGetDependencyBuild", "Could not find the DependencyBuild for ArtifactBuild %s/%s: %s", abr.Namespace, abr.Name, err.Error())
+				r.eventRecorder.Eventf(abr, corev1.EventTypeNormal, "CannotGetDependencyBuild", "Could not find the contaminated DependencyBuild for ArtifactBuild %s/%s: %s", abr.Namespace, abr.Name, err.Error())
 				//this was not found
 				continue
 			}

--- a/pkg/reconciler/artifactbuild/artifactbuild.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild.go
@@ -172,13 +172,9 @@ func (r *ReconcileArtifactBuild) handleTaskRunReceived(ctx context.Context, tr *
 		}
 	}
 	if os.Getenv(DeleteTaskRunPodsEnv) == "1" {
-		pod := corev1.Pod{}
-		poderr := r.client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Status.PodName}, &pod)
-		if poderr == nil {
-			err := r.client.Delete(ctx, &pod)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
+		delerr := r.client.Delete(ctx, tr)
+		if delerr != nil {
+			return reconcile.Result{}, delerr
 		}
 	}
 

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -240,7 +240,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
-            value: "http://hacbs-jvm-cache"
+            value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
           - name: QUARKUS_LOG_FILE_ENABLE
             value: "true"
           - name: QUARKUS_LOG_FILE_PATH
@@ -441,7 +441,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
-            value: "http://hacbs-jvm-cache"
+            value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
           - name: QUARKUS_LOG_FILE_ENABLE
             value: "true"
           - name: QUARKUS_LOG_FILE_PATH

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -444,13 +444,9 @@ func (r *ReconcileDependencyBuild) handleTaskRunReceived(ctx context.Context, tr
 			db.Status.State = v1alpha1.DependencyBuildStateSubmitBuild
 		}
 		if os.Getenv(artifactbuild.DeleteTaskRunPodsEnv) == "1" {
-			pod := v1.Pod{}
-			poderr := r.client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Status.PodName}, &pod)
-			if poderr == nil {
-				err := r.client.Delete(ctx, &pod)
-				if err != nil {
-					return reconcile.Result{}, err
-				}
+			delerr := r.client.Delete(ctx, tr)
+			if delerr != nil {
+				return reconcile.Result{}, delerr
 			}
 		}
 		return reconcile.Result{}, r.client.Status().Update(ctx, &db)

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -233,7 +233,7 @@ func (r *ReconcileDependencyBuild) handleStateAnalyzeBuild(ctx context.Context, 
 		}
 	}
 	success := tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
-	if !success {
+	if !success || len(buildInfo) == 0 {
 		db.Status.State = v1alpha1.DependencyBuildStateFailed
 		db.Status.Message = message
 	} else {

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -503,6 +503,11 @@ func (r *ReconcileDependencyBuild) handleStateContaminated(ctx context.Context, 
 func createLookupBuildInfoTask(build *v1alpha1.DependencyBuildSpec) *pipelinev1beta1.TaskSpec {
 	image := os.Getenv("JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE")
 	recipes := os.Getenv("RECIPE_DATABASE")
+	path := build.ScmInfo.Path
+	//TODO should the buidl request process require context to be set ?
+	if len(path) == 0 {
+		path = "."
+	}
 	return &pipelinev1beta1.TaskSpec{
 		Results: []pipelinev1beta1.TaskResult{{Name: BuildInfoTaskMessage}, {Name: BuildInfoTaskBuildInfo}},
 		Steps: []pipelinev1beta1.Step{
@@ -519,7 +524,7 @@ func createLookupBuildInfoTask(build *v1alpha1.DependencyBuildSpec) *pipelinev1b
 						"--scm-tag",
 						build.ScmInfo.Tag,
 						"--context",
-						build.ScmInfo.Path,
+						path,
 						"--version",
 						build.Version,
 						"--message",

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -337,6 +337,15 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, db *
 	tr.Spec.TaskRef = nil
 	tr.Spec.TaskSpec = taskRun.Spec.TaskSpec
 	tr.Spec.TaskSpec.Sidecars[0].Image = image
+	//TODO: this is all going away, but for now we have lost the ability to confiugure this via YAML
+	//It's not worth adding a heap of env var overrides for something that will likely be gone next week
+	//the actual solution will involve loading deployment config from a ConfigMap
+	tr.Spec.TaskSpec.Sidecars[0].Env = append(tr.Spec.TaskSpec.Sidecars[0].Env, v1.EnvVar{Name: "QUARKUS_S3_ENDPOINT_OVERRIDE", Value: "http://localstack.jvm-build-service.svc.cluster.local:4572"})
+	tr.Spec.TaskSpec.Sidecars[0].Env = append(tr.Spec.TaskSpec.Sidecars[0].Env, v1.EnvVar{Name: "QUARKUS_S3_AWS_REGION", Value: "us-east-1"})
+	tr.Spec.TaskSpec.Sidecars[0].Env = append(tr.Spec.TaskSpec.Sidecars[0].Env, v1.EnvVar{Name: "QUARKUS_S3_AWS_CREDENTIALS_TYPE", Value: "static"})
+	tr.Spec.TaskSpec.Sidecars[0].Env = append(tr.Spec.TaskSpec.Sidecars[0].Env, v1.EnvVar{Name: "QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID", Value: "accesskey"})
+	tr.Spec.TaskSpec.Sidecars[0].Env = append(tr.Spec.TaskSpec.Sidecars[0].Env, v1.EnvVar{Name: "QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY", Value: "secretkey"})
+
 	tr.Spec.Params = []pipelinev1beta1.Param{
 		{Name: TaskScmUrl, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.ScmInfo.SCMURL}},
 		{Name: TaskScmTag, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.ScmInfo.Tag}},


### PR DESCRIPTION
pulled in https://github.com/redhat-appstudio/jvm-build-service/pull/121 in case it would get me a fully green e2e (it was not the deciding factor)

pulled in https://github.com/redhat-appstudio/jvm-build-service/pull/122 in case it would get me a fully gree e2e (it was not the deciding factor)

Aside from switching back to TaskRun (instead of Pod) pruning and removing the associated TaskRun verifications in the in repo e2e test that could fail as as result, this PR also augments the tests some, as well as fixes two bugs I hit in local testing
- an empty context provided to the build request process would break it (my workaround is possibly not the ideal sollution, where I listed at least some alternatives in https://coreos.slack.com/archives/C03KN2B47GU/p1658764804972509)
- the side care inlining change had a bug with the cache service URL, which was a stratight forward fix;

To turn off pruning for the in repo e2e job (to allow for debug) but leave it on for eventual e2e's from redhat-appstudio/e2e-tests (to validate that default path) I've cleared out the settings in this repo and have https://github.com/openshift/release/pull/30790 up

As I noted in slack, for the `mvn-goals` and `gradle-goals` failures I am currently seeing, which I think prevent at least some of the artifactbuilds and dependencybuilds to get to complete, I think it might be best to merge this with the failing in repro e2e run, and then let @stuartwdouglas / @dwalluck look at the results, either via local testing or via subsequent PRs they bring up to address.

Ideally, I'd like to not back off from the current stake in the ground of at least having some artifactbuilds and dependencybuilds successfully complete as signs of a validated PR.  But if we collectively agree that is where we are at, so be it.

Lastly, @stuartwdouglas also noted that he was going to come up with a more inexpensive repo to build, given our cluster size constraints in openshift CI.  Curious if the problems I am currently seeing with the 2 goals go away with a "simpler" repo to build.  I'm thinking "no" but did not want to presume either.

@phillip-kruger @brunoapimentel FYI for your respective active PRs.