### PR TITLE
fix lookup-artifact-location and process-build-requests permission issues running on openshfit

### DIFF
--- a/pkg/reconciler/artifactbuild/artifactbuild.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild.go
@@ -524,6 +524,7 @@ func createLookupScmInfoTask(gav string, config map[string]string) *pipelinev1be
 		recipes = recipes + "," + additional
 	}
 
+	zero := int64(0)
 	return &pipelinev1beta1.TaskSpec{
 		Results: []pipelinev1beta1.TaskResult{
 			{Name: PipelineResultScmUrl},
@@ -553,6 +554,9 @@ func createLookupScmInfoTask(gav string, config map[string]string) *pipelinev1be
 						"$(results." + PipelineResultContextPath + ".path)",
 						"--gav",
 						gav,
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: &zero,
 					},
 				},
 			},

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -634,6 +634,7 @@ func createLookupBuildInfoPipeline(build *v1alpha1.DependencyBuildSpec, config m
 	if len(path) == 0 {
 		path = "."
 	}
+	zero := int64(0)
 	return &pipelinev1beta1.PipelineSpec{
 		Results: []pipelinev1beta1.PipelineResult{{Name: BuildInfoPipelineMessage, Value: "$(tasks." + artifactbuild.TaskName + ".results." + BuildInfoPipelineMessage + ")"}, {Name: BuildInfoPipelineBuildInfo, Value: "$(tasks." + artifactbuild.TaskName + ".results." + BuildInfoPipelineBuildInfo + ")"}},
 		Tasks: []pipelinev1beta1.PipelineTask{
@@ -663,6 +664,9 @@ func createLookupBuildInfoPipeline(build *v1alpha1.DependencyBuildSpec, config m
 										"$(results." + BuildInfoPipelineMessage + ".path)",
 										"--build-info",
 										"$(results." + BuildInfoPipelineBuildInfo + ".path)",
+									},
+									SecurityContext: &v1.SecurityContext{
+										RunAsUser: &zero,
 									},
 								},
 							},


### PR DESCRIPTION
while working on the ci pivot off of infra-deps, I noticed these errors on main branch
```
[task : lookup-artifact-location] 2022/09/09 19:28:25 warning: unsuccessful cred copy: ".docker" from "/tekton/creds" to "/home/jboss": unable to create destination directory: mkdir /home/jboss/.docker: permission denied
[task : lookup-artifact-location] __  ____  __  _____   ___  __ ____  ______ 
[task : lookup-artifact-location]  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
[task : lookup-artifact-location]  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
[task : lookup-artifact-location] --\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
[task : lookup-artifact-location] 2022-09-09 19:28:27,174 INFO  [io.quarkus] (main) hacbs-build-request-processor 1.0-SNAPSHOT on JVM (powered by Quarkus 2.12.0.Final) started in 0.368s. 
[task : lookup-artifact-location] 2022-09-09 19:28:27,192 INFO  [io.quarkus] (main) Profile prod activated. 
[task : lookup-artifact-location] 2022-09-09 19:28:27,193 INFO  [io.quarkus] (main) Installed features: [cdi, jgit, jsch, picocli, rest-client-reactive, smallrye-context-propagation, vertx]
[task : lookup-artifact-location] 2022-09-09 19:28:30,375 ERROR [org.ecl.jgi.uti.FS] (JGit-FileStoreAttributeWriter-2) Cannot save config file 'FileBasedConfig[/home/jboss/.config/jgit/config]': java.io.IOException: Creating directories for /home/jboss/.config/jgit failed
[task : lookup-artifact-location] 	at org.eclipse.jgit.util.FileUtils.mkdirs(FileUtils.java:412)
[task : lookup-artifact-location] 	at org.eclipse.jgit.internal.storage.file.LockFile.lock(LockFile.java:138)
[task : lookup-artifact-location] 	at org.eclipse.jgit.storage.file.FileBasedConfig.save(FileBasedConfig.java:219)
[task : lookup-artifact-location] 	at org.eclipse.jgit.util.FS$FileStoreAttributes.saveToConfig(FS.java:744)
[task : lookup-artifact-location] 	at org.eclipse.jgit.util.FS$FileStoreAttributes.lambda$4(FS.java:430)
[task : lookup-artifact-location] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[task : lookup-artifact-location] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[task : lookup-artifact-location] 	at java.base/java.lang.Thread.run(Thread.java:833)
[task : lookup-artifact-location] 

```

and 

```
[task : process-build-requests] 2022/09/09 19:28:37 warning: unsuccessful cred copy: ".docker" from "/tekton/creds" to "/home/jboss": unable to create destination directory: mkdir /home/jboss/.docker: permission denied
[task : process-build-requests] __  ____  __  _____   ___  __ ____  ______ 
[task : process-build-requests]  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
[task : process-build-requests]  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
[task : process-build-requests] --\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
[task : process-build-requests] 2022-09-09 19:28:41,160 INFO  [io.quarkus] (main) hacbs-build-request-processor 1.0-SNAPSHOT on JVM (powered by Quarkus 2.12.0.Final) started in 0.422s. 
[task : process-build-requests] 2022-09-09 19:28:41,181 INFO  [io.quarkus] (main) Profile prod activated. 
[task : process-build-requests] 2022-09-09 19:28:41,181 INFO  [io.quarkus] (main) Installed features: [cdi, jgit, jsch, picocli, rest-client-reactive, smallrye-context-propagation, vertx]
[task : process-build-requests] 2022-09-09 19:28:44,404 ERROR [org.ecl.jgi.uti.FS] (JGit-FileStoreAttributeWriter-2) Cannot save config file 'FileBasedConfig[/home/jboss/.config/jgit/config]': java.io.IOException: Creating directories for /home/jboss/.config/jgit failed
[task : process-build-requests] 	at org.eclipse.jgit.util.FileUtils.mkdirs(FileUtils.java:412)
[task : process-build-requests] 	at org.eclipse.jgit.internal.storage.file.LockFile.lock(LockFile.java:138)
[task : process-build-requests] 	at org.eclipse.jgit.storage.file.FileBasedConfig.save(FileBasedConfig.java:219)
[task : process-build-requests] 	at org.eclipse.jgit.util.FS$FileStoreAttributes.saveToConfig(FS.java:744)
[task : process-build-requests] 	at org.eclipse.jgit.util.FS$FileStoreAttributes.lambda$4(FS.java:430)
[task : process-build-requests] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[task : process-build-requests] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[task : process-build-requests] 	at java.base/java.lang.Thread.run(Thread.java:833)
[task : process-build-requests] 
[task : process-build-requests] 2022-09-09 19:28:46,427 INFO  [io.quarkus] (main) hacbs-build-request-processor stopped in 0.020s
```

decided to push the fix for them separately

interestingly, the base e2e did not fail with these errors

did not have time to try the service registry periodic 