### PR TITLE
PLNSRVCE-658: add k8s resource quota as an option (kcp env)

### DIFF
--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -1,19 +1,4 @@
 ---
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  name: jvm-build-config
-#data:
-#  enable-rebuilds: "true"
-#  maven-repository-300-jboss: "https://repository.jboss.org/nexus/content/groups/public/"
-#  maven-repository-301-jitpack: "https://jitpack.io"
-#  maven-repository-302-confluent: "https://packages.confluent.io/maven"
-#  maven-repository-303-gradle: "https://repo.gradle.org/artifactory/libs-releases"
-#  maven-repository-304-eclipselink: "https://download.eclipse.org/rt/eclipselink/maven.repo"
-#  maven-repository-305-redhat: "https://maven.repository.redhat.com/ga"
-#  maven-repository-306-gradleplugins: "https://plugins.gradle.org/m2"
-#  maven-repository-307-jsweet: "https://repository.jsweet.org/artifactory/libs-release-local"
-#  maven-repository-308-jenkins: "https://repo.jenkins-ci.org/public/"
 apiVersion: jvmbuildservice.io/v1alpha1
 kind: UserConfig
 metadata:

--- a/deploy/crds/base/jvmbuildservice.io_systemconfigs.yaml
+++ b/deploy/crds/base/jvmbuildservice.io_systemconfigs.yaml
@@ -46,6 +46,8 @@ spec:
                       type: string
                   type: object
                 type: object
+              quota:
+                type: string
             type: object
           status:
             type: object

--- a/deploy/kcp/apiresourceschema_jvmbuildservice.yaml
+++ b/deploy/kcp/apiresourceschema_jvmbuildservice.yaml
@@ -416,6 +416,8 @@ spec:
                     type: string
                 type: object
               type: object
+            quota:
+              type: string
           type: object
         status:
           type: object

--- a/deploy/operator/base/rbac.yaml
+++ b/deploy/operator/base/rbac.yaml
@@ -122,7 +122,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - persistentvolumeclaims
+      - serviceaccounts
     verbs:
       - get
       - create
@@ -132,11 +132,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - serviceaccounts
+      - resourcequotas
     verbs:
       - get
-      - create
-      - patch
       - list
       - watch
   - apiGroups:

--- a/deploy/operator/config/system-config.yaml
+++ b/deploy/operator/config/system-config.yaml
@@ -1,15 +1,4 @@
 ---
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  name: jvm-build-system-config
-#  namespace: jvm-build-service
-#data:
-#  builder-image.names: jdk11,jdk8,jdk17
-#  #note that when updating the ref here you must also update kustomization.yaml
-#  builder-image.jdk8.image: quay.io/redhat-appstudio/hacbs-jdk8-builder:fbe0f42ebe3d50b16d454c95207dd15be6b5008f
-#  builder-image.jdk11.image: quay.io/redhat-appstudio/hacbs-jdk11-builder:fbe0f42ebe3d50b16d454c95207dd15be6b5008f
-#  builder-image.jdk17.image: quay.io/redhat-appstudio/hacbs-jdk17-builder:fbe0f42ebe3d50b16d454c95207dd15be6b5008f
 apiVersion: jvmbuildservice.io/v1alpha1
 kind: SystemConfig
 metadata:

--- a/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
@@ -7,10 +7,16 @@ const (
 	JDK11Builder        = "jdk11"
 	JDK17Builder        = "jdk17"
 	ControllerNamespace = "jvm-build-service"
+
+	OpenShiftQuota = QuotaImpl("openshift")
+	K8SQuota       = QuotaImpl("kubernetes")
 )
+
+type QuotaImpl string
 
 type SystemConfigSpec struct {
 	Builders map[string]JavaVersionInfo `json:"builders,omitempty"`
+	Quota    QuotaImpl                  `json:"quota,omitempty"`
 }
 
 type JavaVersionInfo struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kcp-dev/apimachinery/third_party/informers"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuild"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/clusterresourcequota"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/dependencybuild"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/rebuiltartifact"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/systemconfig"
@@ -137,11 +136,6 @@ func NewManager(cfg *rest.Config, options ctrl.Options, kcp bool) (ctrl.Manager,
 		return nil, err
 	}
 	if err := rebuiltartifact.SetupNewReconcilerWithManager(mgr); err != nil {
-		return nil, err
-	}
-
-	// TODO we are not syncing these types here at all ... do we need the kcp modified cfg?
-	if err := clusterresourcequota.SetupNewReconciler(cfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/k8sresourcequota/controller.go
+++ b/pkg/reconciler/k8sresourcequota/controller.go
@@ -1,0 +1,11 @@
+package k8sresourcequota
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func SetupNewReconcilerWithManager(mgr ctrl.Manager) error {
+	r := newReconciler(mgr)
+	return ctrl.NewControllerManagedBy(mgr).For(&corev1.ResourceQuota{}).Complete(r)
+}

--- a/pkg/reconciler/k8sresourcequota/k8sresourcequota.go
+++ b/pkg/reconciler/k8sresourcequota/k8sresourcequota.go
@@ -1,0 +1,30 @@
+package k8sresourcequota
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ReconcilerResourceQuota struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+}
+
+func newReconciler(mgr ctrl.Manager) reconcile.Reconciler {
+	return &ReconcilerResourceQuota{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("ResourceQuota"),
+	}
+}
+
+func (r *ReconcilerResourceQuota) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}

--- a/pkg/reconciler/tektonwrapper/tektonwrapper_test.go
+++ b/pkg/reconciler/tektonwrapper/tektonwrapper_test.go
@@ -2,6 +2,7 @@ package tektonwrapper
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -11,7 +12,7 @@ import (
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/clusterresourcequota"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,21 +22,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Client, *ReconcileTektonWrapper) {
+func setupClientAndReconciler(useOpenshift bool, objs ...runtimeclient.Object) (runtimeclient.Client, *ReconcileTektonWrapper) {
 	scheme := runtime.NewScheme()
 	_ = v1alpha1.AddToScheme(scheme)
 	_ = v1beta1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	_ = quotav1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-	clusterresourcequota.QuotaClient = fakequotaclientset.NewSimpleClientset()
+	if useOpenshift {
+		clusterresourcequota.QuotaClient = fakequotaclientset.NewSimpleClientset()
+	}
 	reconciler := &ReconcileTektonWrapper{client: client, scheme: scheme, eventRecorder: &record.FakeRecorder{}}
 	return client, reconciler
 }
 
 func TestTektonWrapper(t *testing.T) {
 	g := NewGomegaWithT(t)
-	client, reconciler := setupClientAndReconciler()
+	client, reconciler := setupClientAndReconciler(true)
 
 	pr := v1beta1.PipelineRun{}
 	pr.Namespace = metav1.NamespaceDefault
@@ -63,4 +66,44 @@ func TestTektonWrapper(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(tw.Status.State).To(Equal(v1alpha1.TektonWrapperStateComplete))
 
+}
+
+func TestTektonWrapperK8sQuota(t *testing.T) {
+	g := NewGomegaWithT(t)
+	quota := &corev1.ResourceQuota{
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("5"),
+			},
+		},
+	}
+	quota.Namespace = metav1.NamespaceDefault
+	quota.Name = "foo"
+	client, reconciler := setupClientAndReconciler(false, quota)
+
+	pr := v1beta1.PipelineRun{}
+	pr.Namespace = metav1.NamespaceDefault
+	pr.Name = "test"
+	pr.Spec.ServiceAccountName = "foo"
+	ctx := context.TODO()
+	c := &BatchedCreate{}
+	err := c.CreateWrapperForPipelineRun(ctx, client, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}}))
+	key := runtimeclient.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	tw := &v1alpha1.TektonWrapper{}
+	err = client.Get(ctx, key, tw)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tw.Status.State).To(Equal(v1alpha1.TektonWrapperStateInProgress))
+
+	pr.Status.MarkSucceeded("done", "")
+	err = client.Update(ctx, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}}))
+	err = client.Get(ctx, key, tw)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(tw.Status.State).To(Equal(v1alpha1.TektonWrapperStateComplete))
 }


### PR DESCRIPTION
still defaults to openshift for now (for the apicurio e2e test)

long term should pivot to defaulting to k8s for kcp once/if we have kcp based CI

I did add the systemconfig field vs. just picking the quota type based on kcp detection in main.go to allow for the possibility of defining quota on the workspace/compute clusters vs. at the kcp mgmt level.