### PR TITLE
Include support for minikube based dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,13 @@ dev: dev-image
 	if ! docker images | grep hacbs-jdk17; then echo "Local copy of builder images not found. You need to run 'make builder-image'"; exit 1; fi
 	cd java-components && mvn clean install -Dlocal -DskipTests
 	./deploy/install-openshift-pipelines.sh || true
-	./deploy/development.sh
+
+dev-openshift: dev
+	./deploy/openshift-development.sh
+
+
+dev-minikube: dev
+	./deploy/minikube-development.sh
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/deploy/base-development.sh
+++ b/deploy/base-development.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+kubectl delete deployments.apps hacbs-jvm-operator -n jvm-build-service
+# we don't restart the cache and local storage by default
+# for most cases in development this is not necessary, and just slows things
+# down by needing things to be re-cached/rebuilt
+#kubectl delete deployments.apps hacbs-jvm-cache -n jvm-build-service
+#kubectl delete deployments.apps localstack -n jvm-build-service
+
+DIR=`dirname $0`
+kubectl apply -f $DIR/namespace.yaml
+kubectl config set-context --current --namespace=test-jvm-namespace
+JVM_BUILD_SERVICE_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-controller \
+JVM_BUILD_SERVICE_CACHE_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-cache \
+JVM_BUILD_SERVICE_SIDECAR_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-sidecar:dev \
+JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-build-request-processor:dev \
+JVM_BUILD_SERVICE_ANALYZER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-dependency-analyser:dev \
+JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jdk8-builder:dev \
+JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jdk11-builder:dev \
+JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jdk17-builder:dev \
+$DIR/patch-yaml.sh

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - gradle-v0.1.yaml
-#  - https://github.com/tektoncd/pipeline/releases/download/v0.34.1/release.yaml
   - https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml
   - maven-v0.2.yaml
   - rbac.yaml

--- a/deploy/minikube-development.sh
+++ b/deploy/minikube-development.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+DIR=`dirname $0`
+kubectl apply -f https://github.com/tektoncd/pipeline/releases/download/v0.34.1/release.yaml
+while ! oc get pods -n tekton-pipelines | grep tekton-pipelines-controller | grep Running; do
+    sleep 1
+done
+
+$DIR/base-development.sh
+
+#minikube cannot access registry.redhat.io by default
+#you need to have these credentials in your docker config
+kubectl create secret docker-registry minikube-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json
+kubectl patch serviceaccount pipeline -p '{"imagePullSecrets": [{"name": "minikube-pull-secret"}]}'
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "minikube-pull-secret"}]}'

--- a/deploy/openshift-development.sh
+++ b/deploy/openshift-development.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+DIR=`dirname $0`
+$DIR/install-openshift-pipelines.sh
+$DIR/base-development.sh
+


### PR DESCRIPTION
This splits the dev mode between openshift and minikube. You can now
run make dev-openshift or make dev-minikube depending on your target
environment.