### PR TITLE
PLNSRVCE-762: avoid quota watches with kcp for now

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -128,7 +128,7 @@ func NewManager(cfg *rest.Config, options ctrl.Options, kcp bool) (ctrl.Manager,
 		return nil, err
 	}
 
-	if err := systemconfig.SetupNewReconcilerWithManager(mgr); err != nil {
+	if err := systemconfig.SetupNewReconcilerWithManager(mgr, kcp); err != nil {
 		return nil, err
 	}
 
@@ -139,7 +139,7 @@ func NewManager(cfg *rest.Config, options ctrl.Options, kcp bool) (ctrl.Manager,
 		return nil, err
 	}
 
-	if err := tektonwrapper.SetupNewReconcilerWithManager(mgr); err != nil {
+	if err := tektonwrapper.SetupNewReconcilerWithManager(mgr, kcp); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/systemconfig/controller.go
+++ b/pkg/reconciler/systemconfig/controller.go
@@ -5,8 +5,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func SetupNewReconcilerWithManager(mgr ctrl.Manager) error {
-	r := newReconciler(mgr)
+func SetupNewReconcilerWithManager(mgr ctrl.Manager, kcp bool) error {
+	r := newReconciler(mgr, kcp)
 	return ctrl.NewControllerManagedBy(mgr).For(&v1alpha1.SystemConfig{}).
 		Complete(r)
 }

--- a/pkg/reconciler/tektonwrapper/controller.go
+++ b/pkg/reconciler/tektonwrapper/controller.go
@@ -26,13 +26,13 @@ var (
 	ctrlLog = ctrl.Log.WithName("tektonwrappercontroller")
 )
 
-func SetupNewReconcilerWithManager(mgr ctrl.Manager) error {
+func SetupNewReconcilerWithManager(mgr ctrl.Manager, kcp bool) error {
 	opts := client.Options{Scheme: runtime.NewScheme()}
 	err := quotav1.AddToScheme(opts.Scheme)
 	if err != nil {
 		return err
 	}
-	r := newReconciler(mgr)
+	r := newReconciler(mgr, kcp)
 	pruner := &pruner{client: mgr.GetClient()}
 	_ = mgr.Add(pruner)
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/reconciler/tektonwrapper/tektonwrapper.go
+++ b/pkg/reconciler/tektonwrapper/tektonwrapper.go
@@ -43,13 +43,15 @@ type ReconcileTektonWrapper struct {
 	client        client.Client
 	scheme        *runtime.Scheme
 	eventRecorder record.EventRecorder
+	kcp           bool
 }
 
-func newReconciler(mgr ctrl.Manager) reconcile.Reconciler {
+func newReconciler(mgr ctrl.Manager, kcp bool) reconcile.Reconciler {
 	return &ReconcileTektonWrapper{
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
 		eventRecorder: mgr.GetEventRecorderFor("TektonWrapper"),
+		kcp:           kcp,
 	}
 }
 
@@ -302,6 +304,7 @@ func (r *ReconcileTektonWrapper) unthrottleNextOnQueuePlusCleanup(ctx context.Co
 }
 
 func (r *ReconcileTektonWrapper) getHardPodCount(ctx context.Context, namespace string) (int, error) {
+	// this should be nil in kcp
 	if clusterresourcequota.QuotaClient != nil {
 		//TODO controller runtime seemed unable to deal with openshift API and its attempt at mapping to CRDs; we were using
 		// a non caching client; but now we've switched to a shared informer based controller and its caching client
@@ -340,23 +343,30 @@ func (r *ReconcileTektonWrapper) getHardPodCount(ctx context.Context, namespace 
 		}
 		return hardPodCount, nil
 	}
-	quotaList := corev1.ResourceQuotaList{}
-	err := r.client.List(ctx, &quotaList)
-	if err != nil {
-		return 0, err
+	//TODO when we sort out our perm claim for reqsourcequotas like https://github.com/openshift-pipelines/pipeline-service-workspace-controller/blob/main/config/kcp/apibinding.yaml
+	// we can start accessing this in kcp
+	if !r.kcp {
+		quotaList := corev1.ResourceQuotaList{}
+		err := r.client.List(ctx, &quotaList)
+		if err != nil {
+			return 0, err
+		}
+		hardPodCount := 0
+		for _, quota := range quotaList.Items {
+			if quota.Namespace != namespace {
+				continue
+			}
+			if quota.Spec.Hard.Pods() != nil {
+				hardPodCount = int(quota.Spec.Hard.Pods().Value())
+			}
+			if hardPodCount > 0 {
+				break
+			}
+		}
+		return hardPodCount, nil
+
 	}
-	hardPodCount := 0
-	for _, quota := range quotaList.Items {
-		if quota.Namespace != namespace {
-			continue
-		}
-		if quota.Spec.Hard.Pods() != nil {
-			hardPodCount = int(quota.Spec.Hard.Pods().Value())
-		}
-		if hardPodCount > 0 {
-			break
-		}
-	}
-	return hardPodCount, nil
+	//TODO use our default from e2e testing for now until we sort out accessing resourcequota in kcp
+	return 50, nil
 
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	err = dependencybuild.SetupNewReconcilerWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
-	err = tektonwrapper.SetupNewReconcilerWithManager(k8sManager)
+	err = tektonwrapper.SetupNewReconcilerWithManager(k8sManager, false)
 	Expect(err).ToNot(HaveOccurred())
 	err = clusterresourcequota.SetupNewReconciler(cfg)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
```
I1011 18:15:45.243792       1 round_trippers.go:553] GET https://ckcp-ckcp.apps.gmontero411.devcluster.openshift.com:443/services/apiexport/root:users:zu:yc:kcp-admin:redhat-hacbs/jvm-build-service/apis/quota.openshift.io/v1/clusterresourcequotas 403 Forbidden in 1 milliseconds
1.665512145243876e+09	ERROR	Reconciler error	{"controller": "tektonwrapper", "controllerGroup": "jvmbuildservice.io", "controllerKind": "TektonWrapper", "tektonWrapper": {"name":"simple.jdk17.0.1.2-22fafbfd-scm-discovery-gvffw","namespace":"ggmtest"}, "namespace": "ggmtest", "name": "simple.jdk17.0.1.2-22fafbfd-scm-discovery-gvffw", "reconcileID": "80ba3437-fc77-43ac-baf9-9c58d526d784", "error": "forbidden: User \"system:serviceaccount:jvm-build-service:hacbs-jvm-operator\" cannot get path \"/services/apiexport/root:users:zu:yc:kcp-admin:redhat-hacbs/jvm-build-service/apis/quota.openshift.io/v1/clusterresourcequotas\": Path not resolved to a valid virtual workspace"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/opt/app-root/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/opt/app-root/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234
```

from some long awaited "progress" running on KCP today

normal rbac is not sufficient since it is going through kcp, and while k8s resource quota is getting exposed in https://github.com/openshift-pipelines/pipeline-service-workspace-controller openshift quota will never get exposed via KCP

that said, per recent discussion with @stuartwdouglas I'm not entirely removing to continue to facilitate non KCP scenarios