### PR TITLE
Rename recipes directory to scm-info

### DIFF
--- a/java-components/adhoc-analyser-tool/src/main/java/com/redhat/hacbs/analyser/artifactanalysis/ConsolidateScmInfoCommand.java
+++ b/java-components/adhoc-analyser-tool/src/main/java/com/redhat/hacbs/analyser/artifactanalysis/ConsolidateScmInfoCommand.java
@@ -36,7 +36,7 @@ public class ConsolidateScmInfoCommand implements Runnable {
 
     @Override
     public void run() {
-        Path recipeBase = repoConfig.path().resolve(RecipeRepositoryManager.RECIPES);
+        Path recipeBase = repoConfig.path().resolve(RecipeRepositoryManager.SCM_INFO);
         try {
             Files.walkFileTree(recipeBase, new SimpleFileVisitor<>() {
                 @Override

--- a/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipies/location/RecipeLayoutManager.java
+++ b/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipies/location/RecipeLayoutManager.java
@@ -52,7 +52,9 @@ public class RecipeLayoutManager implements RecipeDirectory {
 
     public RecipeLayoutManager(Path baseDirectory) {
         this.checkoutDirectory = baseDirectory;
-        this.scmInfoDirectory = baseDirectory.resolve(RecipeRepositoryManager.RECIPES);
+        Path legacy = baseDirectory.resolve(RecipeRepositoryManager.RECIPES);
+        Path expected = baseDirectory.resolve(RecipeRepositoryManager.SCM_INFO);
+        this.scmInfoDirectory = Files.isDirectory(expected) ? expected : legacy;
         this.buildInfoDirectory = baseDirectory.resolve(RecipeRepositoryManager.BUILD_INFO);
     }
 

--- a/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipies/location/RecipeRepositoryManager.java
+++ b/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipies/location/RecipeRepositoryManager.java
@@ -11,8 +11,9 @@ import org.eclipse.jgit.api.errors.GitAPIException;
  * A recipe database stored in git.
  */
 public class RecipeRepositoryManager implements RecipeDirectory {
-
+    @Deprecated
     public static final String RECIPES = "recipes";
+    public static final String SCM_INFO = "scm-info";
     public static final String BUILD_INFO = "build-info";
     private final Git git;
     private final String remote;


### PR DESCRIPTION
The name no longer makes sense now that there are different directory structures.