### PR TITLE
PLNSRVCE-564 move recipe database to appstudio

### DIFF
--- a/deploy/operator/base/deployment.yaml
+++ b/deploy/operator/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: RECIPE_DATABASE
-              value: "https://github.com/stuartwdouglas/tempdata2.git"
+              value: "https://github.com/redhat-appstudio/jvm-build-data"
           resources:
             requests:
               memory: "256Mi"

--- a/docs/build-recipe-repo.adoc
+++ b/docs/build-recipe-repo.adoc
@@ -1,6 +1,6 @@
 = Build Recipe Repo
 
-NOTE: Currently, this repo lives at https://github.com/stuartwdouglas/tempdata2.git, it should move to a more official location soon.
+NOTE: Currently, this repo lives at https://github.com/redhat-appstudio/jvm-build-data.
 
 == Introduction
 


### PR DESCRIPTION
This removes the temoprary personal recipe database that was in use until now.