### PR TITLE
Use official builder images for gradle

### DIFF
--- a/builder-images/Dockerfile.template
+++ b/builder-images/Dockerfile.template
@@ -8,9 +8,7 @@ ENV \
     MAVEN_HOME="/usr/share/maven" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
     MAVEN_VERSION="$MAVEN_VERSION" \
-    GRADLE_HOME="/usr/share/gradle" \
     GRADLE_OPTS="-Dorg.gradle.daemon=false" \
-    GRADLE_VERSION="$GRADLE_VERSION" \
     GRADLE_MANIPULATOR_HOME="/usr/share/gradle-manipulator" \
     GRADLE_MANIPULATOR_VERSION="$GRADLE_MANIPULATOR_VERSION" \
     HOME="/home/hacbs" \
@@ -55,25 +53,15 @@ RUN set -o errexit -o nounset \
     && mkdir "${GRADLE_MANIPULATOR_HOME}" \
     && mv cli.jar analyzer-init.gradle "${GRADLE_MANIPULATOR_HOME}/" \
     && mkdir "${GRADLE_MANIPULATOR_HOME}/bin" \
-    && echo -e "#!/bin/sh\n\ntest -n \"\${GRADLE_HOME}\" || GRADLE_HOME=\"${GRADLE_HOME}\"\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
+    && echo -e "#!/bin/sh\n\nset -eu\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
     && chmod 755 ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
-    && ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator --version \
-    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator \
-    && /usr/bin/gradle-manipulator --version \
-    && gradle-manipulator --version
+    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator
+    #we test out gradle manipulator as part of the gradle installation
+
 
 RUN set -o errexit -o nounset \
-    && echo "Downloading Gradle" \
-    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
-    \
-    && echo "Checking download hash" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
-    \
-    && echo "Installing Gradle" \
-    && unzip gradle.zip \
-    && rm gradle.zip \
-    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
-    && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+    && mkdir /opt/gradle \
+    $GRADLE_STRING
 
 LABEL \
     io.cekit.version="4.1.0" \

--- a/builder-images/generate.sh
+++ b/builder-images/generate.sh
@@ -1,32 +1,48 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
+DIR=`dirname $0`
 generate () {
-  mkdir -p $IMAGE_NAME
-  envsubst '$IMAGE_NAME,$BASE_IMAGE,$MAVEN_VERSION,$MAVEN_SHA,$GRADLE_VERSION,$GRADLE_SHA,$GRADLE_MANIPULATOR_VERSION,$CLI_JAR_SHA,$ANALYZER_INIT_SHA' < Dockerfile.template > $IMAGE_NAME/Dockerfile
-  envsubst '$IMAGE_NAME,$BASE_IMAGE' < push.yaml > ../.tekton/$IMAGE_NAME-push.yaml
-  envsubst '$IMAGE_NAME,$BASE_IMAGE' < pull-request.yaml > ../.tekton/$IMAGE_NAME-pull-request.yaml
+
+  export IMAGE_NAME=hacbs-jdk$JAVA-builder
+  export BASE_IMAGE=registry.access.redhat.com/ubi8/openjdk-$JAVA
+  mkdir -p $DIR/$IMAGE_NAME
+  #deal with gradle
+  gradle=`yq .data.\"builder-image.jdk$JAVA.tags\" $DIR/../deploy/base/system-config.yaml | grep -o -E  "gradle:.*,?" | cut -d : -f 2`
+  echo $gradle
+  export GRADLE_STRING=""
+  for i in ${gradle//;/ }
+  do
+      export GRADLE_VERSION=$i
+      export GRADLE_DOWNLOAD_SHA256=$(name=GRADLE_${GRADLE_VERSION//./_} && echo ${!name})
+      res=`envsubst '$GRADLE_DOWNLOAD_SHA256,$GRADLE_VERSION' < $DIR/gradle.template`
+      export GRADLE_STRING="$GRADLE_STRING $res"
+  done
+  export GRADLE_STRING="$GRADLE_STRING true"
+
+  envsubst '$IMAGE_NAME,$BASE_IMAGE,$MAVEN_VERSION,$MAVEN_SHA,$GRADLE_VERSION,$GRADLE_SHA,$GRADLE_MANIPULATOR_VERSION,$CLI_JAR_SHA,$ANALYZER_INIT_SHA,$GRADLE_STRING' < $DIR/Dockerfile.template > $DIR/$IMAGE_NAME/Dockerfile
+  envsubst '$IMAGE_NAME,$BASE_IMAGE' < $DIR/push.yaml > $DIR/../.tekton/$IMAGE_NAME-push.yaml
+  envsubst '$IMAGE_NAME,$BASE_IMAGE' < $DIR/pull-request.yaml > $DIR/../.tekton/$IMAGE_NAME-pull-request.yaml
 }
 
 export MAVEN_VERSION=3.8.6
 export MAVEN_SHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
-export GRADLE_VERSION=7.5
-export GRADLE_SHA=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
 export GRADLE_MANIPULATOR_VERSION=3.7
 export CLI_JAR_SHA=8af7e87638bb237362bf8f486b489c251e474be1cdc40037ba79887c2f0803b9
 export ANALYZER_INIT_SHA=3172f34e126d652efccce50ca98c58f9baca27d89b5482268d0a4cb44023aa7e
 
-export IMAGE_NAME=hacbs-jdk17-builder
-export BASE_IMAGE=registry.access.redhat.com/ubi8/openjdk-17
+export GRADLE_7_5_1=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
+export GRADLE_7_4_2=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+export GRADLE_6_9_2=8b356fd8702d5ffa2e066ed0be45a023a779bba4dd1a68fd11bc2a6bdc981e8f
+export GRADLE_5_6_4=1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d
+export GRADLE_4_10_3=8626cbf206b4e201ade7b87779090690447054bc93f052954c78480fa6ed186e
+
+export JAVA=17
 generate
 
-
-export IMAGE_NAME=hacbs-jdk8-builder
-export BASE_IMAGE=registry.access.redhat.com/ubi8/openjdk-8
+export JAVA=8
 generate
 
-
-export IMAGE_NAME=hacbs-jdk11-builder
-export BASE_IMAGE=registry.access.redhat.com/ubi8/openjdk-11
+export JAVA=11
 generate

--- a/builder-images/gradle.template
+++ b/builder-images/gradle.template
@@ -1,0 +1,11 @@
+    && echo "Downloading Gradle $GRADLE_VERSION" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip" \
+    \
+    && echo "Checking download hash $GRADLE_VERSION" \
+    && echo "$GRADLE_DOWNLOAD_SHA256 *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle $GRADLE_VERSION" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-$GRADLE_VERSION" "/opt/gradle/$GRADLE_VERSION/" \
+    && export GRADLE_HOME=/opt/gradle/$GRADLE_VERSION; gradle-manipulator --version

--- a/builder-images/hacbs-jdk11-builder/Dockerfile
+++ b/builder-images/hacbs-jdk11-builder/Dockerfile
@@ -8,14 +8,12 @@ ENV \
     MAVEN_HOME="/usr/share/maven" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
     MAVEN_VERSION="3.8.6" \
-    GRADLE_HOME="/usr/share/gradle" \
     GRADLE_OPTS="-Dorg.gradle.daemon=false" \
-    GRADLE_VERSION="7.5" \
     GRADLE_MANIPULATOR_HOME="/usr/share/gradle-manipulator" \
     GRADLE_MANIPULATOR_VERSION="3.7" \
     HOME="/home/hacbs" \
     NSS_WRAPPER_PASSWD="/etc/passwd" \
-    GRADLE_DOWNLOAD_SHA256=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2 \
+    GRADLE_DOWNLOAD_SHA256= \
     CLI_JAR_DOWNLOAD_SHA256=8af7e87638bb237362bf8f486b489c251e474be1cdc40037ba79887c2f0803b9 \
     ANALYZER_INIT_DOWNLOAD_SHA256=3172f34e126d652efccce50ca98c58f9baca27d89b5482268d0a4cb44023aa7e \
     PATH="$PATH:$JAVA_HOME/bin" \
@@ -55,25 +53,55 @@ RUN set -o errexit -o nounset \
     && mkdir "${GRADLE_MANIPULATOR_HOME}" \
     && mv cli.jar analyzer-init.gradle "${GRADLE_MANIPULATOR_HOME}/" \
     && mkdir "${GRADLE_MANIPULATOR_HOME}/bin" \
-    && echo -e "#!/bin/sh\n\ntest -n \"\${GRADLE_HOME}\" || GRADLE_HOME=\"${GRADLE_HOME}\"\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
+    && echo -e "#!/bin/sh\n\nset -eu\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
     && chmod 755 ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
-    && ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator --version \
-    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator \
-    && /usr/bin/gradle-manipulator --version \
-    && gradle-manipulator --version
+    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator
+    #we test out gradle manipulator as part of the gradle installation
+
 
 RUN set -o errexit -o nounset \
-    && echo "Downloading Gradle" \
-    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-7.5-bin.zip" \
+    && mkdir /opt/gradle \
+         && echo "Downloading Gradle 7.4.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip" \
     \
-    && echo "Checking download hash" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+    && echo "Checking download hash 7.4.2" \
+    && echo "29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda *gradle.zip" | sha256sum --check - \
     \
-    && echo "Installing Gradle" \
+    && echo "Installing Gradle 7.4.2" \
     && unzip gradle.zip \
     && rm gradle.zip \
-    && mv "gradle-7.5" "${GRADLE_HOME}/" \
-    && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+    && mv "gradle-7.4.2" "/opt/gradle/7.4.2/" \
+    && export GRADLE_HOME=/opt/gradle/7.4.2; gradle-manipulator --version     && echo "Downloading Gradle 6.9.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-6.9.2-bin.zip" \
+    \
+    && echo "Checking download hash 6.9.2" \
+    && echo "8b356fd8702d5ffa2e066ed0be45a023a779bba4dd1a68fd11bc2a6bdc981e8f *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 6.9.2" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-6.9.2" "/opt/gradle/6.9.2/" \
+    && export GRADLE_HOME=/opt/gradle/6.9.2; gradle-manipulator --version     && echo "Downloading Gradle 6.9.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-6.9.2-bin.zip" \
+    \
+    && echo "Checking download hash 6.9.2" \
+    && echo "8b356fd8702d5ffa2e066ed0be45a023a779bba4dd1a68fd11bc2a6bdc981e8f *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 6.9.2" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-6.9.2" "/opt/gradle/6.9.2/" \
+    && export GRADLE_HOME=/opt/gradle/6.9.2; gradle-manipulator --version     && echo "Downloading Gradle 5.6.4" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-5.6.4-bin.zip" \
+    \
+    && echo "Checking download hash 5.6.4" \
+    && echo "1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 5.6.4" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-5.6.4" "/opt/gradle/5.6.4/" \
+    && export GRADLE_HOME=/opt/gradle/5.6.4; gradle-manipulator --version true
 
 LABEL \
     io.cekit.version="4.1.0" \

--- a/builder-images/hacbs-jdk17-builder/Dockerfile
+++ b/builder-images/hacbs-jdk17-builder/Dockerfile
@@ -8,14 +8,12 @@ ENV \
     MAVEN_HOME="/usr/share/maven" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
     MAVEN_VERSION="3.8.6" \
-    GRADLE_HOME="/usr/share/gradle" \
     GRADLE_OPTS="-Dorg.gradle.daemon=false" \
-    GRADLE_VERSION="7.5" \
     GRADLE_MANIPULATOR_HOME="/usr/share/gradle-manipulator" \
     GRADLE_MANIPULATOR_VERSION="3.7" \
     HOME="/home/hacbs" \
     NSS_WRAPPER_PASSWD="/etc/passwd" \
-    GRADLE_DOWNLOAD_SHA256=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2 \
+    GRADLE_DOWNLOAD_SHA256= \
     CLI_JAR_DOWNLOAD_SHA256=8af7e87638bb237362bf8f486b489c251e474be1cdc40037ba79887c2f0803b9 \
     ANALYZER_INIT_DOWNLOAD_SHA256=3172f34e126d652efccce50ca98c58f9baca27d89b5482268d0a4cb44023aa7e \
     PATH="$PATH:$JAVA_HOME/bin" \
@@ -55,25 +53,25 @@ RUN set -o errexit -o nounset \
     && mkdir "${GRADLE_MANIPULATOR_HOME}" \
     && mv cli.jar analyzer-init.gradle "${GRADLE_MANIPULATOR_HOME}/" \
     && mkdir "${GRADLE_MANIPULATOR_HOME}/bin" \
-    && echo -e "#!/bin/sh\n\ntest -n \"\${GRADLE_HOME}\" || GRADLE_HOME=\"${GRADLE_HOME}\"\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
+    && echo -e "#!/bin/sh\n\nset -eu\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
     && chmod 755 ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
-    && ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator --version \
-    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator \
-    && /usr/bin/gradle-manipulator --version \
-    && gradle-manipulator --version
+    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator
+    #we test out gradle manipulator as part of the gradle installation
+
 
 RUN set -o errexit -o nounset \
-    && echo "Downloading Gradle" \
-    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-7.5-bin.zip" \
+    && mkdir /opt/gradle \
+         && echo "Downloading Gradle 7.4.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip" \
     \
-    && echo "Checking download hash" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+    && echo "Checking download hash 7.4.2" \
+    && echo "29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda *gradle.zip" | sha256sum --check - \
     \
-    && echo "Installing Gradle" \
+    && echo "Installing Gradle 7.4.2" \
     && unzip gradle.zip \
     && rm gradle.zip \
-    && mv "gradle-7.5" "${GRADLE_HOME}/" \
-    && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+    && mv "gradle-7.4.2" "/opt/gradle/7.4.2/" \
+    && export GRADLE_HOME=/opt/gradle/7.4.2; gradle-manipulator --version true
 
 LABEL \
     io.cekit.version="4.1.0" \

--- a/builder-images/hacbs-jdk8-builder/Dockerfile
+++ b/builder-images/hacbs-jdk8-builder/Dockerfile
@@ -8,14 +8,12 @@ ENV \
     MAVEN_HOME="/usr/share/maven" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
     MAVEN_VERSION="3.8.6" \
-    GRADLE_HOME="/usr/share/gradle" \
     GRADLE_OPTS="-Dorg.gradle.daemon=false" \
-    GRADLE_VERSION="7.5" \
     GRADLE_MANIPULATOR_HOME="/usr/share/gradle-manipulator" \
     GRADLE_MANIPULATOR_VERSION="3.7" \
     HOME="/home/hacbs" \
     NSS_WRAPPER_PASSWD="/etc/passwd" \
-    GRADLE_DOWNLOAD_SHA256=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2 \
+    GRADLE_DOWNLOAD_SHA256= \
     CLI_JAR_DOWNLOAD_SHA256=8af7e87638bb237362bf8f486b489c251e474be1cdc40037ba79887c2f0803b9 \
     ANALYZER_INIT_DOWNLOAD_SHA256=3172f34e126d652efccce50ca98c58f9baca27d89b5482268d0a4cb44023aa7e \
     PATH="$PATH:$JAVA_HOME/bin" \
@@ -55,25 +53,65 @@ RUN set -o errexit -o nounset \
     && mkdir "${GRADLE_MANIPULATOR_HOME}" \
     && mv cli.jar analyzer-init.gradle "${GRADLE_MANIPULATOR_HOME}/" \
     && mkdir "${GRADLE_MANIPULATOR_HOME}/bin" \
-    && echo -e "#!/bin/sh\n\ntest -n \"\${GRADLE_HOME}\" || GRADLE_HOME=\"${GRADLE_HOME}\"\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
+    && echo -e "#!/bin/sh\n\nset -eu\nARGS=\"-l \${GRADLE_HOME}\"\njava -jar ${GRADLE_MANIPULATOR_HOME}/cli.jar \"\${ARGS}\" --init-script=${GRADLE_MANIPULATOR_HOME}/analyzer-init.gradle \$@" > ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
     && chmod 755 ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator \
-    && ${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator --version \
-    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator \
-    && /usr/bin/gradle-manipulator --version \
-    && gradle-manipulator --version
+    && ln --symbolic "${GRADLE_MANIPULATOR_HOME}/bin/gradle-manipulator" /usr/bin/gradle-manipulator
+    #we test out gradle manipulator as part of the gradle installation
+
 
 RUN set -o errexit -o nounset \
-    && echo "Downloading Gradle" \
-    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-7.5-bin.zip" \
+    && mkdir /opt/gradle \
+         && echo "Downloading Gradle 7.4.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip" \
     \
-    && echo "Checking download hash" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+    && echo "Checking download hash 7.4.2" \
+    && echo "29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda *gradle.zip" | sha256sum --check - \
     \
-    && echo "Installing Gradle" \
+    && echo "Installing Gradle 7.4.2" \
     && unzip gradle.zip \
     && rm gradle.zip \
-    && mv "gradle-7.5" "${GRADLE_HOME}/" \
-    && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+    && mv "gradle-7.4.2" "/opt/gradle/7.4.2/" \
+    && export GRADLE_HOME=/opt/gradle/7.4.2; gradle-manipulator --version     && echo "Downloading Gradle 6.9.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-6.9.2-bin.zip" \
+    \
+    && echo "Checking download hash 6.9.2" \
+    && echo "8b356fd8702d5ffa2e066ed0be45a023a779bba4dd1a68fd11bc2a6bdc981e8f *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 6.9.2" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-6.9.2" "/opt/gradle/6.9.2/" \
+    && export GRADLE_HOME=/opt/gradle/6.9.2; gradle-manipulator --version     && echo "Downloading Gradle 6.9.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-6.9.2-bin.zip" \
+    \
+    && echo "Checking download hash 6.9.2" \
+    && echo "8b356fd8702d5ffa2e066ed0be45a023a779bba4dd1a68fd11bc2a6bdc981e8f *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 6.9.2" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-6.9.2" "/opt/gradle/6.9.2/" \
+    && export GRADLE_HOME=/opt/gradle/6.9.2; gradle-manipulator --version     && echo "Downloading Gradle 5.6.4" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-5.6.4-bin.zip" \
+    \
+    && echo "Checking download hash 5.6.4" \
+    && echo "1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 5.6.4" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-5.6.4" "/opt/gradle/5.6.4/" \
+    && export GRADLE_HOME=/opt/gradle/5.6.4; gradle-manipulator --version     && echo "Downloading Gradle 4.10.2" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-4.10.2-bin.zip" \
+    \
+    && echo "Checking download hash 4.10.2" \
+    && echo "b49c6da1b2cb67a0caf6c7480630b51c70a11ca2016ff2f555eaeda863143a29 *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle 4.10.2" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-4.10.2" "/opt/gradle/4.10.2/" \
+    && export GRADLE_HOME=/opt/gradle/4.10.2; gradle-manipulator --version true
 
 LABEL \
     io.cekit.version="4.1.0" \

--- a/builder-images/push-local.sh
+++ b/builder-images/push-local.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+docker push quay.io/$QUAY_USERNAME/hacbs-jdk8-builder:dev
+docker push quay.io/$QUAY_USERNAME/hacbs-jdk17-builder:dev
+docker push quay.io/$QUAY_USERNAME/hacbs-jdk11-builder:dev

--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -11,3 +11,10 @@ data:
   maven-repository-303-gradle: "https://repo.gradle.org/artifactory/libs-releases"
   maven-repository-304-eclipselink: "https://download.eclipse.org/rt/eclipselink/maven.repo"
   maven-repository-305-redhat: "https://maven.repository.redhat.com/ga"
+  maven-repository-306-gradleplugins: "https://plugins.gradle.org/m2"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-system-config
+  namespace: jvm-build-service

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -9,3 +9,6 @@ resources:
   - rbac.yaml
   - config.yaml
   - pipeline.yaml
+
+patchesStrategicMerge:
+  - system-config.yaml

--- a/deploy/base/system-config.yaml
+++ b/deploy/base/system-config.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-system-config
+  namespace: jvm-build-service
+data:
+  #This is used to drive the builder image build
+  #Versions places here for gradle will be used generate the relevant dockerfiles
+  #after you run generate.sh
+  builder-image.jdk8.tags: jdk:8,maven:3.8,gradle:7.4.2;6.9.2;5.6.4;4.10.3
+  builder-image.jdk11.tags: jdk:11,maven:3.8,gradle:7.4.2;6.9.2;5.6.4;4.10.3
+  builder-image.jdk17.tags: jdk:17,maven:3.8,gradle:7.4.2;6.9.2

--- a/deploy/overlays/dev-template/kustomization.yaml
+++ b/deploy/overlays/dev-template/kustomization.yaml
@@ -7,7 +7,6 @@ bases:
  - "../../operator/overlays/dev-template"
 
 resources:
-  - system-config.yaml
   - secret.yaml
 
 patches:
@@ -28,3 +27,4 @@ patches:
 
 patchesStrategicMerge:
   - config.yaml
+  - system-config.yaml

--- a/deploy/overlays/dev-template/system-config.yaml
+++ b/deploy/overlays/dev-template/system-config.yaml
@@ -8,8 +8,5 @@ data:
   image.cache: jvm-build-service-cache-image:dev
   builder-image.names: jdk11,jdk8,jdk17
   builder-image.jdk8.image: jdk8-builder
-  builder-image.jdk8.tags: jdk:8,maven:3.8,gradle:7.5
   builder-image.jdk11.image: jdk11-builder
-  builder-image.jdk11.tags: jdk:11,maven:3.8,gradle:7.5
   builder-image.jdk17.image: jdk17-builder
-  builder-image.jdk17.tags: jdk:17,maven:3.8,gradle:7.5

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -3,7 +3,6 @@ package com.redhat.hacbs.container.analyser.build;
 import static com.redhat.hacbs.container.analyser.build.BuildInfo.GRADLE;
 import static com.redhat.hacbs.container.analyser.build.BuildInfo.JDK;
 import static com.redhat.hacbs.container.analyser.build.BuildInfo.MAVEN;
-import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.AVAILABLE_GRADLE_VERSIONS;
 import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.GOOGLE_JAVA_FORMAT_PLUGIN;
 
 import java.io.BufferedReader;
@@ -140,12 +139,11 @@ public class LookupBuildInfoCommand implements Runnable {
                 Log.infof("Detected Gradle build in %s", path);
                 var optionalGradleVersion = GradleUtils
                         .getGradleVersionFromWrapperProperties(GradleUtils.getPropertiesFile(path));
-                var detectedGradleVersion = optionalGradleVersion.orElse(null);
+                var detectedGradleVersion = optionalGradleVersion.orElse("7");
                 Log.infof("Detected Gradle version %s",
                         optionalGradleVersion.isPresent() ? detectedGradleVersion : "none");
-                var gradleVersion = GradleUtils.findNearestGradleVersion(detectedGradleVersion);
-                Log.infof("Chose Gradle version %s from available versions %s", gradleVersion, AVAILABLE_GRADLE_VERSIONS);
-                var javaVersion = GradleUtils.getSupportedJavaVersion(gradleVersion);
+                Log.infof("Chose Gradle version %s", detectedGradleVersion);
+                var javaVersion = GradleUtils.getSupportedJavaVersion(detectedGradleVersion);
                 Log.infof("Chose Java version %s based on Gradle version detected", javaVersion);
 
                 if (GradleUtils.isInBuildGradle(path, GOOGLE_JAVA_FORMAT_PLUGIN)) {
@@ -155,9 +153,9 @@ public class LookupBuildInfoCommand implements Runnable {
                 }
 
                 info.tools.put(JDK, new VersionRange("8", "17", javaVersion));
-                info.tools.put(GRADLE, new VersionRange(gradleVersion, gradleVersion, gradleVersion));
+                info.tools.put(GRADLE, new VersionRange(detectedGradleVersion, detectedGradleVersion, detectedGradleVersion));
                 info.invocations.add(new ArrayList<>(GradleUtils.DEFAULT_GRADLE_ARGS));
-                info.toolVersion = gradleVersion;
+                info.toolVersion = detectedGradleVersion;
                 info.javaVersion = javaVersion;
             }
             if (buildRecipeInfo != null) {

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
@@ -11,8 +11,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import org.gradle.util.GradleVersion;
-
 import io.quarkus.logging.Log;
 
 /**
@@ -28,13 +26,6 @@ public final class GradleUtils {
      * Identifier for the plugin {@code com.github.sherter.google-java-format}.
      */
     public static final String GOOGLE_JAVA_FORMAT_PLUGIN = "com.github.sherter.google-java-format";
-
-    /**
-     * List of available Gradle versions in image.
-     */
-    public static final List<GradleVersion> AVAILABLE_GRADLE_VERSIONS = List.of(GradleVersion.version("4.10.3"),
-            GradleVersion.version("5.6.4"), GradleVersion.version("6.9.2"), GradleVersion.version("7.4.1"),
-            GradleVersion.version("7.5.1"));
 
     static final String BUILD_GRADLE = "build.gradle";
 
@@ -100,42 +91,6 @@ public final class GradleUtils {
         }
 
         return Integer.parseInt(matcher.group(2));
-    }
-
-    /**
-     * Find the nearest available Gradle version to the given version. If possible, return the nearest version that is
-     * less than or equal to the given version. If the given version is null or empty, return the latest available
-     * version.
-     *
-     * @param version the version
-     * @return the nearest Gradle version
-     */
-    public static String findNearestGradleVersion(String version) {
-        int majorVersion = getMajorVersion(version);
-        String latestVersion = AVAILABLE_GRADLE_VERSIONS.get(AVAILABLE_GRADLE_VERSIONS.size() - 1).getVersion();
-
-        if (majorVersion == -1) {
-            return latestVersion;
-        }
-
-        if (majorVersion < 4) {
-            return AVAILABLE_GRADLE_VERSIONS.get(0).getVersion();
-        }
-
-        if (AVAILABLE_GRADLE_VERSIONS.contains(GradleVersion.version(version))) {
-            return version;
-        }
-
-        for (GradleVersion gradleVersion : AVAILABLE_GRADLE_VERSIONS) {
-            String availableVersion = gradleVersion.getVersion();
-            int gradleMajorVersion = getMajorVersion(availableVersion);
-
-            if (majorVersion == gradleMajorVersion) {
-                return availableVersion;
-            }
-        }
-
-        return latestVersion;
     }
 
     /**

--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtilsTest.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtilsTest.java
@@ -65,16 +65,4 @@ class GradleUtilsTest {
         assertThat(GradleUtils.isInBuildGradle(basedir, "not found")).isFalse();
     }
 
-    @Test
-    void testFindNearestGradleVersion() {
-        assertThat(GradleUtils.findNearestGradleVersion("3.0")).isEqualTo("4.10.3");
-        assertThat(GradleUtils.findNearestGradleVersion("4.0")).isEqualTo("4.10.3");
-        assertThat(GradleUtils.findNearestGradleVersion("5.4.1")).isEqualTo("5.6.4");
-        assertThat(GradleUtils.findNearestGradleVersion("6.0")).isEqualTo("6.9.2");
-        assertThat(GradleUtils.findNearestGradleVersion("7.0")).isEqualTo("7.4.1");
-        assertThat(GradleUtils.findNearestGradleVersion("7.4.1")).isEqualTo("7.4.1");
-        assertThat(GradleUtils.findNearestGradleVersion("7.5")).isEqualTo("7.4.1");
-        assertThat(GradleUtils.findNearestGradleVersion("7.5.1")).isEqualTo("7.5.1");
-        assertThat(GradleUtils.findNearestGradleVersion("")).isEqualTo("7.5.1");
-    }
 }

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/LocalCache.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/LocalCache.java
@@ -54,6 +54,11 @@ public class LocalCache implements RepositoryClient {
     }
 
     @Override
+    public String getName() {
+        return "local cache";
+    }
+
+    @Override
     public Optional<RepositoryResult> getArtifactFile(String buildPolicy, String group, String artifact, String version,
             String target, Long buildStartTime) {
         //TODO: we don't really care about the policy when using standard maven repositories
@@ -195,7 +200,8 @@ public class LocalCache implements RepositoryClient {
                             }
                             if (!sb.toString().equalsIgnoreCase(result.get().getExpectedSha().get())) {
                                 //TODO: handle this better
-                                Log.error("Filed to cache " + downloadTarget + " calculated sha '" + sb.toString()
+                                Log.error("Filed to cache " + downloadTarget + " from " + repositoryClient.getName()
+                                        + " calculated sha '" + sb.toString()
                                         + "' did not match expected '" + result.get().getExpectedSha().get() + "'");
                                 return clientInvocation.apply(repositoryClient);
                             }

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/RepositoryClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/RepositoryClient.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface RepositoryClient {
 
+    String getName();
+
     /**
      * Retrieves an artifact related file.
      *

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/maven/MavenClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/maven/MavenClient.java
@@ -27,8 +27,13 @@ public class MavenClient implements RepositoryClient {
     }
 
     public static MavenClient of(String name, URI uri) {
-        MavenHttpClient client = RestClientBuilder.newBuilder().baseUri(uri).build(MavenHttpClient.class);
+        MavenHttpClient client = RestClientBuilder.newBuilder().followRedirects(true).baseUri(uri).build(MavenHttpClient.class);
         return new MavenClient(name, uri, client);
+    }
+
+    @Override
+    public String getName() {
+        return name;
     }
 
     @Override

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/ociregistry/OCIRegistryRepositoryClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/ociregistry/OCIRegistryRepositoryClient.java
@@ -82,6 +82,11 @@ public class OCIRegistryRepositoryClient implements RepositoryClient {
     }
 
     @Override
+    public String getName() {
+        return registry;
+    }
+
+    @Override
     public Optional<RepositoryResult> getArtifactFile(String buildPolicy, String group, String artifact, String version,
             String target, Long buildStartTime) {
         long time = System.currentTimeMillis();

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/s3/S3RepositoryClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/s3/S3RepositoryClient.java
@@ -27,6 +27,11 @@ public class S3RepositoryClient implements RepositoryClient {
     }
 
     @Override
+    public String getName() {
+        return "s3/" + bucket;
+    }
+
+    @Override
     public Optional<RepositoryResult> getArtifactFile(String buildPolicy, String group, String artifact, String version,
             String target, Long buildStartTime) {
 

--- a/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/services/LocalCacheTest.java
+++ b/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/services/LocalCacheTest.java
@@ -29,6 +29,11 @@ public class LocalCacheTest {
 
     public final RepositoryClient MOCK_CLIENT = new RepositoryClient() {
         @Override
+        public String getName() {
+            return "";
+        }
+
+        @Override
         public Optional<RepositoryResult> getArtifactFile(String buildPolicy, String group, String artifact, String version,
                 String target, Long buildStartTime) {
             return Optional.ofNullable(current);

--- a/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/MavenProxyResource.java
+++ b/java-components/sidecar/src/main/java/com/redhat/hacbs/sidecar/resources/MavenProxyResource.java
@@ -226,6 +226,8 @@ public class MavenProxyResource {
                         return rb.build();
                     }
                 }
+            } catch (NotFoundException e) {
+                throw e;
             } catch (Exception e) {
                 Log.errorf(e, "Failed to load %s", target);
                 current = e;

--- a/openshift-with-appstudio-test/e2e/util.go
+++ b/openshift-with-appstudio-test/e2e/util.go
@@ -190,13 +190,14 @@ func setup(t *testing.T, ta *testArgs) *testArgs {
 	}
 	cm := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "jvm-build-config", Namespace: ta.ns},
 		Data: map[string]string{
-			"enable-rebuilds":                  "true",
-			"maven-repository-300-jboss":       "https://repository.jboss.org/nexus/content/groups/public/",
-			"maven-repository-301-jitpack":     "https://jitpack.io",
-			"maven-repository-302-confluent":   "https://packages.confluent.io/maven",
-			"maven-repository-303-gradle":      "https://repo.gradle.org/artifactory/libs-releases",
-			"maven-repository-304-eclipselink": "https://download.eclipse.org/rt/eclipselink/maven.repo",
-			"maven-repository-305-redhat":      "https://maven.repository.redhat.com/ga"}}
+			"enable-rebuilds":                    "true",
+			"maven-repository-300-jboss":         "https://repository.jboss.org/nexus/content/groups/public/",
+			"maven-repository-301-gradleplugins": "https://plugins.gradle.org/m2",
+			"maven-repository-302-confluent":     "https://packages.confluent.io/maven",
+			"maven-repository-303-gradle":        "https://repo.gradle.org/artifactory/libs-releases",
+			"maven-repository-304-eclipselink":   "https://download.eclipse.org/rt/eclipselink/maven.repo",
+			"maven-repository-305-redhat":        "https://maven.repository.redhat.com/ga",
+			"maven-repository-306-jitpack":       "https://jitpack.io"}}
 	_, err = kubeClient.CoreV1().ConfigMaps(ta.ns).Create(context.TODO(), &cm, metav1.CreateOptions{})
 	if err != nil {
 		debugAndFailTest(ta, err.Error())

--- a/pkg/reconciler/configmap/configmap.go
+++ b/pkg/reconciler/configmap/configmap.go
@@ -298,7 +298,7 @@ func (r *ReconcileConfigMap) setupCache(ctx context.Context, request reconcile.R
 			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: UserSecretName}, Key: "registry.token", Optional: &trueBool}},
 		})
 	}
-	regex, err := regexp.Compile(`maven-repository-(\d+)-(\w+)`)
+	regex, err := regexp.Compile(`maven-repository-(\d+)-([\w-]+)`)
 	if err != nil {
 		return err
 	}
@@ -311,11 +311,11 @@ func (r *ReconcileConfigMap) setupCache(ctx context.Context, request reconcile.R
 				return err
 			}
 			cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-				Name:  "STORE_" + strings.ToUpper(name) + "_URL",
+				Name:  "STORE_" + strings.ToUpper(strings.Replace(name, "-", "_", -1)) + "_URL",
 				Value: v,
 			})
 			cache.Spec.Template.Spec.Containers[0].Env = append(cache.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-				Name:  "STORE_" + strings.ToUpper(name) + "_TYPE",
+				Name:  "STORE_" + strings.ToUpper(strings.Replace(name, "-", "_", -1)) + "_TYPE",
 				Value: "maven2",
 			})
 			repos = append(repos, Repo{position: atoi, name: name})

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -23,8 +23,6 @@ spec:
       - clean
       - install
       - -Denforcer.skip
-  - name: JAVA_VERSION
-    value: ""
   - name: TOOL_VERSION
     value: ""
   workspaces:
@@ -55,10 +53,6 @@ spec:
           - clean
           - install
           - -Denforcer.skip
-      - name: JAVA_VERSION
-        description: Java version.
-        type: string
-        default: ""
       - name: TOOL_VERSION
         description: Maven version.
         type: string
@@ -270,8 +264,6 @@ spec:
     value:
     - build
     - publish
-  - name: JAVA_VERSION
-    value: ""
   - name: TOOL_VERSION
     value: ""
   workspaces:
@@ -307,10 +299,6 @@ spec:
         default:
           - build
           - publish
-      - name: JAVA_VERSION
-        description: Java version.
-        type: string
-        default: ""
       - name: TOOL_VERSION
         description: Gradle version.
         type: string
@@ -438,10 +426,6 @@ spec:
                           }
                           //allowInsecureProtocol = true
                       }
-                      maven {
-                          name "Gradle Central Plugin Repository"
-                          url "https://plugins.gradle.org/m2/"
-                      }
                   }
               }
               repositories {
@@ -454,10 +438,6 @@ spec:
                           password "$(params.SERVER_PASSWORD)"
                       }
                       //allowInsecureProtocol = true
-                  }
-                  maven {
-                      name "Gradle Central Plugin Repository"
-                      url "https://plugins.gradle.org/m2/"
                   }
               }
           }
@@ -500,21 +480,6 @@ spec:
 
           echo "@=$@"
 
-          if [ -z "$(params.JAVA_VERSION)" ]; then
-              echo "JAVA_VERSION has not been set" >&2
-              exit 1
-          fi
-
-          case "$(params.JAVA_VERSION)" in
-              8)
-                  export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
-                  ;;
-              *)
-                  export JAVA_HOME="/usr/lib/jvm/java-$(params.JAVA_VERSION)-openjdk"
-                  ;;
-          esac
-
-          echo "JAVA_HOME=${JAVA_HOME}"
           export PATH="${JAVA_HOME}/bin:${PATH}"
 
           if [ -z "$(params.TOOL_VERSION)" ]; then
@@ -523,7 +488,7 @@ spec:
           fi
 
           TOOL_VERSION="$(params.TOOL_VERSION)"
-          export GRADLE_HOME="/opt/gradle-${TOOL_VERSION}"
+          export GRADLE_HOME="/opt/gradle/${TOOL_VERSION}"
           echo "GRADLE_HOME=${GRADLE_HOME}"
 
           if [ ! -d "${GRADLE_HOME}" ]; then

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -268,18 +268,7 @@ func (r *ReconcileDependencyBuild) handleStateAnalyzeBuild(ctx context.Context, 
 		db.Status.State = v1alpha1.DependencyBuildStateFailed
 		db.Status.Message = message
 	} else {
-		unmarshalled := struct {
-			Tools map[string]struct {
-				Min       string
-				Max       string
-				Preferred string
-			}
-			Invocations      [][]string
-			EnforceVersion   string
-			IgnoredArtifacts []string
-			ToolVersion      string
-			JavaVersion      string
-		}{}
+		unmarshalled := marshalledBuildInfo{}
 
 		if err := json.Unmarshal([]byte(buildInfo), &unmarshalled); err != nil {
 			r.eventRecorder.Eventf(&db, v1.EventTypeWarning, "InvalidJson", "Failed to unmarshal build info for AB %s/%s JSON: %s", db.Namespace, db.Name, buildInfo)
@@ -372,6 +361,21 @@ func (r *ReconcileDependencyBuild) handleStateAnalyzeBuild(ctx context.Context, 
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+type marshalledBuildInfo struct {
+	Tools            map[string]toolInfo
+	Invocations      [][]string
+	EnforceVersion   string
+	IgnoredArtifacts []string
+	ToolVersion      string
+	JavaVersion      string
+}
+
+type toolInfo struct {
+	Min       string
+	Max       string
+	Preferred string
 }
 
 // compares versions, returns 0 if versions

--- a/pkg/reconciler/dependencybuild/dependencybuild_test.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild_test.go
@@ -174,7 +174,7 @@ func TestStateDetect(t *testing.T) {
 					g.Expect(or.Name).Should(Equal(db.Name))
 				}
 			}
-			g.Expect(len(pr.Spec.Params)).Should(Equal(9))
+			g.Expect(len(pr.Spec.Params)).Should(Equal(8))
 			for _, param := range pr.Spec.Params {
 				switch param.Name {
 				case PipelineScmTag:
@@ -192,9 +192,7 @@ func TestStateDetect(t *testing.T) {
 				case PipelineIgnoredArtifacts:
 					g.Expect(param.Value.StringVal).Should(BeEmpty())
 				case PipelineToolVersion:
-					g.Expect(param.Value.StringVal).Should(BeEmpty())
-				case PipelineJavaVersion:
-					g.Expect(param.Value.StringVal).Should(BeEmpty())
+					g.Expect(param.Value.StringVal).Should(Equal("3.8.1"))
 				}
 			}
 		}

--- a/pkg/reconciler/dependencybuild/dependencybuild_test.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild_test.go
@@ -2,6 +2,7 @@ package dependencybuild
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/configmap"
 	v1 "k8s.io/api/core/v1"
@@ -39,9 +40,20 @@ func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Clien
 	sysConfig := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: configmap.SystemConfigMapName, Namespace: configmap.SystemConfigMapNamespace},
 		Data: map[string]string{
-			configmap.SystemBuilderImages:                            "jdk11",
-			fmt.Sprintf(configmap.SystemBuilderImageFormat, "jdk11"): "quay.io/sdouglas/hacbs-jdk11-builder:latest",
+			//bogus gradle images used to unit test the selection logic
+			configmap.SystemBuilderImages:                            "jdk11,g5,g6,g7",
+			fmt.Sprintf(configmap.SystemBuilderImageFormat, "jdk11"): "quay.io/redhat-appstudio/hacbs-jdk11-builder:latest",
 			fmt.Sprintf(configmap.SystemBuilderTagFormat, "jdk11"):   "jdk:11,maven:3.8",
+			fmt.Sprintf(configmap.SystemBuilderImageFormat, "jdk8"):  "quay.io/redhat-appstudio/hacbs-jdk8-builder:latest",
+			fmt.Sprintf(configmap.SystemBuilderTagFormat, "jdk8"):    "jdk:8,maven:3.8",
+			fmt.Sprintf(configmap.SystemBuilderImageFormat, "jdk17"): "quay.io/redhat-appstudio/hacbs-jdk17-builder:latest",
+			fmt.Sprintf(configmap.SystemBuilderTagFormat, "jdk17"):   "jdk:17,maven:3.8",
+			fmt.Sprintf(configmap.SystemBuilderImageFormat, "g5"):    "quay.io/redhat-appstudio/hacbs-g5-builder:latest",
+			fmt.Sprintf(configmap.SystemBuilderTagFormat, "g5"):      "jdk:11,gradle:5.4.3",
+			fmt.Sprintf(configmap.SystemBuilderImageFormat, "g6"):    "quay.io/redhat-appstudio/hacbs-g6-builder:latest",
+			fmt.Sprintf(configmap.SystemBuilderTagFormat, "g6"):      "jdk:11,gradle:6.1.2",
+			fmt.Sprintf(configmap.SystemBuilderImageFormat, "g7"):    "quay.io/redhat-appstudio/hacbs-g7-builder:latest",
+			fmt.Sprintf(configmap.SystemBuilderTagFormat, "g7"):      "jdk:11,gradle:7.1.3",
 		},
 	}
 	_ = client.Create(context.TODO(), &sysConfig)
@@ -87,7 +99,7 @@ func TestStateNew(t *testing.T) {
 			Name:      "test",
 		}, &db))
 		g.Expect(db.Status.CurrentBuildRecipe).ShouldNot(BeNil())
-		g.Expect(db.Status.CurrentBuildRecipe.Image).Should(Equal("quay.io/sdouglas/hacbs-jdk11-builder:latest"))
+		g.Expect(db.Status.CurrentBuildRecipe.Image).Should(Equal("quay.io/redhat-appstudio/hacbs-jdk11-builder:latest"))
 
 	})
 }
@@ -139,7 +151,7 @@ func TestStateDetect(t *testing.T) {
 		g.Expect(client.Get(ctx, types.NamespacedName{
 			Namespace: metav1.NamespaceDefault,
 			Name:      "test",
-		}, &db))
+		}, &db)).Should(BeNil())
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateAnalyzeBuild))
 		return db, client, reconciler, ctx
 	}
@@ -184,7 +196,7 @@ func TestStateDetect(t *testing.T) {
 				case PipelineScmUrl:
 					g.Expect(param.Value.StringVal).Should(Equal("some-url"))
 				case PipelineImage:
-					g.Expect(param.Value.StringVal).Should(Equal("quay.io/sdouglas/hacbs-jdk11-builder:latest"))
+					g.Expect(param.Value.StringVal).Should(Equal("quay.io/redhat-appstudio/hacbs-jdk11-builder:latest"))
 				case PipelineGoals:
 					g.Expect(param.Value.ArrayVal).Should(ContainElement("testgoal"))
 				case PipelineEnforceVersion:
@@ -209,13 +221,19 @@ func TestStateDetect(t *testing.T) {
 func getBuild(client runtimeclient.Client, g *WithT) *v1alpha1.DependencyBuild {
 	ctx := context.TODO()
 	build := v1alpha1.DependencyBuild{}
-	g.Expect(client.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test"}, &build))
+	g.Expect(client.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test"}, &build)).Should(BeNil())
 	return &build
 }
-func getTr(client runtimeclient.Client, g *WithT) *pipelinev1beta1.PipelineRun {
+func getBuildPipeline(client runtimeclient.Client, g *WithT) *pipelinev1beta1.PipelineRun {
 	ctx := context.TODO()
 	build := pipelinev1beta1.PipelineRun{}
-	g.Expect(client.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-build-0"}, &build))
+	g.Expect(client.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-build-0"}, &build)).Should(BeNil())
+	return &build
+}
+func getBuildInfoPipeline(client runtimeclient.Client, g *WithT) *pipelinev1beta1.PipelineRun {
+	ctx := context.TODO()
+	build := pipelinev1beta1.PipelineRun{}
+	g.Expect(client.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-build-discovery"}, &build)).Should(BeNil())
 	return &build
 }
 func TestStateBuilding(t *testing.T) {
@@ -236,14 +254,14 @@ func TestStateBuilding(t *testing.T) {
 		db.Spec.ScmInfo.Tag = "some-tag"
 		db.Spec.ScmInfo.Path = "some-path"
 		db.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: hashToString(db.Spec.ScmInfo.SCMURL + db.Spec.ScmInfo.Tag + db.Spec.ScmInfo.Path)}
-		g.Expect(client.Create(ctx, &db))
+		g.Expect(client.Create(ctx, &db)).Should(BeNil())
 
 		pr := pipelinev1beta1.PipelineRun{}
 		pr.Namespace = metav1.NamespaceDefault
 		pr.Name = "test-build-0"
 		pr.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: hashToString(db.Spec.ScmInfo.SCMURL + db.Spec.ScmInfo.Tag + db.Spec.ScmInfo.Path), PipelineType: PipelineTypeBuild}
-		g.Expect(controllerutil.SetOwnerReference(&db, &pr, reconciler.scheme))
-		g.Expect(client.Create(ctx, &pr))
+		g.Expect(controllerutil.SetOwnerReference(&db, &pr, reconciler.scheme)).Should(BeNil())
+		g.Expect(client.Create(ctx, &pr)).Should(BeNil())
 
 	}
 
@@ -256,7 +274,7 @@ func TestStateBuilding(t *testing.T) {
 		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: buildName}))
 		db = getBuild(client, g)
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateBuilding))
-		getTr(client, g)
+		getBuildPipeline(client, g)
 	})
 	t.Run("Test reconcile building DependencyBuild with running pipeline, DependencyBuild arrives first", func(t *testing.T) {
 		g := NewGomegaWithT(t)
@@ -267,19 +285,19 @@ func TestStateBuilding(t *testing.T) {
 		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: taskRunName}))
 		db = getBuild(client, g)
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateBuilding))
-		getTr(client, g)
+		getBuildPipeline(client, g)
 	})
 	t.Run("Test reconcile building DependencyBuild with succeeded pipeline", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		setup(g)
-		pr := getTr(client, g)
+		pr := getBuildPipeline(client, g)
 		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 		pr.Status.SetCondition(&apis.Condition{
 			Type:               apis.ConditionSucceeded,
 			Status:             "True",
 			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
 		})
-		g.Expect(client.Update(ctx, pr))
+		g.Expect(client.Update(ctx, pr)).Should(BeNil())
 		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: taskRunName}))
 		db := getBuild(client, g)
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateComplete))
@@ -287,14 +305,14 @@ func TestStateBuilding(t *testing.T) {
 	t.Run("Test reconcile building DependencyBuild with failed pipeline", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		setup(g)
-		pr := getTr(client, g)
+		pr := getBuildPipeline(client, g)
 		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 		pr.Status.SetCondition(&apis.Condition{
 			Type:               apis.ConditionSucceeded,
 			Status:             "False",
 			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
 		})
-		g.Expect(client.Update(ctx, pr))
+		g.Expect(client.Update(ctx, pr)).Should(BeNil())
 		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: taskRunName}))
 		db := getBuild(client, g)
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateSubmitBuild))
@@ -305,7 +323,7 @@ func TestStateBuilding(t *testing.T) {
 	t.Run("Test reconcile building DependencyBuild with contaminants", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		setup(g)
-		pr := getTr(client, g)
+		pr := getBuildPipeline(client, g)
 		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 		pr.Status.SetCondition(&apis.Condition{
 			Type:               apis.ConditionSucceeded,
@@ -313,7 +331,7 @@ func TestStateBuilding(t *testing.T) {
 			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
 		})
 		pr.Status.PipelineResults = []pipelinev1beta1.PipelineRunResult{{Name: "contaminants", Value: "com.acme:foo:1.0,com.acme:bar:1.0"}}
-		g.Expect(client.Update(ctx, pr))
+		g.Expect(client.Update(ctx, pr)).Should(BeNil())
 		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: taskRunName}))
 		db := getBuild(client, g)
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateContaminated))
@@ -321,5 +339,55 @@ func TestStateBuilding(t *testing.T) {
 		db = getBuild(client, g)
 		g.Expect(db.Status.Contaminants).Should(ContainElement("com.acme:foo:1.0"))
 		g.Expect(db.Status.Contaminants).Should(ContainElement("com.acme:bar:1.0"))
+	})
+
+}
+
+func TestStateDependencyBuildStateAnalyzeBuild(t *testing.T) {
+	ctx := context.TODO()
+
+	var client runtimeclient.Client
+	var reconciler *ReconcileDependencyBuild
+	taskRunName := types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-build-discovery"}
+	setup := func(g *WithT) {
+		client, reconciler = setupClientAndReconciler()
+		db := v1alpha1.DependencyBuild{}
+		db.Namespace = metav1.NamespaceDefault
+		db.Name = "test"
+		db.Status.State = v1alpha1.DependencyBuildStateAnalyzeBuild
+		db.Spec.ScmInfo.SCMURL = "some-url"
+		db.Spec.ScmInfo.Tag = "some-tag"
+		db.Spec.ScmInfo.Path = "some-path"
+		db.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: hashToString(db.Spec.ScmInfo.SCMURL + db.Spec.ScmInfo.Tag + db.Spec.ScmInfo.Path)}
+		g.Expect(client.Create(ctx, &db)).Should(BeNil())
+
+		pr := pipelinev1beta1.PipelineRun{}
+		pr.Namespace = metav1.NamespaceDefault
+		pr.Name = "test-build-discovery"
+		pr.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: hashToString(db.Spec.ScmInfo.SCMURL + db.Spec.ScmInfo.Tag + db.Spec.ScmInfo.Path), PipelineType: PipelineTypeBuildInfo}
+		g.Expect(controllerutil.SetOwnerReference(&db, &pr, reconciler.scheme))
+		g.Expect(client.Create(ctx, &pr)).Should(BeNil())
+
+	}
+	t.Run("Test build info discovery for maven build", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setup(g)
+		buildInfoJson, err := json.Marshal(marshalledBuildInfo{ToolVersion: "5.8.7", Tools: map[string]toolInfo{"gradle": {}}, Invocations: [][]string{{""}}})
+		g.Expect(err).Should(BeNil())
+		pr := getBuildInfoPipeline(client, g)
+		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+		pr.Status.PipelineResults = []pipelinev1beta1.PipelineRunResult{{Name: BuildInfoPipelineBuildInfo, Value: string(buildInfoJson)}}
+		pr.Status.SetCondition(&apis.Condition{
+			Type:               apis.ConditionSucceeded,
+			Status:             "True",
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
+		})
+		g.Expect(client.Status().Update(ctx, pr)).Should(BeNil())
+		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: taskRunName}))
+
+		db := getBuild(client, g)
+		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateSubmitBuild))
+		g.Expect(len(db.Status.PotentialBuildRecipes)).Should(Equal(1))
+		g.Expect(db.Status.PotentialBuildRecipes[0].Image).Should(Equal("quay.io/redhat-appstudio/hacbs-g5-builder:latest"))
 	})
 }


### PR DESCRIPTION
This changes the way that builder images are produced, and how gradle builds are performed. In particular:

- Builder images now have multiple gradle versions. The versions that are including are driven by the config map information so the config and builders will stay aligned.
- The build discovery tool now has no knowledge of available versions, it just performs the discovery and reports what it has found
- dependencybuilds.go is now responsible for mapping the discovered information into builder image invocations.