### PR TITLE
Give wrappers the same owners as the pipeline

### DIFF
--- a/pkg/reconciler/tektonwrapper/util.go
+++ b/pkg/reconciler/tektonwrapper/util.go
@@ -27,6 +27,9 @@ func (b *BatchedCreate) CreateWrapperForPipelineRun(ctx context.Context, client 
 	tw.Namespace = run.Namespace
 	tw.Name = run.Name
 	tw.GenerateName = run.GenerateName
+	//we use the same owner references as the pipeline
+	//so these are cleaned up if the owner is deleted
+	tw.OwnerReferences = run.OwnerReferences
 	buffer := bytes.Buffer{}
 	scheme := runtime.NewScheme()
 	utilruntime.Must(v1beta1.AddToScheme(scheme))


### PR DESCRIPTION
This is breaking the 'rebuild' functionality is the wrappers are not deleted when the DependencyBuild is deleted, so subsequent attempts to create the same pipeline run fail due to it already existing.