### PR TITLE
debug operator rbac right before starting periodic/apicurio test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ appstudio-installed-on-openshift-e2e:
 	KUBERNETES_CONFIG=${KUBECONFIG} go test -count 1 -tags normal -timeout 120m -v ./openshift-with-appstudio-test/...
 
 appstudio-installed-on-openshift-periodic:
+	oc get clusterrole hacbs-jvm-operator || true
+	oc get clusterrolebinding hacbs-jvm-operator || true
+	oc adm policy who-can list serviceaccounts || true
 	KUBERNETES_CONFIG=${KUBECONFIG} go test -count 1 -tags periodic -timeout 180m -v ./openshift-with-appstudio-test/...
 
 build:


### PR DESCRIPTION
OK @stuartwdouglas @psturc @dwalluck let's see what this debug spits out when we run the apicurio/service registry build.

If things haven't changed I should be able to log onto the openshift ci cluster and view the logs in real time before the test times out.

When I run locally with rbac properly defined, I get 

```
while ! oc get clusterrole hacbs-jvm-operator; do sleep 1; done
NAME                 CREATED AT
hacbs-jvm-operator   2022-09-07T13:46:54Z
while ! oc get clusterrolebinding hacbs-jvm-operator; do sleep 1; done
NAME                 ROLE                             AGE
hacbs-jvm-operator   ClusterRole/hacbs-jvm-operator   7h38m
while ! oc adm policy who-can list serviceaccounts | grep jvm-build; do sleep 1; done
        system:serviceaccount:jvm-build-service:hacbs-jvm-operator
```

As a reminder I was getting the errors noted at https://github.com/redhat-appstudio/jvm-build-service/pull/183#issuecomment-1238332025 after trying the test with @psturc "pre-kcp" fix.