### PR TITLE
Use a specific revision for the tests

### DIFF
--- a/hack/examples/pipeline.yaml
+++ b/hack/examples/pipeline.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   params:
     - name: url
+    - default: ""
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      name: revision
     - name: context
       default: ""
     - name: app-path
@@ -22,6 +25,8 @@ spec:
       params:
         - name: url
           value: "$(params.url)"
+        - name: revision
+          value: "$(params.revision)"
         - name: subdirectory
           value: ""
         - name: deleteExisting

--- a/hack/examples/run-e2e-shaded-app.yaml
+++ b/hack/examples/run-e2e-shaded-app.yaml
@@ -8,6 +8,8 @@ spec:
   params:
     - name: url
       value: https://github.com/stuartwdouglas/hacbs-test-project
+    - name: revision
+      value: a2dc78fcc71f7d735a29f6f1715ae2aa41ee2856
   workspaces:
     - name: maven-settings
       emptyDir: {}


### PR DESCRIPTION
This will prevent our tests being broken by changes to the test
repository (e.g. adding a gradle test).