### PR TITLE
create a new ci flow that is a subset of the kustomize dev flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ nb-configuration.xml
 .envrc
 *.out
 
-# Kustomize overlays for development
+# Kustomize overlays for development, openshift ci
 deploy/**/development/**
+deploy/**/ci-final/**

--- a/deploy/openshift-ci.sh
+++ b/deploy/openshift-ci.sh
@@ -2,10 +2,33 @@
 
 echo "Executing openshift-ci.sh"
 
+echo "jvm build service golang operator image:"
+echo ${JVM_BUILD_SERVICE_IMAGE}
+echo "jvm build service jvm cache image:"
+echo ${JVM_BUILD_SERVICE_CACHE_IMAGE}
+echo "jvm build service jvm sidecar image:"
+echo ${JVM_BUILD_SERVICE_SIDECAR_IMAGE}
+echo "jvm build service jvm analyzer image:"
+echo ${JVM_BUILD_SERVICE_ANALYZER_IMAGE}
+echo "jvm build service jvm reqprocessor image:"
+echo ${JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE}
+
 DIR=`dirname $0`
 echo "Running out of ${DIR}"
 $DIR/install-openshift-pipelines.sh
-oc apply -f $DIR/namespace.yaml
-$DIR/patch-yaml.sh
-oc apply -k $DIR/overlays/development
-
+oc create ns jvm-build-service || true
+find $DIR -name ci-final -exec rm -r {} \;
+find $DIR -name ci-template -exec cp -r {} {}/../ci-final \;
+# copy this over since if updates more frequently
+cp $DIR/base/system-config.yaml $DIR/overlays/ci-final/system-config-builders.yaml
+find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-image%${JVM_BUILD_SERVICE_IMAGE}% {} \;
+find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-cache-image%${JVM_BUILD_SERVICE_CACHE_IMAGE}% {} \;
+find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-sidecar-image%${JVM_BUILD_SERVICE_SIDECAR_IMAGE}% {} \;
+find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-analyzer-image%${JVM_BUILD_SERVICE_ANALYZER_IMAGE}% {} \;
+find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-reqprocessor-image%${JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE}% {} \;
+find $DIR -path \*ci-final\*.yaml -exec sed -i s/ci-template/ci-final/ {} \;
+oc apply -k $DIR/crds/base
+oc apply -f $DIR/operator/base/sa.yaml
+oc apply -f $DIR/operator/base/rbac.yaml
+oc apply -k $DIR/operator/overlays/ci-final
+oc apply -k $DIR/overlays/ci-final

--- a/deploy/operator/overlays/ci-template/base-deployment.yaml
+++ b/deploy/operator/overlays/ci-template/base-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hacbs-jvm-operator
+  namespace: jvm-build-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hacbs-jvm-operator
+  template:
+    metadata:
+      labels:
+        app: hacbs-jvm-operator
+    spec:
+      containers:
+        - name: hacbs-jvm-operator
+          image: jvm-build-service-image
+          imagePullPolicy: Always
+          env:
+            - name: RECIPE_DATABASE
+              value: "https://github.com/redhat-appstudio/jvm-build-data"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      serviceAccountName: hacbs-jvm-operator

--- a/deploy/operator/overlays/ci-template/kustomization.yaml
+++ b/deploy/operator/overlays/ci-template/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - operator-images.yaml
+
+patchesStrategicMerge:
+  # this is a copy of deploy/operator/base/deployment.yaml, but needed because image substitution works differently in CI vs. dev flow,
+  # and I'm bypassing that gross env var munging we had to do in infra-deps; also, the deployment yaml should be pretty static at this point
+  - base-deployment.yaml

--- a/deploy/operator/overlays/ci-template/operator-images.yaml
+++ b/deploy/operator/overlays/ci-template/operator-images.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hacbs-jvm-operator
+  namespace: jvm-build-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: hacbs-jvm-operator
+          env:
+            - name: JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE
+              value: jvm-build-service-reqprocessor-image
+            - name: JVM_BUILD_SERVICE_SIDECAR_IMAGE
+              value: jvm-build-service-sidecar-image

--- a/deploy/overlays/ci-template/kustomization.yaml
+++ b/deploy/overlays/ci-template/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - system-config.yaml
+
+patchesStrategicMerge:
+  # see copy from openshift-ci.sh of deploy/base/system-config.yaml
+  - system-config-builders.yaml
+  - https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service-builder-images/fbe0f42ebe3d50b16d454c95207dd15be6b5008f/image-config.yaml

--- a/deploy/overlays/ci-template/system-config.yaml
+++ b/deploy/overlays/ci-template/system-config.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-system-config
+  namespace: jvm-build-service
+data:
+  image.cache: jvm-build-service-cache-image


### PR DESCRIPTION
see https://github.com/openshift/release/pull/32127#issuecomment-1242010463

admittedly, there is a tad of duplication, but I sided on minimal disruption to the existing dev flow

also, I had to break away from the assumption that the image tag for the operator would always be `dev` and was not keen on duplicating the image/tag env var splitting that we had to do in infra-deployments

longer term, if this approach for CI remains after the kcp transition for jvm-build-service is complete, or if this just bothers you too much @stuartwdouglas, we can rework this further; my first thought along those lines is the system config config map and other jvm-build-service namesapce items needs to be separated from the items in the base dir which are related to the test namespace

As I have managed to avoid changing any files directly related to the dev flow, I'm inclined to merge this, and iterate of any improvements in subsequent PRs, if I get green e2e's to facilitate retests in my openshift/release PR.  

Then again, I would not be shocked if @stuartwdouglas sees this before that happens :-) 

Sample output from my local testing (albeit I did not remove every obj like roles iteration to iteration):
```
JVM_BUILD_SERVICE_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-controller:dev JVM_BUILD_SERVICE_CACHE_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-cache:dev JVM_BUILD_SERVICE_SIDECAR_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-sidecar:dev JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-build-request-processor:dev JVM_BUILD_SERVICE_ANALYZER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-dependency-analyser:dev JVM_BUILD_SERVICE_JDK8_BUILDER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jdk8-builder:dev JVM_BUILD_SERVICE_JDK11_BUILDER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jdk11-builder:dev JVM_BUILD_SERVICE_JDK17_BUILDER_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jdk17-builder:dev ./deploy/openshift-ci.sh 
Executing openshift-ci.sh
jvm build service golang operator image:
quay.io/gabemontero/hacbs-jvm-controller:dev
jvm build service jvm cache image:
quay.io/gabemontero/hacbs-jvm-cache:dev
jvm build service jvm sidecar image:
quay.io/gabemontero/hacbs-jvm-sidecar:dev
jvm build service jvm analyzer image:
quay.io/gabemontero/hacbs-jvm-dependency-analyser:dev
jvm build service jvm reqprocessor image:
quay.io/gabemontero/hacbs-jvm-build-request-processor:dev
Running out of ./deploy
subscription.operators.coreos.com/openshift-pipelines-operator unchanged
tekton-pipelines-controller-79969c5f59-j6lhv        1/1     Running     0          6h55m
Tekton controller is running
Error from server (AlreadyExists): namespaces "jvm-build-service" already exists
find: ‘./deploy/operator/overlays/ci-final’: No such file or directory
find: ‘./deploy/overlays/ci-final’: No such file or directory
customresourcedefinition.apiextensions.k8s.io/artifactbuilds.jvmbuildservice.io configured
customresourcedefinition.apiextensions.k8s.io/dependencybuilds.jvmbuildservice.io configured
customresourcedefinition.apiextensions.k8s.io/tektonwrappers.jvmbuildservice.io configured
serviceaccount/hacbs-jvm-operator unchanged
clusterrole.rbac.authorization.k8s.io/hacbs-jvm-operator unchanged
clusterrolebinding.rbac.authorization.k8s.io/hacbs-jvm-operator unchanged
clusterrole.rbac.authorization.k8s.io/hacbs-jvm-operator-view unchanged
clusterrole.rbac.authorization.k8s.io/hacbs-jvm-cache unchanged
deployment.apps/hacbs-jvm-operator created
configmap/jvm-build-system-config unchanged
gmontero ~/go/src/github.com/redhat-appstudio/jvm-build-service  (more-dev-flow-ci-kustomize-pain)$

```

basic e2e passed for me locally
