### PR TITLE
PLNSRVCE-762: update pac infra-deployment update to use regex for commit update

### DIFF
--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -20,10 +20,7 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: >
-        sed -i 
-        -e 's|\(https://github.com/redhat-appstudio/jvm-build-service/.*?ref=\)\(.*\)|\1{{ revision }}|'
-        -e 's/\(newTag: \).*/\1{{ revision }}/'
-        components/hacbs/jvm-build-service/base/kustomization.yaml
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/hacbs/jvm-build-service/base/kustomization.yaml
 
         ./hack/generate-apiexport-overlays.sh components/hacbs/jvm-build-service/
   pipelineRef:


### PR DESCRIPTION
@Michkov this use of regex with sed updated all the sha instances correctly in my local copy of https://github.com/redhat-appstudio/infra-deployments/pull/827 and also correctly left the remaining content untouched.

The only concern I could come up with is whether the `sed` available to the PaC pipelinerun has the `-E` option.

So I took a look at https://github.com/redhat-appstudio/build-definitions/blob/main/tasks/buildah.yaml#L21, pulled that buildah image, booted up a container with it, an confirmed `sed` has the `-E` option.

PTAL

@stuartwdouglas FYI