### PR TITLE
Increase memory for deploy pod

### DIFF
--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -103,8 +103,8 @@ func createPipelineSpec(maven bool, sidecarImage string, namespace string) *pipe
 					SecurityContext: &v1.SecurityContext{RunAsUser: &zero},
 					Resources: v1.ResourceRequirements{
 						//TODO: make configurable
-						Requests: v1.ResourceList{"memory": resource.MustParse("128Mi"), "cpu": resource.MustParse("10m")},
-						Limits:   v1.ResourceList{"memory": resource.MustParse("128Mi"), "cpu": resource.MustParse("300m")},
+						Requests: v1.ResourceList{"memory": resource.MustParse("256Mi"), "cpu": resource.MustParse("10m")},
+						Limits:   v1.ResourceList{"memory": resource.MustParse("256Mi"), "cpu": resource.MustParse("300m")},
 					},
 				},
 				Script: deploy,


### PR DESCRIPTION
It looks like the Quarkus deployment was running out of memory.

This is a very short lived pod, so it should not be an issue for now.