### PR TITLE
PLNSRVCE-452: switch to less expensive test repo

### DIFF
--- a/hack/examples/run-e2e-shaded-app.sh
+++ b/hack/examples/run-e2e-shaded-app.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# This command runs the sample-component-build pipeline to build
+# https://github.com/stuartwdouglas/shaded-java-app - the "smaller" app picked to run in constrained openshift CI clusters
+
+DIR=`dirname "$0"`
+
+echo
+echo "👉 Registering sample pipeline:"
+echo
+
+kubectl apply -f $DIR/pipeline.yaml
+
+kubectl apply -f $DIR/openshift-specific-rbac.yaml || true
+
+echo
+echo "👉 Running the pipeline with the smaller repo suited for e2e's on openshift CI:"
+echo
+
+kubectl create -f $DIR/run-e2e-shaded-app.yaml
+
+echo
+echo "🎉 Done! You can watch logs now with the following command: tkn pr logs --last -f"

--- a/hack/examples/run-e2e-shaded-app.yaml
+++ b/hack/examples/run-e2e-shaded-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: sample-component-build-
+spec:
+  pipelineRef:
+    name: sample-component-build
+  params:
+    - name: url
+      value: https://github.com/stuartwdouglas/shaded-java-app
+  workspaces:
+    - name: maven-settings
+      emptyDir: {}
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce # access mode may affect how you can use this volume in parallel tasks
+          resources:
+            requests:
+              storage: 1Gi
+  serviceAccountNames:
+    - serviceAccountName: pipeline
+      taskName: maven-run

--- a/openshift-with-appstudio-test/e2e/jvm_build_service_test.go
+++ b/openshift-with-appstudio-test/e2e/jvm_build_service_test.go
@@ -301,7 +301,7 @@ func TestExampleRun(t *testing.T) {
 		debugAndFailTest(ta, err.Error())
 	}
 
-	runYamlPath := filepath.Join(path, "..", "..", "hack", "examples", "run.yaml")
+	runYamlPath := filepath.Join(path, "..", "..", "hack", "examples", "run-e2e-shaded-app.yaml")
 	ta.run = &v1beta1.PipelineRun{}
 	obj = streamFileYamlToTektonObj(runYamlPath, ta.run, ta)
 	ta.run, ok = obj.(*v1beta1.PipelineRun)


### PR DESCRIPTION
this offering from @stuartwdouglas takes us from 80+ artifactbuilds and 30+ dependency builds to 20 and 6

the pod count when we got to a successfully completed artifactbuild was in the 30's (I think)

the final pod count after all the artifactbuilds and dependencybuilds got to terminal state was 48; of course, with pruning on, that will be less

after a series of retests to get some sense of consistency wrt resource consumption, I'll move over to https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/build/jvm-build.go and try to reactivate things with https://github.com/stuartwdouglas/shaded-java-app

and as I mentioned in scrum, I'll open a new story on the backlog around capacity testing and crafting periodics with more expensive repo's like https://github.com/stuartwdouglas/code-with-quarkus and maybe even https://github.com/Apicurio/apicurio-registry.git (though I'll most likely need to explore on the possibility of provisioning clusters with larger instance types as defined in https://aws.amazon.com/ec2/instance-types/m6i/)

@psturc @Michkov @brunoapimentel @dwalluck @phillip-kruger FYI

