### PR TITLE
Build with lowest JDK first

### DIFF
--- a/deploy/operator/config/system-config.yaml
+++ b/deploy/operator/config/system-config.yaml
@@ -7,10 +7,10 @@ spec:
   builders:
     jdk8:
       image: quay.io/redhat-appstudio/hacbs-jdk8-builder:9d571619a763f7106f1e37a9340159ea6f598cc9
-      priority: 2000
+      priority: 1000
     jdk11:
       image: quay.io/redhat-appstudio/hacbs-jdk11-builder:9d571619a763f7106f1e37a9340159ea6f598cc9
-      priority: 3000
+      priority: 2000
     jdk17:
       image: quay.io/redhat-appstudio/hacbs-jdk17-builder:9d571619a763f7106f1e37a9340159ea6f598cc9
-      priority: 1000
+      priority: 3000


### PR DESCRIPTION
Some builds don't specify the bytecode level, so we can end up with a higher level if we rebuild with a newer JDK.

This can cause very hard to diagnose build issues.