### PR TITLE
abort override-tekton-bundle.sh if JVM_BUILD_SERVICE_PR_SHA not set

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -31,5 +31,6 @@ The following environments are used to launch the CI tests in Openshift CI:
 | `JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE` | no | A valid jvm build service request processor container image reference from openshift CI. | `quay.io/redhat-appstudio/hacbs-jvm-request-processor@<SHA reference in infra-deployments>` |
 | `JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE_REPO` | no | A valid jvm build service request processor container without tag. | `quay.io/redhat-appstudio/hacbs-jvm-request-processor` |
 | `JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE_TAG` | no | A jvm valid build service request processor container tag. | `next` |
+| `JVM_BUILD_SERVICE_PR_SHA` | depends | The commit provided by OpenShift CI on PRs. We want to override the bundles with code changes from PRs, but for testing against the current main commit level of AppStudio we use the current bundles at quay.io | `` |
 | `GITHUB_TOKEN` | yes | A github token used to create AppStudio applications in GITHUB  | ''  |
 | `QUAY_TOKEN` | yes | A quay token to push components images to quay.io | '' |

--- a/.ci/override-tekton-bundle.sh
+++ b/.ci/override-tekton-bundle.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 # This script will generate a new Tekton bundle that allows the overriding of images that are hard-coded into task steps
+# It minimally requires the JVM_BUILD_SERVICE_PR_SHA env var be set.  In the case of non PR openshift CI tests like
+# rehearsal jobs in openshift/release or periodics, we do not need to override the bundle and we just use the latest
+# at quay.io/redhat-appstudio
+if [ -z "$JVM_BUILD_SERVICE_PR_SHA" ];
+then
+  echo "JVM_BUILD_SERVICE_PR_SHA is not set so aborting"
+  exit 0
+fi
 TEMP_FOLDER=$WORKSPACE/tmp/bundle-override
 APPSTUDIO_QE_REPO=quay.io/redhat-appstudio-qe/test-images
 TASK_BUNDLE_IMG=$APPSTUDIO_QE_REPO:task-bundle-$JVM_BUILD_SERVICE_PR_SHA


### PR DESCRIPTION
see https://github.com/openshift/release/pull/30919#issuecomment-1199651067
summary: we need this change for rehearsals and periodic in openshift CI.

local test output:

```
gmontero ~/go/src/github.com/redhat-appstudio/jvm-build-service  (override-bundle-prs-only)$ ./.ci/override-tekton-bundle.sh 
JVM_BUILD_SERVICE_PR_SHA is not set so aborting
gmontero ~/go/src/github.com/redhat-appstudio/jvm-build-service  (override-bundle-prs-only)$ JVM_BUILD_SERVICE_PR_SHA=foo ./.ci/override-tekton-bundle.sh 
<I'll avoid posting the output when the script starts running with this
```

@brunoapimentel @stuartwdouglas @psturc FYI