### PR TITLE
PLNSRVCE-762: add prelim helm charts for workspace resource controller integration

### DIFF
--- a/deploy/init-hacbs-user-workspace-sa-rbac.sh
+++ b/deploy/init-hacbs-user-workspace-sa-rbac.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+DIR=`dirname $0`
+#COMPUTE_KUBECONFIG should match whatever you have set in your infra-deployments preview.env file
+#HABCS_WORKSPACE_NAMESPACE is the name of whatever namespace in the KCP hacbs ws that you ran init-hacbs-user-workspace.sh from
+KUBECONFIG=$COMPUTE_KUBECONFIG helm install --set kcpNamespace=$HABCS_WORKSPACE_NAMESPACE $DIR/kcp-hacbs-workspace-compute-cluster-rbac --debug --generate-name

--- a/deploy/init-hacbs-user-workspace.sh
+++ b/deploy/init-hacbs-user-workspace.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+DIR=`dirname $0`
+#KCP_KUBECONFIG should match whatever you have set in your infra-deployments preview.env file
+#QUAY_USERNAME and QUAY_TOKEN are the same env's you use in the other dev flow scripts
+#QUAY_TAG is either the sha for the images up at quay.io/redhat-appstudio or 'dev' if you are using
+# the jmv-build-service `make dev` flow.
+KUBECONFIG=$KCP_KUBECONFIG helm install --set quayRespository=$QUAY_USERNAME --set quayToken=$QUAY_TOKEN --set quayTag=$QUAY_TAG $DIR/kcp-hacbs-workspace-init --debug --generate-name

--- a/deploy/kcp-hacbs-workspace-compute-cluster-rbac/Chart.yaml
+++ b/deploy/kcp-hacbs-workspace-compute-cluster-rbac/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for initializing a hacbs user workspace's compute cluster rbac for jvm build service
+name: hacbs-user-workspace-jvm-build-service-compute-cluster-rbac
+type: application
+version: 0.1.0

--- a/deploy/kcp-hacbs-workspace-compute-cluster-rbac/templates/_helpers.tpl
+++ b/deploy/kcp-hacbs-workspace-compute-cluster-rbac/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.labels" -}}
+app.kubernetes.io/name: {{ include "hacbs-user-workspace-jvm-build-service.name" . }}
+helm.sh/chart: {{ include "hacbs-user-workspace-jvm-build-service.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/deploy/kcp-hacbs-workspace-compute-cluster-rbac/templates/rbac.yaml
+++ b/deploy/kcp-hacbs-workspace-compute-cluster-rbac/templates/rbac.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hacbs-jvm-cache
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns/status
+      - taskruns/status
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hacbs-jvm-cache-{{ .Values.kcpNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hacbs-jvm-cache
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: {{ .Values.kcpNamespace }}
+

--- a/deploy/kcp-hacbs-workspace-compute-cluster-rbac/values.yaml
+++ b/deploy/kcp-hacbs-workspace-compute-cluster-rbac/values.yaml
@@ -1,0 +1,1 @@
+kcpNamespace: XXXXXX

--- a/deploy/kcp-hacbs-workspace-init/Chart.yaml
+++ b/deploy/kcp-hacbs-workspace-init/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for initializing a hacbs user workspace for jvm build service
+name: hacbs-user-workspace-jvm-build-service
+type: application
+version: 0.1.0

--- a/deploy/kcp-hacbs-workspace-init/templates/_helpers.tpl
+++ b/deploy/kcp-hacbs-workspace-init/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "hacbs-user-workspace-jvm-build-service.labels" -}}
+app.kubernetes.io/name: {{ include "hacbs-user-workspace-jvm-build-service.name" . }}
+helm.sh/chart: {{ include "hacbs-user-workspace-jvm-build-service.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/deploy/kcp-hacbs-workspace-init/templates/clone-task.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/clone-task.yaml
@@ -1,0 +1,208 @@
+# a placeholder for development; in a fully integrated system, this will come from the appstudio tekton bundle
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: git clone
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git
+  name: git-clone
+spec:
+  description: |-
+    These Tasks are Git tasks to work with repositories used by other tasks in your Pipeline.
+    The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace. You can clone into a subdirectory by setting this Task's subdirectory param. This Task also supports sparse checkouts. To perform a sparse checkout, pass a list of comma separated directory patterns to this Task's sparseCheckoutDirectories param.
+  params:
+    - description: Repository URL to clone from.
+      name: url
+      type: string
+    - default: ""
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      name: revision
+      type: string
+    - default: ""
+      description: Refspec to fetch before checking out revision.
+      name: refspec
+      type: string
+    - default: "true"
+      description: Initialize and fetch git submodules.
+      name: submodules
+      type: string
+    - default: "1"
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      name: depth
+      type: string
+    - default: "true"
+      description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+      name: sslVerify
+      type: string
+    - default: ""
+      description: Subdirectory inside the `output` Workspace to clone the repo into.
+      name: subdirectory
+      type: string
+    - default: ""
+      description: Define the directory patterns to match or exclude when performing a sparse checkout.
+      name: sparseCheckoutDirectories
+      type: string
+    - default: "true"
+      description: Clean out the contents of the destination directory if it already exists before cloning.
+      name: deleteExisting
+      type: string
+    - default: ""
+      description: HTTP proxy server for non-SSL requests.
+      name: httpProxy
+      type: string
+    - default: ""
+      description: HTTPS proxy server for SSL requests.
+      name: httpsProxy
+      type: string
+    - default: ""
+      description: Opt out of proxying HTTP/HTTPS requests.
+      name: noProxy
+      type: string
+    - default: "true"
+      description: Log the commands that are executed during `git-clone`'s operation.
+      name: verbose
+      type: string
+    - default: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b1598a980f17d5f5d3d8a4b11ab4f5184677f7f17ad302baa36bd3c1
+      description: The image providing the git-init binary that this Task runs.
+      name: gitInitImage
+      type: string
+    - default: /tekton/home
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+        the gitInitImage param with an image containing custom user configuration.
+      name: userHome
+      type: string
+  results:
+    - description: The precise commit SHA that was fetched by this Task.
+      name: commit
+    - description: The precise URL that was fetched by this Task.
+      name: url
+  steps:
+    - env:
+        - name: HOME
+          value: $(params.userHome)
+        - name: PARAM_URL
+          value: $(params.url)
+        - name: PARAM_REVISION
+          value: $(params.revision)
+        - name: PARAM_REFSPEC
+          value: $(params.refspec)
+        - name: PARAM_SUBMODULES
+          value: $(params.submodules)
+        - name: PARAM_DEPTH
+          value: $(params.depth)
+        - name: PARAM_SSL_VERIFY
+          value: $(params.sslVerify)
+        - name: PARAM_SUBDIRECTORY
+          value: $(params.subdirectory)
+        - name: PARAM_DELETE_EXISTING
+          value: $(params.deleteExisting)
+        - name: PARAM_HTTP_PROXY
+          value: $(params.httpProxy)
+        - name: PARAM_HTTPS_PROXY
+          value: $(params.httpsProxy)
+        - name: PARAM_NO_PROXY
+          value: $(params.noProxy)
+        - name: PARAM_VERBOSE
+          value: $(params.verbose)
+        - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+          value: $(params.sparseCheckoutDirectories)
+        - name: PARAM_USER_HOME
+          value: $(params.userHome)
+        - name: WORKSPACE_OUTPUT_PATH
+          value: $(workspaces.output.path)
+        - name: WORKSPACE_SSH_DIRECTORY_BOUND
+          value: $(workspaces.ssh-directory.bound)
+        - name: WORKSPACE_SSH_DIRECTORY_PATH
+          value: $(workspaces.ssh-directory.path)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
+      image: $(params.gitInitImage)
+      name: clone
+      resources: {}
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+          # or the root of a mounted volume.
+          if [ -d "${CHECKOUT_DIR}" ] ; then
+            # Delete non-hidden files and directories
+            rm -rf "${CHECKOUT_DIR:?}"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "${CHECKOUT_DIR}"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "${CHECKOUT_DIR}"/..?*
+          fi
+        }
+
+        if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+          cleandir
+        fi
+
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+        /ko-app/git-init \
+          -url="${PARAM_URL}" \
+          -revision="${PARAM_REVISION}" \
+          -refspec="${PARAM_REFSPEC}" \
+          -path="${CHECKOUT_DIR}" \
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth="${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+  workspaces:
+    - description: The git repo will be cloned onto the volume backing this Workspace.
+      name: output
+    - description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+      name: ssh-directory
+      optional: true
+    - description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+      name: basic-auth
+      optional: true

--- a/deploy/kcp-hacbs-workspace-init/templates/deployment.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jvm-build-workspace-artifact-cache
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: jvm-build-workspace-artifact-cache
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: jvm-build-workspace-artifact-cache
+    spec:
+      containers:
+      - env:
+        - name: CACHE_PATH
+          value: /cache
+        - name: QUARKUS_VERTX_EVENT_LOOPS_POOL_SIZE
+          value: "4"
+        - name: QUARKUS_THREAD_POOL_MAX_THREADS
+          value: "50"
+        - name: REGISTRY_OWNER
+          value: {{ .Values.quayRespository }}
+        - name: REGISTRY_HOST
+          value: quay.io
+        - name: REGISTRY_REPOSITORY
+          value: test-images
+        - name: REGISTRY_INSECURE
+          value: "false"
+        - name: REGISTRY_PREPEND_TAG
+          value: "{{ .Values.prependTag }}"
+        - name: REGISTRY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: registry.token
+              name: jvm-build-secrets
+        - name: BUILD_POLICY_DEFAULT_RELOCATION_PATTERN
+          value: (io.github.stuartwdouglas.hacbs-test.simple):(simple-jdk17):(99-does-not-exist)=io.github.stuartwdouglas.hacbs-test.simple:simple-jdk17:0.1.2
+        - name: STORE_ECLIPSELINK_URL
+          value: https://download.eclipse.org/rt/eclipselink/maven.repo
+        - name: STORE_ECLIPSELINK_TYPE
+          value: maven2
+        - name: STORE_GRADLE_URL
+          value: https://repo.gradle.org/artifactory/libs-releases
+        - name: STORE_GRADLE_TYPE
+          value: maven2
+        - name: STORE_KOTLINNATIVE14LINUX_URL
+          value: https://download.jetbrains.com/kotlin/native/builds/releases/1.4/linux
+        - name: STORE_KOTLINNATIVE14LINUX_TYPE
+          value: maven2
+        - name: STORE_AJOBERSTAR_URL
+          value: https://ajoberstar.org/bintray-backup
+        - name: STORE_AJOBERSTAR_TYPE
+          value: maven2
+        - name: STORE_GOOGLEANDROID_URL
+          value: https://dl.google.com/dl/android/maven2/
+        - name: STORE_GOOGLEANDROID_TYPE
+          value: maven2
+        - name: STORE_CONFLUENT_URL
+          value: https://packages.confluent.io/maven
+        - name: STORE_CONFLUENT_TYPE
+          value: maven2
+        - name: STORE_REDHAT_URL
+          value: https://maven.repository.redhat.com/ga
+        - name: STORE_REDHAT_TYPE
+          value: maven2
+        - name: STORE_SPRING_PLUGINS_URL
+          value: https://repo.springsource.org/plugins-release
+        - name: STORE_SPRING_PLUGINS_TYPE
+          value: maven2
+        - name: STORE_JSWEET_URL
+          value: https://repository.jsweet.org/artifactory/libs-release-local
+        - name: STORE_JSWEET_TYPE
+          value: maven2
+        - name: STORE_JITPACK_URL
+          value: https://jitpack.io
+        - name: STORE_JITPACK_TYPE
+          value: maven2
+        - name: STORE_JCS_URL
+          value: https://packages.jetbrains.team/maven/p/jcs/maven
+        - name: STORE_JCS_TYPE
+          value: maven2
+        - name: STORE_DOKKADEV_URL
+          value: https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev
+        - name: STORE_DOKKADEV_TYPE
+          value: maven2
+        - name: STORE_GRADLEPLUGINS_URL
+          value: https://plugins.gradle.org/m2
+        - name: STORE_GRADLEPLUGINS_TYPE
+          value: maven2
+        - name: STORE_JBOSS_URL
+          value: https://repository.jboss.org/nexus/content/groups/public/
+        - name: STORE_JBOSS_TYPE
+          value: maven2
+        - name: STORE_JENKINS_URL
+          value: https://repo.jenkins-ci.org/public/
+        - name: STORE_JENKINS_TYPE
+          value: maven2
+        - name: BUILD_POLICY_DEFAULT_STORE_LIST
+          value: rebuilt,central,jboss,gradleplugins,confluent,gradle,eclipselink,redhat,jitpack,jsweet,jenkins,spring-plugins,dokkadev,ajoberstar,googleandroid,kotlinnative14linux,jcs
+        image: quay.io/gabemontero/hacbs-jvm-cache:dev
+        imagePullPolicy: Always
+        name: jvm-build-workspace-artifact-cache
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "4"
+            memory: 3Gi
+          requests:
+            cpu: "1"
+            memory: 3Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /cache
+          name: jvm-build-workspace-artifact-cache
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: pipeline
+      serviceAccountName: pipeline
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir:
+          sizeLimit: 10Gi
+        name: jvm-build-workspace-artifact-cache
+

--- a/deploy/kcp-hacbs-workspace-init/templates/maven-task.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/maven-task.yaml
@@ -177,7 +177,7 @@ spec:
     - name: analyse-dependencies
       securityContext:
         runAsUser: 0
-      image: quay.io/replaced-image:bogus
+      image: quay.io/{{ .Values.quayRespository }}/hacbs-jvm-build-request-processor:{{ .Values.quayTag }}
       args:
         - analyse-dependencies
         - path

--- a/deploy/kcp-hacbs-workspace-init/templates/quota.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/quota.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: jvm-build-service-pod-count-quota
+spec:
+  hard:
+    pods: "50"

--- a/deploy/kcp-hacbs-workspace-init/templates/rbac.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/rbac.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hacbs-jvm-cache
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns/status
+      - taskruns/status
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hacbs-jvm-cache-{{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hacbs-jvm-cache
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: {{ .Release.Namespace }}
+

--- a/deploy/kcp-hacbs-workspace-init/templates/secret.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jvm-build-secrets
+stringData:
+  registry.token: {{ .Values.quayToken }}

--- a/deploy/kcp-hacbs-workspace-init/templates/service.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jvm-build-workspace-artifact-cache
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: jvm-build-workspace-artifact-cache
+  type: ClusterIP
+

--- a/deploy/kcp-hacbs-workspace-init/templates/serviceaccount.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+# short term work around see https://github.com/redhat-appstudio/book/pull/5
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline

--- a/deploy/kcp-hacbs-workspace-init/templates/userconfig.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/userconfig.yaml
@@ -1,0 +1,36 @@
+#TODO  long term, do we want to merge this with <repoHome>/deploy/base/config.yaml ??
+---
+apiVersion: jvmbuildservice.io/v1alpha1
+kind: UserConfig
+metadata:
+  name: jvm-build-config
+spec:
+  enableRebuilds: true
+  mavenBaseLocations:
+    maven-repository-300-jboss: "https://repository.jboss.org/nexus/content/groups/public/"
+    maven-repository-301-jitpack: "https://jitpack.io"
+    maven-repository-302-confluent: "https://packages.confluent.io/maven"
+    maven-repository-303-gradle: "https://repo.gradle.org/artifactory/libs-releases"
+    maven-repository-304-eclipselink: "https://download.eclipse.org/rt/eclipselink/maven.repo"
+    maven-repository-305-redhat: "https://maven.repository.redhat.com/ga"
+    maven-repository-306-gradleplugins: "https://plugins.gradle.org/m2"
+    maven-repository-307-jsweet: "https://repository.jsweet.org/artifactory/libs-release-local"
+    maven-repository-308-jenkins: "https://repo.jenkins-ci.org/public/"
+    maven-repository-309-spring-plugins: "https://repo.springsource.org/plugins-release"
+    maven-repository-309-spring-plugins: https://repo.springsource.org/plugins-release
+    maven-repository-310-dokkadev: https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev
+    maven-repository-311-ajoberstar: https://ajoberstar.org/bintray-backup
+    maven-repository-312-googleandroid: https://dl.google.com/dl/android/maven2/
+    maven-repository-313-kotlinnative14linux: https://download.jetbrains.com/kotlin/native/builds/releases/1.4/linux
+    maven-repository-314-jcs: https://packages.jetbrains.team/maven/p/jcs/maven
+  owner: {{ .Values.quayRespository }}
+  prependTag: "{{ .Values.prependTag }}"
+  relocationPatterns:
+  - relocationPattern:
+      buildPolicy: default
+      patterns:
+      - pattern:
+          from: (io.github.stuartwdouglas.hacbs-test.simple):(simple-jdk17):(99-does-not-exist)
+          to: io.github.stuartwdouglas.hacbs-test.simple:simple-jdk17:0.1.2
+  repository: test-images
+

--- a/deploy/kcp-hacbs-workspace-init/values.yaml
+++ b/deploy/kcp-hacbs-workspace-init/values.yaml
@@ -1,0 +1,7 @@
+quayRespository: redhat-appstudio
+
+quayToken: XXXXXXX
+
+quayTag: XXXXXX
+
+prependTag: "1665346673212"


### PR DESCRIPTION
So this is the first pass at scripting for what I have been doing (along with bootstrapping from infra deployments with local copies of https://github.com/redhat-appstudio/infra-deployments/pull/827) to test on KCP.

In this first pass, I chose Helm (vs. Kustomize) based on a sidebar conversation I had with @sbose78 and where he might be steering the wokspace resource controller work that @rajivnathan has.

That said, we can always pivot from Helm to whatever easily enough.

In addition to the workspace controller work, there is also a dependency on the discussions we've had in the cabal around builder service accounts, where short term, I follow the stop gap approach the build-service controller employs of creating the `pipeline` SA in KCP, but ultimately, the direction being established in https://github.com/redhat-appstudio/book/pull/5 or follow on to that work is also needed long term for setting up jvm build service in a user hacbs workspace.

Thus, as you'll see here, we have to apply rbac on both the kcp and compute cluster sides to facilitate 
- the artifact cache needing to access configmaps for @stuartwdouglas 's bloom filter for cache image registry content
- the dependencybuild pipeline runs needs to update tekton status (namely the results) so that the controller can propogate the state machine accordingly

Other details
- I downloaded helm via curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm
- my infra-deployments `preview.env` sets
- - `export ROOT_WORKSPACE="~"`
- - `export CLUSTER_KUBECONFIG=<path to compute cluster kubeconfig`
- - `export KCP_KUBECONFIG=/tmp/ckcp-admin.kubeconfig` ..... I use the install ckcp script in infra-deployments for bring up kcp
- - `export PIPELINE_SERVICE_LOCAL_DEPLOY=true`
- - also the gitops `MY_GITHUB*` env vars are still needed to fully bootstrap appstudio
- my new scripts reference the 2 KUBECONFIG env vars from `preview.env`

First, run `./deploy/init-hacbs-user-workspace-sa-rbac.sh ` against your compute/workload cluster.

Then, I left these bits as manual (feels like something the workspace resource controller handles independently of jvm build service)
- from KCP, enter the `hacbs` workspace in the infra-deployments bootstrapped env, i.e. `oc ws hacbs` 
- from KCP, create a test namesapce i.e. `oc create ns jvm-bld-test`
- from KCP, enter that new test namespace i.e. `oc project jvm-bld-test` or `kubectl config set-context --current --namespace=jvm-bld-test` and then run `./deploy/init-hacbs-user-workspace.sh `