### PR TITLE
PLNSRVCE-762: build image names in KCP via IMAGE_* env vars

### DIFF
--- a/pkg/reconciler/artifactbuild/artifactbuild_test.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild_test.go
@@ -2,6 +2,7 @@ package artifactbuild
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -37,6 +38,7 @@ func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Clien
 	_ = appsv1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	reconciler := &ReconcileArtifactBuild{client: client, scheme: scheme, eventRecorder: &record.FakeRecorder{}, prCreator: &tektonwrapper.ImmediateCreate{}}
+	os.Setenv("IMAGE_TAG", "foo")
 	return client, reconciler
 }
 

--- a/pkg/reconciler/dependencybuild/dependencybuild_test.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild_test.go
@@ -3,13 +3,15 @@ package dependencybuild
 import (
 	"context"
 	"encoding/json"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/systemconfig"
+	"os"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
+
 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuild"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/systemconfig"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/tektonwrapper"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
@@ -66,6 +68,7 @@ func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Clien
 		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: v1alpha1.UserConfigName},
 	}
 	_ = client.Create(context.TODO(), &usrConfig)
+	os.Setenv("IMAGE_TAG", "foo")
 
 	return client, reconciler
 }

--- a/pkg/reconciler/userconfig/userconfig_test.go
+++ b/pkg/reconciler/userconfig/userconfig_test.go
@@ -2,6 +2,7 @@ package userconfig
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -31,6 +32,7 @@ func setupClientAndReconciler(objs ...runtimeclient.Object) (runtimeclient.Clien
 		scheme:        scheme,
 		eventRecorder: &record.FakeRecorder{},
 	}
+	os.Setenv("IMAGE_TAG", "foo")
 	return client, reconciler
 }
 

--- a/test/e2e/task_run_controller_test.go
+++ b/test/e2e/task_run_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -95,6 +96,7 @@ func setupSystemConfig() {
 		userConfig.Name = v1alpha1.UserConfigName
 		Expect(k8sClient.Create(context.TODO(), &userConfig)).Should(Succeed())
 	}
+	os.Setenv("IMAGE_TAG", "foo")
 }
 
 func createDB(componentLookupKey types.NamespacedName) {


### PR DESCRIPTION
this PR will partner with an upcoming infra-deployments PR, and together they will address the fact that the current use of the controller deployment to build the cache and request processor image refs is not viable in KCP.

Hence, when the controller attempts to create the discovery pipelinerun, the syncer complains with 

```
E1012 15:29:31.201873       1 spec_process.go:409] Error upserting pipelineruns kcp-g73zr038e4mk/jts.core.1.15.0-b4781954-scm-discovery-5w9cq from upstream root:users:zu:yc:kcp-admin:hacbs|ggmtest/jts.core.1.15.0-b4781954-scm-discovery-5w9cq: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: missing field(s): spec.pipelineSpec.tasks[0].taskSpec.steps[0].Image
```

this form of change should allow the current openshift only dev and CI flows to continue to work as is