### PR TITLE
Don't mark AB as succeeded if it is not deployed

### DIFF
--- a/deploy/crds/base/jvmbuildservice.io_dependencybuilds.yaml
+++ b/deploy/crds/base/jvmbuildservice.io_dependencybuilds.yaml
@@ -178,6 +178,10 @@ spec:
                   toolVersion:
                     type: string
                 type: object
+              deployedArtifacts:
+                items:
+                  type: string
+                type: array
               failedBuildRecipes:
                 description: FailedBuildRecipes recipes that resulted in a failure
                   if the current state is failed this may include the current BuildRecipe

--- a/deploy/kcp/apiexport_jvmbuildservice.yaml
+++ b/deploy/kcp/apiexport_jvmbuildservice.yaml
@@ -26,9 +26,9 @@ spec:
     # replace by pipeline-service identityHash
     identityHash: pipeline-service
   latestResourceSchemas:
-    - v202210100115.artifactbuilds.jvmbuildservice.io
-    - v202210100115.dependencybuilds.jvmbuildservice.io
-    - v202210100115.rebuiltartifacts.jvmbuildservice.io
-    - v202210100115.systemconfigs.jvmbuildservice.io
-    - v202210100115.tektonwrappers.jvmbuildservice.io
-    - v202210100115.userconfigs.jvmbuildservice.io
+    - v202210110553.artifactbuilds.jvmbuildservice.io
+    - v202210110553.dependencybuilds.jvmbuildservice.io
+    - v202210110553.rebuiltartifacts.jvmbuildservice.io
+    - v202210110553.systemconfigs.jvmbuildservice.io
+    - v202210110553.tektonwrappers.jvmbuildservice.io
+    - v202210110553.userconfigs.jvmbuildservice.io

--- a/deploy/kcp/apiresourceschema_jvmbuildservice.yaml
+++ b/deploy/kcp/apiresourceschema_jvmbuildservice.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202210100115.artifactbuilds.jvmbuildservice.io
+  name: v202210110553.artifactbuilds.jvmbuildservice.io
 spec:
   group: jvmbuildservice.io
   names:
@@ -77,7 +77,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202210100115.dependencybuilds.jvmbuildservice.io
+  name: v202210110553.dependencybuilds.jvmbuildservice.io
 spec:
   group: jvmbuildservice.io
   names:
@@ -248,6 +248,10 @@ spec:
                 toolVersion:
                   type: string
               type: object
+            deployedArtifacts:
+              items:
+                type: string
+              type: array
             failedBuildRecipes:
               description: FailedBuildRecipes recipes that resulted in a failure if
                 the current state is failed this may include the current BuildRecipe
@@ -326,7 +330,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202210100115.rebuiltartifacts.jvmbuildservice.io
+  name: v202210110553.rebuiltartifacts.jvmbuildservice.io
 spec:
   group: jvmbuildservice.io
   names:
@@ -377,7 +381,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202210100115.systemconfigs.jvmbuildservice.io
+  name: v202210110553.systemconfigs.jvmbuildservice.io
 spec:
   group: jvmbuildservice.io
   names:
@@ -434,7 +438,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202210100115.tektonwrappers.jvmbuildservice.io
+  name: v202210110553.tektonwrappers.jvmbuildservice.io
 spec:
   group: jvmbuildservice.io
   names:
@@ -519,7 +523,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202210100115.userconfigs.jvmbuildservice.io
+  name: v202210110553.userconfigs.jvmbuildservice.io
 spec:
   group: jvmbuildservice.io
   names:

--- a/pkg/apis/jvmbuildservice/v1alpha1/dependencybuild_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/dependencybuild_types.go
@@ -37,6 +37,7 @@ type DependencyBuildStatus struct {
 	FailedBuildRecipes            []*BuildRecipe `json:"failedBuildRecipes,omitempty"`
 	LastCompletedBuildPipelineRun string         `json:"lastCompletedBuildPipelineRun,omitempty"`
 	CommitTime                    int64          `json:"commitTime,omitempty"`
+	DeployedArtifacts             []string       `json:"deployedArtifacts,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/jvmbuildservice/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/zz_generated.deepcopy.go
@@ -304,6 +304,11 @@ func (in *DependencyBuildStatus) DeepCopyInto(out *DependencyBuildStatus) {
 			}
 		}
 	}
+	if in.DeployedArtifacts != nil {
+		in, out := &in.DeployedArtifacts, &out.DeployedArtifacts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/reconciler/artifactbuild/artifactbuild_test.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild_test.go
@@ -293,7 +293,7 @@ func TestStateBuilding(t *testing.T) {
 				Labels:    map[string]string{DependencyBuildIdLabel: hashString("")},
 			},
 			Spec:   v1alpha1.DependencyBuildSpec{},
-			Status: v1alpha1.DependencyBuildStatus{State: v1alpha1.DependencyBuildStateComplete},
+			Status: v1alpha1.DependencyBuildStatus{State: v1alpha1.DependencyBuildStateComplete, DeployedArtifacts: []string{abr.Spec.GAV}},
 		}
 		g.Expect(controllerutil.SetOwnerReference(abr, db, reconciler.scheme))
 		g.Expect(client.Create(ctx, db))

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -582,6 +582,7 @@ func (r *ReconcileDependencyBuild) handleBuildPipelineRunReceived(ctx context.Co
 				} else if i.Name == artifactbuild.DeployedResources {
 					//we need to create 'DeployedArtifact' resources for the objects that were deployed
 					deployed := strings.Split(i.Value, ",")
+					db.Status.DeployedArtifacts = deployed
 					for _, i := range deployed {
 						ra := v1alpha1.RebuiltArtifact{}
 						ra.Namespace = pr.Namespace

--- a/pkg/reconciler/dependencybuild/dependencybuild_test.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild_test.go
@@ -315,10 +315,12 @@ func TestStateBuilding(t *testing.T) {
 			Status:             "True",
 			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
 		})
+		pr.Status.PipelineResults = []pipelinev1beta1.PipelineRunResult{{Name: artifactbuild.DeployedResources, Value: TestArtifact}}
 		g.Expect(client.Update(ctx, pr)).Should(BeNil())
 		g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: taskRunName}))
 		db := getBuild(client, g)
 		g.Expect(db.Status.State).Should(Equal(v1alpha1.DependencyBuildStateComplete))
+		g.Expect(db.Status.DeployedArtifacts).Should(ContainElement(TestArtifact))
 	})
 	t.Run("Test reconcile building DependencyBuild with failed pipeline", func(t *testing.T) {
 		g := NewGomegaWithT(t)


### PR DESCRIPTION
Check that the output of the build matches what is expected from the ArtifactBuild objects, and fail the AB if the build did not produce this artifact.

I noticed that jackson-databind was missing its info, but being lumped into the jackson-core build and marked as a success.