### PR TITLE
PLNSRVCE-534: have sidecar image pull policy conform with production grade k8s conventions

### DIFF
--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -252,7 +252,7 @@ spec:
       - image: hacbs-jvm-sidecar
         securityContext:
           runAsUser: 0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
           - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
             value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"
@@ -610,7 +610,7 @@ spec:
       - image: hacbs-jvm-sidecar
         securityContext:
           runAsUser: 0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
           - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
             value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -368,6 +368,10 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, db *
 		}
 	}
 	pr.Spec.PipelineSpec.Tasks[0].TaskSpec.Sidecars[0].Image = image
+	if !strings.HasPrefix(image, "quay.io/redhat-appstudio") {
+		// work around for developer mode while we are hard coding the task spec in the controller
+		pr.Spec.PipelineSpec.Tasks[0].TaskSpec.Sidecars[0].ImagePullPolicy = v1.PullAlways
+	}
 	//TODO: this is all going away, but for now we have lost the ability to confiugure this via YAML
 	//It's not worth adding a heap of env var overrides for something that will likely be gone next week
 	//the actual solution will involve loading deployment config from a ConfigMap


### PR DESCRIPTION
So yeah in production k8s clusters, the general convention is to not use Always for the image pull policy.  That policy best serves inner loop development.

And sure enough, "stress testing", i.e. building service registry, I did instances of 

` Failed to pull image .... pull QPS exceeded`

So a low hanging fruit improvement.

I do have a hack, to go along with our, as I understand it, short term hard coding of task refs in the pipeline runs, to allow for switching from IfNotPresent.  If hard coding becomes permanent, and in conjunction we stabilize our yaml file set and locations, this could make me more amenable to moving off of buildrecipes.go

