### PR TITLE
return systemconfig definition to patch merge with jvm-build-service-builder-images

### DIFF
--- a/deploy/operator/config/kustomization.yaml
+++ b/deploy/operator/config/kustomization.yaml
@@ -6,6 +6,6 @@ commonLabels:
 resources:
   - system-config.yaml
 
-#patchesStrategicMerge:
-#  #note that when updating the ref here you must also update system-config.yaml
-#  - https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service-builder-images/fbe0f42ebe3d50b16d454c95207dd15be6b5008f/image-config.yaml
+patchesStrategicMerge:
+  #note that when updating the ref here you must also update system-config.yaml
+  - https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service-builder-images/9d571619a763f7106f1e37a9340159ea6f598cc9/image-config.yaml

--- a/deploy/operator/config/system-config.yaml
+++ b/deploy/operator/config/system-config.yaml
@@ -17,14 +17,8 @@ metadata:
 spec:
   builders:
     jdk8:
-      image: quay.io/redhat-appstudio/hacbs-jdk8-builder:fbe0f42ebe3d50b16d454c95207dd15be6b5008f
-      # until we can update builder repo, pull its changes in here vs. patch merge
-      tag: jdk:8,maven:3.8,gradle:7.4.2;6.9.2;5.6.4;4.10.3
+      image: quay.io/redhat-appstudio/hacbs-jdk8-builder:9d571619a763f7106f1e37a9340159ea6f598cc9
     jdk11:
-      image: quay.io/redhat-appstudio/hacbs-jdk11-builder:fbe0f42ebe3d50b16d454c95207dd15be6b5008f
-      # until we can update builder repo, pull its changes in here vs. patch merge
-      tag: jdk:11,maven:3.8,gradle:7.4.2;6.9.2;5.6.4;4.10.3
+      image: quay.io/redhat-appstudio/hacbs-jdk11-builder:9d571619a763f7106f1e37a9340159ea6f598cc9
     jdk17:
-      image: quay.io/redhat-appstudio/hacbs-jdk17-builder:fbe0f42ebe3d50b16d454c95207dd15be6b5008f
-      # until we can update builder repo, pull its changes in here vs. patch merge
-      tag: jdk:17,maven:3.8,gradle:7.4.2;6.9.2
+      image: quay.io/redhat-appstudio/hacbs-jdk17-builder:9d571619a763f7106f1e37a9340159ea6f598cc9


### PR DESCRIPTION
running with the fbe0f42ebe3d50b16d454c95207dd15be6b5008f level builder images would not have any bearing on the deploy contaminants step always failing for me, would it @stuartwdouglas ?