### PR TITLE
Add all ABs for service registry

### DIFF
--- a/hack/dump-ab.sh
+++ b/hack/dump-ab.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+dir="$(dirname $0)/service-registry-artifacts"
+echo $dir
+rm -r "${dir}"
+mkdir -p "${dir}"
+rsrcs=$(kubectl  get -o json artifactbuild |jq '.items[].metadata.name'|sed "s/\"//g")
+for r in ${rsrcs};do
+  target=$dir/$(kubectl  get -o yaml artifactbuild ${r} | yq '.status.state')
+  mkdir -p "${target}"
+  kubectl get -o yaml artifactbuild  ${r} |  yq 'del(.status, .metadata.creationTimestamp, .metadata.generation, .metadata.resourceVersion, .metadata.uid)' > "${target}/${r}.yaml"
+done

--- a/hack/rerun-failed-ab.sh
+++ b/hack/rerun-failed-ab.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+list=""
+rsrcs=$(kubectl  get -o json artifactbuild |jq '.items[].metadata.name'|sed "s/\"//g")
+for r in ${rsrcs};do
+  state=$(kubectl  get -o yaml artifactbuild ${r} | yq '.status.state')
+  if [ $state = "ArtifactBuildFailed" ]; then
+      list="$list $r"
+  fi
+done
+kubectl annotate artifactbuilds $list  jvmbuildservice.io/rebuild=true

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/agroal.api.1.15-401ad867.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/agroal.api.1.15-401ad867.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: agroal.api.1.15-401ad867
+  namespace: test-jvm-namespace
+spec:
+  gav: io.agroal:agroal-api:1.15

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/agroal.narayana.1.15-a31cab82.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/agroal.narayana.1.15-a31cab82.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: agroal.narayana.1.15-a31cab82
+  namespace: test-jvm-namespace
+spec:
+  gav: io.agroal:agroal-narayana:1.15

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/agroal.pool.1.15-b8e7530a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/agroal.pool.1.15-b8e7530a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: agroal.pool.1.15-b8e7530a
+  namespace: test-jvm-namespace
+spec:
+  gav: io.agroal:agroal-pool:1.15

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.config.definitions.0.1.10.final-967c55df.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.config.definitions.0.1.10.final-967c55df.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.app.components.config.definitions.0.1.10.final-967c55df
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-app-components-config-definitions:0.1.10.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.config.impl.0.1.10.final-b7354bb6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.config.impl.0.1.10.final-b7354bb6.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.app.components.config.impl.0.1.10.final-b7354bb6
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-app-components-config-impl:0.1.10.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.config.index.0.1.10.final-ec27b160.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.config.index.0.1.10.final-ec27b160.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.app.components.config.index.0.1.10.final-ec27b160
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-app-components-config-index:0.1.10.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.core.0.1.10.final-e239ac48.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.core.0.1.10.final-e239ac48.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.app.components.core.0.1.10.final-e239ac48
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-app-components-core:0.1.10.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.logging.0.1.10.final-99eb95e1.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.app.components.logging.0.1.10.final-99eb95e1.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.app.components.logging.0.1.10.final-99eb95e1
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-app-components-logging:0.1.10.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.rest.client.common.0.1.11.final-0c7a4a97.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.rest.client.common.0.1.11.final-0c7a4a97.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.rest.client.common.0.1.11.final-0c7a4a97
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-rest-client-common:0.1.11.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.rest.client.jdk.0.1.11.final-e83c8cfd.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.common.rest.client.jdk.0.1.11.final-e83c8cfd.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.common.rest.client.jdk.0.1.11.final-e83c8cfd
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-common-rest-client-jdk:0.1.11.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.data.models.1.1.26-e82d94b2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/apicurio.data.models.1.1.26-e82d94b2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: apicurio.data.models.1.1.26-e82d94b2
+  namespace: test-jvm-namespace
+spec:
+  gav: io.apicurio:apicurio-data-models:1.1.26

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/arc.2.7.6.final-0e5b11a4.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/arc.2.7.6.final-0e5b11a4.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: arc.2.7.6.final-0e5b11a4
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus.arc:arc:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/asyncutil.0.1.0-5a8117df.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/asyncutil.0.1.0-5a8117df.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: asyncutil.0.1.0-5a8117df
+  namespace: test-jvm-namespace
+spec:
+  gav: com.ibm.async:asyncutil:0.1.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/auto.common.0.10-abb1f5d9.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/auto.common.0.10-abb1f5d9.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-85a56b4f3bbcfcabd713: b430445f7ab85d39f5e95d2699bcec4a
+  name: auto.common.0.10-abb1f5d9
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.auto:auto-common:0.10

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/auto.common.1.1.2-10d304c0.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/auto.common.1.1.2-10d304c0.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-39f49b5914b6e02e3597: bda2be2b23d206868f57e9238d1f4c32
+  name: auto.common.1.1.2-10d304c0
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.auto:auto-common:1.1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/auto.service.annotations.1.0.rc6-2192b10a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/auto.service.annotations.1.0.rc6-2192b10a.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-54792278f39fab30462e: bda2be2b23d206868f57e9238d1f4c32
+  name: auto.service.annotations.1.0.rc6-2192b10a
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.auto.service:auto-service-annotations:1.0-rc6

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/avro.1.11.0-bd2e6743.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/avro.1.11.0-bd2e6743.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: avro.1.11.0-bd2e6743
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.avro:avro:1.11.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.codec.1.15-18bdc8a6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.codec.1.15-18bdc8a6.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.codec.1.15-18bdc8a6
+  namespace: test-jvm-namespace
+spec:
+  gav: commons-codec:commons-codec:1.15

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.compress.1.21-b219faec.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.compress.1.21-b219faec.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.compress.1.21-b219faec
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.commons:commons-compress:1.21

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.digester.2.1-0dd46fe9.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.digester.2.1-0dd46fe9.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.digester.2.1-0dd46fe9
+  namespace: test-jvm-namespace
+spec:
+  gav: commons-digester:commons-digester:2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.lang3.3.12.0-5cb11d87.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.lang3.3.12.0-5cb11d87.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.lang3.3.12.0-5cb11d87
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.commons:commons-lang3:3.12.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.lang3.3.5-0612ad3b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.lang3.3.5-0612ad3b.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-e26f2955830ae268e2b0: bf3faa469efdd1de517438465de5200e
+  name: commons.lang3.3.5-0612ad3b
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.commons:commons-lang3:3.5

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.lang3.3.7-bb1a5b7a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.lang3.3.7-bb1a5b7a.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-67ece1a5738c01f0bec8: bf3faa469efdd1de517438465de5200e
+  name: commons.lang3.3.7-bb1a5b7a
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.commons:commons-lang3:3.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.logging.1.2-472adc7d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.logging.1.2-472adc7d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.logging.1.2-472adc7d
+  namespace: test-jvm-namespace
+spec:
+  gav: commons-logging:commons-logging:1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.logging.jboss.logging.1.0.0.final-f1da8869.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.logging.jboss.logging.1.0.0.final-f1da8869.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.logging.jboss.logging.1.0.0.final-f1da8869
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.logging:commons-logging-jboss-logging:1.0.0.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/commons.validator.1.7-ddbc54b6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/commons.validator.1.7-ddbc54b6.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.validator.1.7-ddbc54b6
+  namespace: test-jvm-namespace
+spec:
+  gav: commons-validator:commons-validator:1.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/cron.utils.9.1.6-3f0912c3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/cron.utils.9.1.6-3f0912c3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: cron.utils.9.1.6-3f0912c3
+  namespace: test-jvm-namespace
+spec:
+  gav: com.cronutils:cron-utils:9.1.6

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/escapevelocity.0.9.1-3877018e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/escapevelocity.0.9.1-3877018e.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-46c82d77b75c9402bc3e: b430445f7ab85d39f5e95d2699bcec4a
+  name: escapevelocity.0.9.1-3877018e
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.escapevelocity:escapevelocity:0.9.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/failureaccess.1.0.1-b93c7202.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/failureaccess.1.0.1-b93c7202.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-acce4f2a927779953ad3: bda2be2b23d206868f57e9238d1f4c32
+  name: failureaccess.1.0.1-b93c7202
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.guava:failureaccess:1.0.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/graphql.java.18.1-c97ac593.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/graphql.java.18.1-c97ac593.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: graphql.java.18.1-c97ac593
+  namespace: test-jvm-namespace
+spec:
+  gav: com.graphql-java:graphql-java:18.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/guava.28.1.jre-f987bbea.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/guava.28.1.jre-f987bbea.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-1a7389767c26e1a28d96: b430445f7ab85d39f5e95d2699bcec4a
+  name: guava.28.1.jre-f987bbea
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.guava:guava:28.1-jre

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/guava.30.1.1.jre-8e2b3569.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/guava.30.1.1.jre-8e2b3569.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: guava.30.1.1.jre-8e2b3569
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.guava:guava:30.1.1-jre

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/guava.30.1.jre-cb6f8ca6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/guava.30.1.jre-cb6f8ca6.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-7b1fc87d0165b65a2df5: bda2be2b23d206868f57e9238d1f4c32
+  name: guava.30.1.jre-cb6f8ca6
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.guava:guava:30.1-jre

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/guava.31.0.1.jre-a84ebac6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/guava.31.0.1.jre-a84ebac6.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-755398b25e96ca88e0cf: 90fe38e227d2b8fae737ddd769cfdbb2
+  name: guava.31.0.1.jre-a84ebac6
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.guava:guava:31.0.1-jre

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/h2.1.4.197-d877ee5d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/h2.1.4.197-d877ee5d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: h2.1.4.197-d877ee5d
+  namespace: test-jvm-namespace
+spec:
+  gav: com.h2database:h2:1.4.197

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/handy.uri.templates.2.1.8-5e13a894.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/handy.uri.templates.2.1.8-5e13a894.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: handy.uri.templates.2.1.8-5e13a894
+  namespace: test-jvm-namespace
+spec:
+  gav: com.damnhandy:handy-uri-templates:2.1.8

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/hdrhistogram.2.1.12-2b52bf16.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/hdrhistogram.2.1.12-2b52bf16.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: hdrhistogram.2.1.12-2b52bf16
+  namespace: test-jvm-namespace
+spec:
+  gav: org.hdrhistogram:HdrHistogram:2.1.12

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/j2objc.annotations.1.3-dfb172c2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/j2objc.annotations.1.3-dfb172c2.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-717ae675bf155feb3ee6: b430445f7ab85d39f5e95d2699bcec4a
+  name: j2objc.annotations.1.3-dfb172c2
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.j2objc:j2objc-annotations:1.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.annotations.2.13.3-745a8e63.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.annotations.2.13.3-745a8e63.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.annotations.2.13.3-745a8e63
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.core:jackson-annotations:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.core.2.13.3-f6af404a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.core.2.13.3-f6af404a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.core.2.13.3-f6af404a
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.core:jackson-core:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.databind.2.13.3-dd3c0418.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.databind.2.13.3-dd3c0418.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.databind.2.13.3-dd3c0418
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.core:jackson-databind:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.dataformat.yaml.2.12.5-363d48b2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.dataformat.yaml.2.12.5-363d48b2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.dataformat.yaml.2.12.5-363d48b2
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.datatype.jdk8.2.13.3-64ee29a8.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.datatype.jdk8.2.13.3-64ee29a8.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.datatype.jdk8.2.13.3-64ee29a8
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.datatype.json.org.2.13.0-a78cbf34.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.datatype.json.org.2.13.0-a78cbf34.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.datatype.json.org.2.13.0-a78cbf34
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.13.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.datatype.jsr310.2.13.3-ccf4abee.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.datatype.jsr310.2.13.3-ccf4abee.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.datatype.jsr310.2.13.3-ccf4abee
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.jaxrs.base.2.13.3-4c3e7985.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.jaxrs.base.2.13.3-4c3e7985.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.jaxrs.base.2.13.3-4c3e7985
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.jaxrs.json.provider.2.13.3-cb79dc95.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.jaxrs.json.provider.2.13.3-cb79dc95.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.jaxrs.json.provider.2.13.3-cb79dc95
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.module.parameter.names.2.13.3-13a1e9ce.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jackson.module.parameter.names.2.13.3-13a1e9ce.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.module.parameter.names.2.13.3-13a1e9ce
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.activation.1.2.1-3d9b65b0.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.activation.1.2.1-3d9b65b0.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.activation.1.2.1-3d9b65b0
+  namespace: test-jvm-namespace
+spec:
+  gav: com.sun.activation:jakarta.activation:1.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.activation.api.1.2.1-1f4b3064.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.activation.api.1.2.1-1f4b3064.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.activation.api.1.2.1-1f4b3064
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.activation:jakarta.activation-api:1.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.annotation.api.1.3.5-adb3e708.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.annotation.api.1.3.5-adb3e708.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.annotation.api.1.3.5-adb3e708
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.annotation:jakarta.annotation-api:1.3.5

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.el.3.0.4-eafd518d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.el.3.0.4-eafd518d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.el.3.0.4-eafd518d
+  namespace: test-jvm-namespace
+spec:
+  gav: org.glassfish:jakarta.el:3.0.4

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.el.api.3.0.3-bc8638bb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.el.api.3.0.3-bc8638bb.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.el.api.3.0.3-bc8638bb
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.el:jakarta.el-api:3.0.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.interceptor.api.1.2.5-35dee32a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.interceptor.api.1.2.5-35dee32a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.interceptor.api.1.2.5-35dee32a
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.interceptor:jakarta.interceptor-api:1.2.5

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.json.1.1.6-cb9496eb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.json.1.1.6-cb9496eb.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.json.1.1.6-cb9496eb
+  namespace: test-jvm-namespace
+spec:
+  gav: org.glassfish:jakarta.json:1.1.6

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.servlet.api.4.0.3-2428061e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.servlet.api.4.0.3-2428061e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.servlet.api.4.0.3-2428061e
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.servlet:jakarta.servlet-api:4.0.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.transaction.api.1.3.3-4ce6f0f3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.transaction.api.1.3.3-4ce6f0f3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.transaction.api.1.3.3-4ce6f0f3
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.transaction:jakarta.transaction-api:1.3.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.validation.api.2.0.2-c300c592.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jakarta.validation.api.2.0.2-c300c592.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.validation.api.2.0.2-c300c592
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.validation:jakarta.validation-api:2.0.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/java.dataloader.3.1.2-52c4f915.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/java.dataloader.3.1.2-52c4f915.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: java.dataloader.3.1.2-52c4f915
+  namespace: test-jvm-namespace
+spec:
+  gav: com.graphql-java:java-dataloader:3.1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/java.diff.utils.4.0-abdc468a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/java.diff.utils.4.0-abdc468a.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-41aa1d19a12d310f3071: bda2be2b23d206868f57e9238d1f4c32
+  name: java.diff.utils.4.0-abdc468a
+  namespace: test-jvm-namespace
+spec:
+  gav: io.github.java-diff-utils:java-diff-utils:4.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/javapoet.1.11.1-348811ed.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/javapoet.1.11.1-348811ed.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-93dff80963e75a56b1ec: b430445f7ab85d39f5e95d2699bcec4a
+  name: javapoet.1.11.1-348811ed
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup:javapoet:1.11.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/javapoet.1.13.0-08e8339f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/javapoet.1.13.0-08e8339f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: javapoet.1.13.0-08e8339f
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup:javapoet:1.13.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/javassist.3.27.0.ga-5df186e8.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/javassist.3.27.0.ga-5df186e8.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: javassist.3.27.0.ga-5df186e8
+  namespace: test-jvm-namespace
+spec:
+  gav: org.javassist:javassist:3.27.0-GA

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.connector.api.1.7.spec.1.0.0.final-c2214343.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.connector.api.1.7.spec.1.0.0.final-c2214343.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.connector.api.1.7.spec.1.0.0.final-c2214343
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec:1.0.0.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.jaxb.api.2.3.spec.2.0.0.final-0eccd2d7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.jaxb.api.2.3.spec.2.0.0.final-0eccd2d7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.jaxb.api.2.3.spec.2.0.0.final-0eccd2d7
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec:2.0.0.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.jaxrs.api.2.1.spec.2.0.1.final-09d98d1e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.jaxrs.api.2.1.spec.2.0.1.final-09d98d1e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.jaxrs.api.2.1.spec.2.0.1.final-09d98d1e
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:2.0.1.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.logging.3.4.3.final-c6139dd5.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.logging.3.4.3.final-c6139dd5.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.logging.3.4.3.final-c6139dd5
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.logging:jboss-logging:3.4.3.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.logging.annotations.2.2.1.final-ff6d88ad.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.logging.annotations.2.2.1.final-ff6d88ad.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.logging.annotations.2.2.1.final-ff6d88ad
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.logging:jboss-logging-annotations:2.2.1.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.logmanager.embedded.1.0.9-61829eab.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.logmanager.embedded.1.0.9-61829eab.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.logmanager.embedded.1.0.9-61829eab
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.logmanager:jboss-logmanager-embedded:1.0.9

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.threads.3.4.2.final-c4f6ef0d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jboss.threads.3.4.2.final-c4f6ef0d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.threads.3.4.2.final-c4f6ef0d
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.threads:jboss-threads:3.4.2.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jctools.core.3.1.0-ac68cb2e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jctools.core.3.1.0-ac68cb2e.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-9305f643106be0fa9fb2: d1f3a6d34e891ddc731c33f45f8e05de
+  name: jctools.core.3.1.0-ac68cb2e
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jctools:jctools-core:3.1.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jimfs.1.1-fd8084ba.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jimfs.1.1-fd8084ba.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jimfs.1.1-fd8084ba
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.jimfs:jimfs:1.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/joda.time.2.10.2-bd07a427.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/joda.time.2.10.2-bd07a427.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: joda.time.2.10.2-bd07a427
+  namespace: test-jvm-namespace
+spec:
+  gav: joda-time:joda-time:2.10.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/jose4j.0.7.9-7a1e3d28.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/jose4j.0.7.9-7a1e3d28.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jose4j.0.7.9-7a1e3d28
+  namespace: test-jvm-namespace
+spec:
+  gav: org.bitbucket.b_c:jose4j:0.7.9

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/json.20220320-1e3bd061.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/json.20220320-1e3bd061.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: json.20220320-1e3bd061
+  namespace: test-jvm-namespace
+spec:
+  gav: org.json:json:20220320

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/latencyutils.2.0.3-1e83f839.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/latencyutils.2.0.3-1e83f839.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: latencyutils.2.0.3-1e83f839
+  namespace: test-jvm-namespace
+spec:
+  gav: org.latencyutils:LatencyUtils:2.0.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.config.api.2.0.1-b7693820.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.config.api.2.0.1-b7693820.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: microprofile.config.api.2.0.1-b7693820
+  namespace: test-jvm-namespace
+spec:
+  gav: org.eclipse.microprofile.config:microprofile-config-api:2.0.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.context.propagation.api.1.2-811e0872.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.context.propagation.api.1.2-811e0872.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: microprofile.context.propagation.api.1.2-811e0872
+  namespace: test-jvm-namespace
+spec:
+  gav: org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.fault.tolerance.api.3.0-8aa745ae.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.fault.tolerance.api.3.0-8aa745ae.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: microprofile.fault.tolerance.api.3.0-8aa745ae
+  namespace: test-jvm-namespace
+spec:
+  gav: org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.health.api.3.1-1ea02145.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.health.api.3.1-1ea02145.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: microprofile.health.api.3.1-1ea02145
+  namespace: test-jvm-namespace
+spec:
+  gav: org.eclipse.microprofile.health:microprofile-health-api:3.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.jwt.auth.api.1.2-b9ad6e80.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.jwt.auth.api.1.2-b9ad6e80.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: microprofile.jwt.auth.api.1.2-b9ad6e80
+  namespace: test-jvm-namespace
+spec:
+  gav: org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.metrics.api.3.0.1-d50347d0.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/microprofile.metrics.api.3.0.1-d50347d0.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: microprofile.metrics.api.3.0.1-d50347d0
+  namespace: test-jvm-namespace
+spec:
+  gav: org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/mutiny.1.4.0-0df3b02c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/mutiny.1.4.0-0df3b02c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: mutiny.1.4.0-0df3b02c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:mutiny:1.4.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/mutiny.smallrye.context.propagation.1.4.0-f5dbeb01.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/mutiny.smallrye.context.propagation.1.4.0-f5dbeb01.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: mutiny.smallrye.context.propagation.1.4.0-f5dbeb01
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:mutiny-smallrye-context-propagation:1.4.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/netty.tcnative.classes.2.0.48.final-473f8e9f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/netty.tcnative.classes.2.0.48.final-473f8e9f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.tcnative.classes.2.0.48.final-473f8e9f
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-tcnative-classes:2.0.48.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/org.everit.json.schema.1.14.1-73829fe3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/org.everit.json.schema.1.14.1-73829fe3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: org.everit.json.schema.1.14.1-73829fe3
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.everit-org.json-schema:org.everit.json.schema:1.14.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/paranamer.2.8-6c4dcb59.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/paranamer.2.8-6c4dcb59.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-8a2e33a871254b162b38: 71c8ff5d09f2242b3c9e76a075aeb94b
+  name: paranamer.2.8-6c4dcb59
+  namespace: test-jvm-namespace
+spec:
+  gav: com.thoughtworks.paranamer:paranamer:2.8

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/pcollections.2.1.2-b4fb28cd.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/pcollections.2.1.2-b4fb28cd.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-7ac3ebc1254ec96c0b17: bda2be2b23d206868f57e9238d1f4c32
+  name: pcollections.2.1.2-b4fb28cd
+  namespace: test-jvm-namespace
+spec:
+  gav: org.pcollections:pcollections:2.1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/proto.google.common.protos.2.8.3-2f82f595.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/proto.google.common.protos.2.8.3-2f82f595.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: proto.google.common.protos.2.8.3-2f82f595
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.api.grpc:proto-google-common-protos:2.8.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.agroal.2.7.6.final-5f15cdd3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.agroal.2.7.6.final-5f15cdd3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.agroal.2.7.6.final-5f15cdd3
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-agroal:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.arc.2.7.6.final-e9cc5bc8.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.arc.2.7.6.final-e9cc5bc8.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.arc.2.7.6.final-e9cc5bc8
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-arc:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.bootstrap.runner.2.7.6.final-174caa7a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.bootstrap.runner.2.7.6.final-174caa7a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.bootstrap.runner.2.7.6.final-174caa7a
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-bootstrap-runner:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.core.2.7.6.final-6e817c70.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.core.2.7.6.final-6e817c70.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.core.2.7.6.final-6e817c70
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-core:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.credentials.2.7.6.final-5c1d4daf.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.credentials.2.7.6.final-5c1d4daf.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.credentials.2.7.6.final-5c1d4daf
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-credentials:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.datasource.2.7.6.final-6c171bc5.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.datasource.2.7.6.final-6c171bc5.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.datasource.2.7.6.final-6c171bc5
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-datasource:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.datasource.common.2.7.6.final-05c11e79.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.datasource.common.2.7.6.final-05c11e79.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.datasource.common.2.7.6.final-05c11e79
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-datasource-common:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.development.mode.spi.2.7.6.final-78d605ce.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.development.mode.spi.2.7.6.final-78d605ce.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.development.mode.spi.2.7.6.final-78d605ce
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-development-mode-spi:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.fs.util.0.0.9-161748c9.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.fs.util.0.0.9-161748c9.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.fs.util.0.0.9-161748c9
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-fs-util:0.0.9

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.core.4.1.7-0620c0a1.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.core.4.1.7-0620c0a1.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.http.core.4.1.7-0620c0a1
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus.http:quarkus-http-core:4.1.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.http.core.4.1.7-ca362385.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.http.core.4.1.7-ca362385.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.http.http.core.4.1.7-ca362385
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus.http:quarkus-http-http-core:4.1.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.servlet.4.1.7-21130ca7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.servlet.4.1.7-21130ca7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.http.servlet.4.1.7-21130ca7
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus.http:quarkus-http-servlet:4.1.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.vertx.backend.4.1.7-692ddc05.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.http.vertx.backend.4.1.7-692ddc05.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.http.vertx.backend.4.1.7-692ddc05
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus.http:quarkus-http-vertx-backend:4.1.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.jdbc.h2.2.7.6.final-a9bd0433.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.jdbc.h2.2.7.6.final-a9bd0433.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.jdbc.h2.2.7.6.final-a9bd0433
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-jdbc-h2:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.micrometer.2.7.6.final-7648ce7e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.micrometer.2.7.6.final-7648ce7e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.micrometer.2.7.6.final-7648ce7e
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-micrometer:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.mutiny.2.7.6.final-6a40ffeb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.mutiny.2.7.6.final-6a40ffeb.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.mutiny.2.7.6.final-6a40ffeb
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-mutiny:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.narayana.jta.2.7.6.final-85c96031.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.narayana.jta.2.7.6.final-85c96031.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.narayana.jta.2.7.6.final-85c96031
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-narayana-jta:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.netty.2.7.6.final-91434430.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.netty.2.7.6.final-91434430.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.netty.2.7.6.final-91434430
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-netty:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.oidc.2.7.6.final-00ec0c9c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.oidc.2.7.6.final-00ec0c9c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.oidc.2.7.6.final-00ec0c9c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-oidc:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.oidc.common.2.7.6.final-906a2622.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.oidc.common.2.7.6.final-906a2622.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.oidc.common.2.7.6.final-906a2622
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-oidc-common:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.resteasy.2.7.6.final-3e68caac.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.resteasy.2.7.6.final-3e68caac.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.resteasy.2.7.6.final-3e68caac
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-resteasy:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.resteasy.common.2.7.6.final-362cdd1d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.resteasy.common.2.7.6.final-362cdd1d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.resteasy.common.2.7.6.final-362cdd1d
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-resteasy-common:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.resteasy.server.common.2.7.6.final-fad44218.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.resteasy.server.common.2.7.6.final-fad44218.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.resteasy.server.common.2.7.6.final-fad44218
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-resteasy-server-common:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.scheduler.2.7.6.final-5ddd1a05.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.scheduler.2.7.6.final-5ddd1a05.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.scheduler.2.7.6.final-5ddd1a05
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-scheduler:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.security.1.1.4.final-4e861fa7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.security.1.1.4.final-4e861fa7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.security.1.1.4.final-4e861fa7
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus.security:quarkus-security:1.1.4.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.security.2.7.6.final-92ca05e3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.security.2.7.6.final-92ca05e3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.security.2.7.6.final-92ca05e3
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-security:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.security.runtime.spi.2.7.6.final-5db7403f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.security.runtime.spi.2.7.6.final-5db7403f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.security.runtime.spi.2.7.6.final-5db7403f
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-security-runtime-spi:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.smallrye.context.propagation.2.7.6.final-f532094c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.smallrye.context.propagation.2.7.6.final-f532094c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.smallrye.context.propagation.2.7.6.final-f532094c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-smallrye-context-propagation:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.smallrye.fault.tolerance.2.7.6.final-407756dd.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.smallrye.fault.tolerance.2.7.6.final-407756dd.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.smallrye.fault.tolerance.2.7.6.final-407756dd
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-smallrye-fault-tolerance:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.smallrye.health.2.7.6.final-03aefae2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.smallrye.health.2.7.6.final-03aefae2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.smallrye.health.2.7.6.final-03aefae2
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-smallrye-health:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.undertow.2.7.6.final-ebed49da.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.undertow.2.7.6.final-ebed49da.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.undertow.2.7.6.final-ebed49da
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-undertow:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.vertx.2.7.6.final-34f3e569.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.vertx.2.7.6.final-34f3e569.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.vertx.2.7.6.final-34f3e569
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-vertx:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.vertx.http.2.7.6.final-acb06099.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.vertx.http.2.7.6.final-acb06099.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.vertx.http.2.7.6.final-acb06099
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-vertx-http:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.vertx.http.dev.console.runtime.spi.2.7.6.final-71a25444.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/quarkus.vertx.http.dev.console.runtime.spi.2.7.6.final-71a25444.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.vertx.http.dev.console.runtime.spi.2.7.6.final-71a25444
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-vertx-http-dev-console-runtime-spi:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/reactive.streams.1.0.3-dbfd9932.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/reactive.streams.1.0.3-dbfd9932.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: reactive.streams.1.0.3-dbfd9932
+  namespace: test-jvm-namespace
+spec:
+  gav: org.reactivestreams:reactive-streams:1.0.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/resteasy.core.4.7.5.final-8b4d26a2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/resteasy.core.4.7.5.final-8b4d26a2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: resteasy.core.4.7.5.final-8b4d26a2
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.resteasy:resteasy-core:4.7.5.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/resteasy.core.spi.4.7.5.final-707c5142.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/resteasy.core.spi.4.7.5.final-707c5142.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: resteasy.core.spi.4.7.5.final-707c5142
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.resteasy:resteasy-core-spi:4.7.5.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/resteasy.jackson2.provider.4.7.5.final-bc59295b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/resteasy.jackson2.provider.4.7.5.final-bc59295b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: resteasy.jackson2.provider.4.7.5.final-bc59295b
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.resteasy:resteasy-jackson2-provider:4.7.5.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/sentry.1.7.30-d3d604c7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/sentry.1.7.30-d3d604c7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: sentry.1.7.30-d3d604c7
+  namespace: test-jvm-namespace
+spec:
+  gav: io.sentry:sentry:1.7.30

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.0.12.0-124ca427.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.0.12.0-124ca427.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: simpleclient.0.12.0-124ca427
+  namespace: test-jvm-namespace
+spec:
+  gav: io.prometheus:simpleclient:0.12.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.common.0.12.0-3d69fde7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.common.0.12.0-3d69fde7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: simpleclient.common.0.12.0-3d69fde7
+  namespace: test-jvm-namespace
+spec:
+  gav: io.prometheus:simpleclient_common:0.12.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.tracer.common.0.12.0-f3a8c55c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.tracer.common.0.12.0-f3a8c55c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: simpleclient.tracer.common.0.12.0-f3a8c55c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.prometheus:simpleclient_tracer_common:0.12.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.tracer.otel.0.12.0-b422a986.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.tracer.otel.0.12.0-b422a986.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: simpleclient.tracer.otel.0.12.0-b422a986
+  namespace: test-jvm-namespace
+spec:
+  gav: io.prometheus:simpleclient_tracer_otel:0.12.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.tracer.otel.agent.0.12.0-f36348cd.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/simpleclient.tracer.otel.agent.0.12.0-f36348cd.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: simpleclient.tracer.otel.agent.0.12.0-f36348cd
+  namespace: test-jvm-namespace
+spec:
+  gav: io.prometheus:simpleclient_tracer_otel_agent:0.12.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/slf4j.api.1.7.33-2c084403.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/slf4j.api.1.7.33-2c084403.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: slf4j.api.1.7.33-2c084403
+  namespace: test-jvm-namespace
+spec:
+  gav: org.slf4j:slf4j-api:1.7.33

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/slf4j.jboss.logmanager.1.1.0.final-5d9bd2b8.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/slf4j.jboss.logmanager.1.1.0.final-5d9bd2b8.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: slf4j.jboss.logmanager.1.1.0.final-5d9bd2b8
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.slf4j:slf4j-jboss-logmanager:1.1.0.Final

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.annotation.1.10.0-7aaf538b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.annotation.1.10.0-7aaf538b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.annotation.1.10.0-7aaf538b
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-annotation:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.classloader.1.10.0-cb1cce25.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.classloader.1.10.0-cb1cce25.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.classloader.1.10.0-cb1cce25
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-classloader:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.constraint.1.10.0-32f02777.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.constraint.1.10.0-32f02777.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.constraint.1.10.0-32f02777
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-constraint:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.expression.1.10.0-fb989506.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.expression.1.10.0-fb989506.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.expression.1.10.0-fb989506
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-expression:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.function.1.10.0-619f793d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.function.1.10.0-619f793d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.function.1.10.0-619f793d
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-function:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.io.1.10.0-9fbad59e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.io.1.10.0-9fbad59e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.io.1.10.0-9fbad59e
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-io:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.vertx.context.1.10.0-60f221eb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.common.vertx.context.1.10.0-60f221eb.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.common.vertx.context.1.10.0-60f221eb
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.common:smallrye-common-vertx-context:1.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.config.2.9.2-e83a7103.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.config.2.9.2-e83a7103.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.config.2.9.2-e83a7103
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.config:smallrye-config:2.9.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.config.common.2.9.2-688371d8.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.config.common.2.9.2-688371d8.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.config.common.2.9.2-688371d8
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.config:smallrye-config-common:2.9.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.config.core.2.9.2-b6e855bc.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.config.core.2.9.2-b6e855bc.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.config.core.2.9.2-b6e855bc
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.config:smallrye-config-core:2.9.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.1.2.2-5263ebe7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.1.2.2-5263ebe7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.context.propagation.1.2.2-5263ebe7
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-context-propagation:1.2.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.api.1.2.2-35842b0f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.api.1.2.2-35842b0f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.context.propagation.api.1.2.2-35842b0f
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-context-propagation-api:1.2.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.jta.1.2.2-6660dcb7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.jta.1.2.2-6660dcb7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.context.propagation.jta.1.2.2-6660dcb7
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-context-propagation-jta:1.2.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.storage.1.2.2-9881e00d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.context.propagation.storage.1.2.2-9881e00d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.context.propagation.storage.1.2.2-9881e00d
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-context-propagation-storage:1.2.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.5.2.1-7f9f5f40.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.5.2.1-7f9f5f40.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.fault.tolerance.5.2.1-7f9f5f40
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-fault-tolerance:5.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.api.5.2.1-5d7bd3da.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.api.5.2.1-5d7bd3da.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.fault.tolerance.api.5.2.1-5d7bd3da
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-fault-tolerance-api:5.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.autoconfig.core.5.2.1-92918345.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.autoconfig.core.5.2.1-92918345.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.fault.tolerance.autoconfig.core.5.2.1-92918345
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-fault-tolerance-autoconfig-core:5.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.context.propagation.5.2.1-9d3b2334.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.context.propagation.5.2.1-9d3b2334.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.fault.tolerance.context.propagation.5.2.1-9d3b2334
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-fault-tolerance-context-propagation:5.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.core.5.2.1-ac88bc98.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.core.5.2.1-ac88bc98.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.fault.tolerance.core.5.2.1-ac88bc98
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-fault-tolerance-core:5.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.vertx.5.2.1-b0f1b194.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.fault.tolerance.vertx.5.2.1-b0f1b194.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.fault.tolerance.vertx.5.2.1-b0f1b194
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-fault-tolerance-vertx:5.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.health.3.1.2-60b4042c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.health.3.1.2-60b4042c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.health.3.1.2-60b4042c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-health:3.1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.health.api.3.1.2-1e3c057e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.health.api.3.1.2-1e3c057e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.health.api.3.1.2-1e3c057e
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-health-api:3.1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.health.provided.checks.3.1.2-90562359.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.health.provided.checks.3.1.2-90562359.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.health.provided.checks.3.1.2-90562359
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-health-provided-checks:3.1.2

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.jwt.3.3.3-65d65630.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.jwt.3.3.3-65d65630.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.jwt.3.3.3-65d65630
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-jwt:3.3.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.jwt.build.3.3.3-17115ce6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.jwt.build.3.3.3-17115ce6.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.jwt.build.3.3.3-17115ce6
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-jwt-build:3.3.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.jwt.common.3.3.3-f04234c3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.jwt.common.3.3.3-f04234c3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.jwt.common.3.3.3-f04234c3
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye:smallrye-jwt-common:3.3.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.auth.common.2.21.0-2ebb38c0.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.auth.common.2.21.0-2ebb38c0.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.auth.common.2.21.0-2ebb38c0
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-auth-common:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.bridge.common.2.21.0-c55bc57f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.bridge.common.2.21.0-c55bc57f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.bridge.common.2.21.0-c55bc57f
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-bridge-common:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.core.2.21.0-2f747d82.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.core.2.21.0-2f747d82.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.core.2.21.0-2f747d82
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-core:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.runtime.2.21.0-1b76159f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.runtime.2.21.0-1b76159f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.runtime.2.21.0-1b76159f
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-runtime:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.web.2.21.0-bd460f89.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.web.2.21.0-bd460f89.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.web.2.21.0-bd460f89
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-web:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.web.client.2.21.0-309f62f0.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.web.client.2.21.0-309f62f0.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.web.client.2.21.0-309f62f0
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-web-client:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.web.common.2.21.0-6394554b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.mutiny.vertx.web.common.2.21.0-6394554b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.mutiny.vertx.web.common.2.21.0-6394554b
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-mutiny-vertx-web-common:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.reactive.converter.api.2.7.0-40a2d27b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.reactive.converter.api.2.7.0-40a2d27b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.reactive.converter.api.2.7.0-40a2d27b
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-reactive-converter-api:2.7.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.reactive.converter.mutiny.2.7.0-b26f427c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/smallrye.reactive.converter.mutiny.2.7.0-b26f427c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: smallrye.reactive.converter.mutiny.2.7.0-b26f427c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:smallrye-reactive-converter-mutiny:2.7.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/snakeyaml.1.30-0a60d869.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/snakeyaml.1.30-0a60d869.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: snakeyaml.1.30-0a60d869
+  namespace: test-jvm-namespace
+spec:
+  gav: org.yaml:snakeyaml:1.30

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/st4.4.3-723b0f6c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/st4.4.3-723b0f6c.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-1493b2d5f7e52735148d: f1ec184d8c48b56f6d9b5b942411d111
+  name: st4.4.3-723b0f6c
+  namespace: test-jvm-namespace
+spec:
+  gav: org.antlr:ST4:4.3

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/stax2.api.4.2.1-e7d0ac5e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/stax2.api.4.2.1-e7d0ac5e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: stax2.api.4.2.1-e7d0ac5e
+  namespace: test-jvm-namespace
+spec:
+  gav: org.codehaus.woodstox:stax2-api:4.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/swiftpoet.1.0.0-ea7a20d2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/swiftpoet.1.0.0-ea7a20d2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: swiftpoet.1.0.0-ea7a20d2
+  namespace: test-jvm-namespace
+spec:
+  gav: io.outfoxx:swiftpoet:1.0.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.auth.common.4.2.7-3d1ee871.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.auth.common.4.2.7-3d1ee871.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.auth.common.4.2.7-3d1ee871
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-auth-common:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.bridge.common.4.2.7-b089e7d6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.bridge.common.4.2.7-b089e7d6.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.bridge.common.4.2.7-b089e7d6
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-bridge-common:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.codegen.4.2.7-d166c52d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.codegen.4.2.7-d166c52d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.codegen.4.2.7-d166c52d
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-codegen:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.core.4.2.7-63a01a18.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.core.4.2.7-63a01a18.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.core.4.2.7-63a01a18
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-core:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.mutiny.generator.2.21.0-1286ca72.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.mutiny.generator.2.21.0-1286ca72.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.mutiny.generator.2.21.0-1286ca72
+  namespace: test-jvm-namespace
+spec:
+  gav: io.smallrye.reactive:vertx-mutiny-generator:2.21.0

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.web.4.2.7-58bed826.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.web.4.2.7-58bed826.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.web.4.2.7-58bed826
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-web:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.web.client.4.2.7-74f39845.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.web.client.4.2.7-74f39845.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.web.client.4.2.7-74f39845
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-web-client:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.web.common.4.2.7-bd6ce4f1.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/vertx.web.common.4.2.7-bd6ce4f1.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: vertx.web.common.4.2.7-bd6ce4f1
+  namespace: test-jvm-namespace
+spec:
+  gav: io.vertx:vertx-web-common:4.2.7

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/wildfly.common.1.5.4.final.format.001-6945a3ad.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/wildfly.common.1.5.4.final.format.001-6945a3ad.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wildfly.common.1.5.4.final.format.001-6945a3ad
+  namespace: test-jvm-namespace
+spec:
+  gav: org.wildfly.common:wildfly-common:1.5.4.Final-format-001

--- a/hack/service-registry-artifacts/ArtifactBuildComplete/xmlsec.3.0.0-ceb06cd9.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildComplete/xmlsec.3.0.0-ceb06cd9.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: xmlsec.3.0.0-ceb06cd9
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.santuario:xmlsec:3.0.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/annotations.13.0-367cdd89.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/annotations.13.0-367cdd89.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: annotations.13.0-367cdd89
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jetbrains:annotations:13.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/antlr.runtime.3.5.2-1007c041.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/antlr.runtime.3.5.2-1007c041.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-bfdb1657e48f1639e7f4: f1ec184d8c48b56f6d9b5b942411d111
+  name: antlr.runtime.3.5.2-1007c041
+  namespace: test-jvm-namespace
+spec:
+  gav: org.antlr:antlr-runtime:3.5.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/antlr4.runtime.4.9.2-3a575097.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/antlr4.runtime.4.9.2-3a575097.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: antlr4.runtime.4.9.2-3a575097
+  namespace: test-jvm-namespace
+spec:
+  gav: org.antlr:antlr4-runtime:4.9.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/asm.9.0-70a244b9.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/asm.9.0-70a244b9.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-000d50421b8dee628642: 71c8ff5d09f2242b3c9e76a075aeb94b
+  name: asm.9.0-70a244b9
+  namespace: test-jvm-namespace
+spec:
+  gav: org.ow2.asm:asm:9.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/auto.value.annotations.1.7-856c90cb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/auto.value.annotations.1.7-856c90cb.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-67b392471e4f38f20230: bda2be2b23d206868f57e9238d1f4c32
+  name: auto.value.annotations.1.7-856c90cb
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.auto.value:auto-value-annotations:1.7

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/btf.1.3-48596fc3.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/btf.1.3-48596fc3.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: btf.1.3-48596fc3
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.java-json-tools:btf:1.3

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/caffeine.2.8.8-19e9f482.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/caffeine.2.8.8-19e9f482.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-9e789852d2530e8f89f1: bda2be2b23d206868f57e9238d1f4c32
+  name: caffeine.2.8.8-19e9f482
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.ben-manes.caffeine:caffeine:2.8.8

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/checker.qual.2.8.1-c385d8a1.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/checker.qual.2.8.1-c385d8a1.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-f8618b797f59ca97bebf: b430445f7ab85d39f5e95d2699bcec4a
+  name: checker.qual.2.8.1-c385d8a1
+  namespace: test-jvm-namespace
+spec:
+  gav: org.checkerframework:checker-qual:2.8.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/checker.qual.3.21.1-d4bf4bfc.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/checker.qual.3.21.1-d4bf4bfc.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: checker.qual.3.21.1-d4bf4bfc
+  namespace: test-jvm-namespace
+spec:
+  gav: org.checkerframework:checker-qual:3.21.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/commons.collections.3.2.2-96cf26d7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/commons.collections.3.2.2-96cf26d7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: commons.collections.3.2.2-96cf26d7
+  namespace: test-jvm-namespace
+spec:
+  gav: commons-collections:commons-collections:3.2.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/connect.api.2.8.1-377e2495.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/connect.api.2.8.1-377e2495.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: connect.api.2.8.1-377e2495
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.kafka:connect-api:2.8.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/connect.json.2.8.1-9ad7898e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/connect.json.2.8.1-9ad7898e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: connect.json.2.8.1-9ad7898e
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.kafka:connect-json:2.8.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/error.prone.annotations.2.10.0-39800540.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/error.prone.annotations.2.10.0-39800540.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: error.prone.annotations.2.10.0-39800540
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.errorprone:error_prone_annotations:2.10.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/incap.0.2-b777f81c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/incap.0.2-b777f81c.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-870c792a170c9de43d52: b430445f7ab85d39f5e95d2699bcec4a
+  name: incap.0.2-b777f81c
+  namespace: test-jvm-namespace
+spec:
+  gav: net.ltgt.gradle.incap:incap:0.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/jackson.module.jaxb.annotations.2.13.3-1a9c459c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/jackson.module.jaxb.annotations.2.13.3-1a9c459c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.module.jaxb.annotations.2.13.3-1a9c459c
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.3

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/jakarta.enterprise.cdi.api.2.0.2-9ada6222.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/jakarta.enterprise.cdi.api.2.0.2-9ada6222.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.enterprise.cdi.api.2.0.2-9ada6222
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/jakarta.inject.api.1.0-e12bfe6b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/jakarta.inject.api.1.0-e12bfe6b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.inject.api.1.0-e12bfe6b
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.inject:jakarta.inject-api:1.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/jakarta.xml.bind.api.2.3.3-042ef329.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/jakarta.xml.bind.api.2.3.3-042ef329.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jakarta.xml.bind.api.2.3.3-042ef329
+  namespace: test-jvm-namespace
+spec:
+  gav: jakarta.xml.bind:jakarta.xml.bind-api:2.3.3

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/jboss.transaction.spi.7.6.0.final-96cab33a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/jboss.transaction.spi.7.6.0.final-96cab33a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jboss.transaction.spi.7.6.0.final-96cab33a
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss:jboss-transaction-spi:7.6.0.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/json.patch.1.13-ec926997.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/json.patch.1.13-ec926997.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: json.patch.1.13-ec926997
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.java-json-tools:json-patch:1.13

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/jts.core.1.15.0-b4781954.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/jts.core.1.15.0-b4781954.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jts.core.1.15.0-b4781954
+  namespace: test-jvm-namespace
+spec:
+  gav: org.locationtech.jts:jts-core:1.15.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kafka.clients.2.8.1-4ef49f38.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kafka.clients.2.8.1-4ef49f38.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kafka.clients.2.8.1-4ef49f38
+  namespace: test-jvm-namespace
+spec:
+  gav: org.apache.kafka:kafka-clients:2.8.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kaml.0.20.0-68495629.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kaml.0.20.0-68495629.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kaml.0.20.0-68495629
+  namespace: test-jvm-namespace
+spec:
+  gav: com.charleskorn.kaml:kaml:0.20.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.reflect.1.6.10-f6020a4a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.reflect.1.6.10-f6020a4a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kotlin.reflect.1.6.10-f6020a4a
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jetbrains.kotlin:kotlin-reflect:1.6.10

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.stdlib.1.6.10-bd125cda.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.stdlib.1.6.10-bd125cda.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kotlin.stdlib.1.6.10-bd125cda
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jetbrains.kotlin:kotlin-stdlib:1.6.10

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.stdlib.jdk7.1.6.10-4358c935.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.stdlib.jdk7.1.6.10-4358c935.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kotlin.stdlib.jdk7.1.6.10-4358c935
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.stdlib.jdk8.1.6.10-a9d5ad47.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kotlin.stdlib.jdk8.1.6.10-a9d5ad47.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kotlin.stdlib.jdk8.1.6.10-a9d5ad47
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kotlinpoet.1.7.2-7dbfdddf.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kotlinpoet.1.7.2-7dbfdddf.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kotlinpoet.1.7.2-7dbfdddf
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup:kotlinpoet:1.7.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/kotlinx.serialization.core.jvm.1.0.1-0188e32c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/kotlinx.serialization.core.jvm.1.0.1-0188e32c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: kotlinx.serialization.core.jvm.1.0.1-0188e32c
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.0.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/lombok.1.18.24-6e480400.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/lombok.1.18.24-6e480400.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: lombok.1.18.24-6e480400
+  namespace: test-jvm-namespace
+spec:
+  gav: org.projectlombok:lombok:1.18.24

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/micrometer.core.1.8.3-017e07c4.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/micrometer.core.1.8.3-017e07c4.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: micrometer.core.1.8.3-017e07c4
+  namespace: test-jvm-namespace
+spec:
+  gav: io.micrometer:micrometer-core:1.8.3

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/micrometer.registry.prometheus.1.8.3-5271e893.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/micrometer.registry.prometheus.1.8.3-5271e893.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: micrometer.registry.prometheus.1.8.3-5271e893
+  namespace: test-jvm-namespace
+spec:
+  gav: io.micrometer:micrometer-registry-prometheus:1.8.3

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/msg.simple.1.2-a2c2bde7.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/msg.simple.1.2-a2c2bde7.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: msg.simple.1.2-a2c2bde7
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.java-json-tools:msg-simple:1.2

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/narayana.jta.5.12.4.final-7aa961a6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/narayana.jta.5.12.4.final-7aa961a6.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: narayana.jta.5.12.4.final-7aa961a6
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.narayana.jta:narayana-jta:5.12.4.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/narayana.jts.integration.5.12.4.final-76a443a8.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/narayana.jts.integration.5.12.4.final-76a443a8.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: narayana.jts.integration.5.12.4.final-76a443a8
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jboss.narayana.jts:narayana-jts-integration:5.12.4.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.buffer.4.1.74.final-35712835.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.buffer.4.1.74.final-35712835.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.buffer.4.1.74.final-35712835
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-buffer:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.4.1.74.final-6f583e41.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.4.1.74.final-6f583e41.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.codec.4.1.74.final-6f583e41
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-codec:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.dns.4.1.74.final-f8dfdba2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.dns.4.1.74.final-f8dfdba2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.codec.dns.4.1.74.final-f8dfdba2
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-codec-dns:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.haproxy.4.1.74.final-2c08ebdb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.haproxy.4.1.74.final-2c08ebdb.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.codec.haproxy.4.1.74.final-2c08ebdb
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-codec-haproxy:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.http.4.1.74.final-4d6098f2.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.http.4.1.74.final-4d6098f2.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.codec.http.4.1.74.final-4d6098f2
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-codec-http:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.http2.4.1.74.final-bda16b51.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.http2.4.1.74.final-bda16b51.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.codec.http2.4.1.74.final-bda16b51
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-codec-http2:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.socks.4.1.74.final-a0adee06.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.codec.socks.4.1.74.final-a0adee06.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.codec.socks.4.1.74.final-a0adee06
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-codec-socks:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.common.4.1.74.final-1a53a167.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.common.4.1.74.final-1a53a167.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.common.4.1.74.final-1a53a167
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-common:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.handler.4.1.74.final-6f29a8b1.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.handler.4.1.74.final-6f29a8b1.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.handler.4.1.74.final-6f29a8b1
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-handler:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.handler.proxy.4.1.74.final-ed3891eb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.handler.proxy.4.1.74.final-ed3891eb.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.handler.proxy.4.1.74.final-ed3891eb
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-handler-proxy:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.resolver.4.1.74.final-2208f32c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.resolver.4.1.74.final-2208f32c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.resolver.4.1.74.final-2208f32c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-resolver:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.resolver.dns.4.1.74.final-7d71a58f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.resolver.dns.4.1.74.final-7d71a58f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.resolver.dns.4.1.74.final-7d71a58f
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-resolver-dns:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/netty.transport.4.1.74.final-a363f12c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/netty.transport.4.1.74.final-a363f12c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: netty.transport.4.1.74.final-a363f12c
+  namespace: test-jvm-namespace
+spec:
+  gav: io.netty:netty-transport:4.1.74.Final

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/okio.2.8.0-5a0dc62e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/okio.2.8.0-5a0dc62e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: okio.2.8.0-5a0dc62e
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.okio:okio:2.8.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/protobuf.java.3.21.1-711e524a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/protobuf.java.3.21.1-711e524a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: protobuf.java.3.21.1-711e524a
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.protobuf:protobuf-java:3.21.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/protobuf.java.3.4.0-7665a7de.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/protobuf.java.3.4.0-7665a7de.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-4e6e4786df17bb0eecc6: bda2be2b23d206868f57e9238d1f4c32
+  name: protobuf.java.3.4.0-7665a7de
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.protobuf:protobuf-java:3.4.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/re2j.1.6-7ce0aa33.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/re2j.1.6-7ce0aa33.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: re2j.1.6-7ce0aa33
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.re2j:re2j:1.6

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/snakeyaml.engine.2.1-2cf31d01.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/snakeyaml.engine.2.1-2cf31d01.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: snakeyaml.engine.2.1-2cf31d01
+  namespace: test-jvm-namespace
+spec:
+  gav: org.snakeyaml:snakeyaml-engine:2.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/software.and.algorithms.1.0-387fd235.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/software.and.algorithms.1.0-387fd235.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-b3fa7d9237af697aaa0b: bda2be2b23d206868f57e9238d1f4c32
+  name: software.and.algorithms.1.0-387fd235
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.kevinstern:software-and-algorithms:1.0

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.compiler.3.7.1-2fe511a5.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.compiler.3.7.1-2fe511a5.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.compiler.3.7.1-2fe511a5
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-compiler:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.grpc.server.generator.3.7.1-675b289e.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.grpc.server.generator.3.7.1-675b289e.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.grpc.server.generator.3.7.1-675b289e
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-grpc-server-generator:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.java.generator.3.7.1-73a0169a.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.java.generator.3.7.1-73a0169a.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.java.generator.3.7.1-73a0169a
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-java-generator:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.kotlin.generator.3.7.1-d0357606.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.kotlin.generator.3.7.1-d0357606.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.kotlin.generator.3.7.1-d0357606
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-kotlin-generator:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.profiles.3.7.1-a3cde84b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.profiles.3.7.1-a3cde84b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.profiles.3.7.1-a3cde84b
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-profiles:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.runtime.3.7.1-1724a2ad.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.runtime.3.7.1-1724a2ad.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.runtime.3.7.1-1724a2ad
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-runtime:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.schema.3.7.1-fd91dc5b.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.schema.3.7.1-fd91dc5b.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.schema.3.7.1-fd91dc5b
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-schema:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/wire.swift.generator.3.7.1-996d5b3d.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/wire.swift.generator.3.7.1-996d5b3d.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wire.swift.generator.3.7.1-996d5b3d
+  namespace: test-jvm-namespace
+spec:
+  gav: com.squareup.wire:wire-swift-generator:3.7.1

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/woodstox.core.6.2.6-f4b5b8a1.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/woodstox.core.6.2.6-f4b5b8a1.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: woodstox.core.6.2.6-f4b5b8a1
+  namespace: test-jvm-namespace
+spec:
+  gav: com.fasterxml.woodstox:woodstox-core:6.2.6

--- a/hack/service-registry-artifacts/ArtifactBuildFailed/zstd.jni.1.4.9.1-00b365de.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildFailed/zstd.jni.1.4.9.1-00b365de.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: zstd.jni.1.4.9.1-00b365de
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.luben:zstd-jni:1.4.9-1

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/antlr.2.7.7-c7e3cad6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/antlr.2.7.7-c7e3cad6.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-61bbcfffa623aa2ba2f4: d5e0d034a4d0acec36eb48156d21521a
+  name: antlr.2.7.7-c7e3cad6
+  namespace: test-jvm-namespace
+spec:
+  gav: antlr:antlr:2.7.7

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/graal.sdk.21.3.2-c752d42c.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/graal.sdk.21.3.2-c752d42c.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: graal.sdk.21.3.2-c752d42c
+  namespace: test-jvm-namespace
+spec:
+  gav: org.graalvm.sdk:graal-sdk:21.3.2

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/icu4j.71.1-f226f02f.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/icu4j.71.1-f226f02f.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: icu4j.71.1-f226f02f
+  namespace: test-jvm-namespace
+spec:
+  gav: com.ibm.icu:icu4j:71.1

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/isorelax.20090621-05e0ec30.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/isorelax.20090621-05e0ec30.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-689addfbba569e0a96e4: 1ba645360e9136d45fe15e3d63a721de
+  name: isorelax.20090621-05e0ec30
+  namespace: test-jvm-namespace
+spec:
+  gav: com.sun.xml.bind.jaxb:isorelax:20090621

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/jackson.coreutils.2.0-99503031.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/jackson.coreutils.2.0-99503031.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: jackson.coreutils.2.0-99503031
+  namespace: test-jvm-namespace
+spec:
+  gav: com.github.java-json-tools:jackson-coreutils:2.0

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/javax.json.1.0.4-f1236455.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/javax.json.1.0.4-f1236455.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-9621166bc4f193822257: f1ec184d8c48b56f6d9b5b942411d111
+  name: javax.json.1.0.4-f1236455
+  namespace: test-jvm-namespace
+spec:
+  gav: org.glassfish:javax.json:1.0.4

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/jdom2.2.0.6-e0b28b33.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/jdom2.2.0.6-e0b28b33.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-be6e6a22de5231a69b93: bf3faa469efdd1de517438465de5200e
+  name: jdom2.2.0.6-e0b28b33
+  namespace: test-jvm-namespace
+spec:
+  gav: org.jdom:jdom2:2.0.6

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/json.simple.1.1.1-e46028fd.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/json.simple.1.1.1-e46028fd.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-ab892a89a8309b363fcf: bf3faa469efdd1de517438465de5200e
+  name: json.simple.1.1.1-e46028fd
+  namespace: test-jvm-namespace
+spec:
+  gav: com.googlecode.json-simple:json-simple:1.1.1

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/jsr305.3.0.0-a51b0170.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/jsr305.3.0.0-a51b0170.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-2d1b031a2a86f2a36cb2: bda2be2b23d206868f57e9238d1f4c32
+  name: jsr305.3.0.0-a51b0170
+  namespace: test-jvm-namespace
+spec:
+  gav: com.google.code.findbugs:jsr305:3.0.0

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/lz4.java.1.8.0-ce136a71.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/lz4.java.1.8.0-ce136a71.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: lz4.java.1.8.0-ce136a71
+  namespace: test-jvm-namespace
+spec:
+  gav: org.lz4:lz4-java:1.8.0

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/msv.core.2013.6.1-7719b089.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/msv.core.2013.6.1-7719b089.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-591fe2b03c0c7b42b099: 1ba645360e9136d45fe15e3d63a721de
+  name: msv.core.2013.6.1-7719b089
+  namespace: test-jvm-namespace
+spec:
+  gav: net.java.dev.msv:msv-core:2013.6.1

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/org.abego.treelayout.core.1.0.3-11b33e04.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/org.abego.treelayout.core.1.0.3-11b33e04.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-e55b65c7b92ab964f58a: f1ec184d8c48b56f6d9b5b942411d111
+  name: org.abego.treelayout.core.1.0.3-11b33e04
+  namespace: test-jvm-namespace
+spec:
+  gav: org.abego.treelayout:org.abego.treelayout.core:1.0.3

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/quarkus.jackson.2.7.6.final-d14d9635.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/quarkus.jackson.2.7.6.final-d14d9635.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: quarkus.jackson.2.7.6.final-d14d9635
+  namespace: test-jvm-namespace
+spec:
+  gav: io.quarkus:quarkus-jackson:2.7.6.Final

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/relaxngdatatype.20020414-b5186432.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/relaxngdatatype.20020414-b5186432.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-0166c08ae10a810facc2: 1ba645360e9136d45fe15e3d63a721de
+  name: relaxngdatatype.20020414-b5186432
+  namespace: test-jvm-namespace
+spec:
+  gav: relaxngDatatype:relaxngDatatype:20020414

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/snappy.java.1.1.8.4-be22d572.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/snappy.java.1.1.8.4-be22d572.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: snappy.java.1.1.8.4-be22d572
+  namespace: test-jvm-namespace
+spec:
+  gav: org.xerial.snappy:snappy-java:1.1.8.4

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/st4.4.0.8-73098598.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/st4.4.0.8-73098598.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-b02a798181e60b3f5eca: d5e0d034a4d0acec36eb48156d21521a
+  name: st4.4.0.8-73098598
+  namespace: test-jvm-namespace
+spec:
+  gav: org.antlr:ST4:4.0.8

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/stringtemplate.3.2.1-1ff51cbb.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/stringtemplate.3.2.1-1ff51cbb.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-6083812c2ef59ef125c6: d5e0d034a4d0acec36eb48156d21521a
+  name: stringtemplate.3.2.1-1ff51cbb
+  namespace: test-jvm-namespace
+spec:
+  gav: org.antlr:stringtemplate:3.2.1

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/wsdl4j.1.6.3-138a1801.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/wsdl4j.1.6.3-138a1801.yaml
@@ -1,0 +1,7 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  name: wsdl4j.1.6.3-138a1801
+  namespace: test-jvm-namespace
+spec:
+  gav: wsdl4j:wsdl4j:1.6.3

--- a/hack/service-registry-artifacts/ArtifactBuildMissing/xsdlib.2013.6.1-0aed4ed6.yaml
+++ b/hack/service-registry-artifacts/ArtifactBuildMissing/xsdlib.2013.6.1-0aed4ed6.yaml
@@ -1,0 +1,9 @@
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: ArtifactBuild
+metadata:
+  annotations:
+    jvmbuildservice.io/contaminated-4effa5267e972d5f20ae: 1ba645360e9136d45fe15e3d63a721de
+  name: xsdlib.2013.6.1-0aed4ed6
+  namespace: test-jvm-namespace
+spec:
+  gav: net.java.dev.msv:xsdlib:2013.6.1

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -247,9 +247,9 @@ func (r *ReconcileDependencyBuild) handleStateAnalyzeBuild(ctx context.Context, 
 			return reconcile.Result{}, err
 		}
 		//read our builder images from the config
-		var mavenImages []BuilderImage
+		var allBuilderImages []BuilderImage
 		var selectedImages []BuilderImage
-		mavenImages, err = r.processBuilderImages(ctx, log)
+		allBuilderImages, err = r.processBuilderImages(ctx, log)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -260,7 +260,7 @@ func (r *ReconcileDependencyBuild) handleStateAnalyzeBuild(ctx context.Context, 
 		_, gradle := unmarshalled.Tools["gradle"]
 		java := unmarshalled.Tools["jdk"]
 
-		for _, image := range mavenImages {
+		for _, image := range allBuilderImages {
 			//we only have one JDK version in the builder at the moment
 			//other tools will potentially have multiple versions
 			//we only want to use builder images that have java versions that the analyser


### PR DESCRIPTION
As a temporary measure to aid with debugging the service registry build this adds all the AB's generated by the build so they can be easily tested locally.