### PR TITLE
PLNSRVCE-762: update chart/template/instructions to test both developer flow and images at quay.io/redhat-appstudio

### DIFF
--- a/deploy/init-hacbs-user-workspace.sh
+++ b/deploy/init-hacbs-user-workspace.sh
@@ -5,4 +5,4 @@ DIR=`dirname $0`
 #QUAY_USERNAME and QUAY_TOKEN are the same env's you use in the other dev flow scripts
 #QUAY_TAG is either the sha for the images up at quay.io/redhat-appstudio or 'dev' if you are using
 # the jmv-build-service `make dev` flow.
-KUBECONFIG=$KCP_KUBECONFIG helm install --set quayRespository=$QUAY_USERNAME --set quayToken=$QUAY_TOKEN --set quayTag=$QUAY_TAG $DIR/kcp-hacbs-workspace-init --debug --generate-name
+KUBECONFIG=$KCP_KUBECONFIG helm install --set quayJvmBuildServiceRepo=$QUAY_USERNAME --set quayTestRepoOwner=$QUAY_E2E_ORGANIZATION --set quayToken=$QUAY_TOKEN --set quayJvmBuildServiceTag=$QUAY_TAG $DIR/kcp-hacbs-workspace-init --debug --generate-name

--- a/deploy/kcp-hacbs-workspace-init/templates/deployment.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: QUARKUS_THREAD_POOL_MAX_THREADS
           value: "50"
         - name: REGISTRY_OWNER
-          value: {{ .Values.quayRespository }}
+          value: {{ .Values.quayTestRepoOwner }}
         - name: REGISTRY_HOST
           value: quay.io
         - name: REGISTRY_REPOSITORY
@@ -103,7 +103,7 @@ spec:
           value: maven2
         - name: BUILD_POLICY_DEFAULT_STORE_LIST
           value: rebuilt,central,jboss,gradleplugins,confluent,gradle,eclipselink,redhat,jitpack,jsweet,jenkins,spring-plugins,dokkadev,ajoberstar,googleandroid,kotlinnative14linux,jcs
-        image: quay.io/gabemontero/hacbs-jvm-cache:dev
+        image: quay.io/{{ .Values.quayJvmBuildServiceRepo }}/hacbs-jvm-cache:{{ .Values.quayJvmBuildServiceTag }}
         imagePullPolicy: Always
         name: jvm-build-workspace-artifact-cache
         ports:

--- a/deploy/kcp-hacbs-workspace-init/templates/maven-task.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/maven-task.yaml
@@ -177,7 +177,7 @@ spec:
     - name: analyse-dependencies
       securityContext:
         runAsUser: 0
-      image: quay.io/{{ .Values.quayRespository }}/hacbs-jvm-build-request-processor:{{ .Values.quayTag }}
+      image: quay.io/{{ .Values.quayJvmBuildServiceRepo }}/hacbs-jvm-build-request-processor:{{ .Values.quayJvmBuildServiceTag }}
       args:
         - analyse-dependencies
         - path

--- a/deploy/kcp-hacbs-workspace-init/templates/userconfig.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/userconfig.yaml
@@ -23,7 +23,7 @@ spec:
     maven-repository-312-googleandroid: https://dl.google.com/dl/android/maven2/
     maven-repository-313-kotlinnative14linux: https://download.jetbrains.com/kotlin/native/builds/releases/1.4/linux
     maven-repository-314-jcs: https://packages.jetbrains.team/maven/p/jcs/maven
-  owner: {{ .Values.quayRespository }}
+  owner: {{ .Values.quayTestRepoOwner }}
   prependTag: "{{ .Values.prependTag }}"
   relocationPatterns:
   - relocationPattern:

--- a/deploy/kcp-hacbs-workspace-init/values.yaml
+++ b/deploy/kcp-hacbs-workspace-init/values.yaml
@@ -1,7 +1,9 @@
-quayRespository: redhat-appstudio
+quayJvmBuildServiceRepo: redhat-appstudio
+
+quayJvmBuildServiceTag: XXXXXXXX
+
+quayTestRepoOwner: XXXXXXX
 
 quayToken: XXXXXXX
-
-quayTag: XXXXXX
 
 prependTag: "1665346673212"

--- a/readme.adoc
+++ b/readme.adoc
@@ -10,8 +10,12 @@ See each component's directory for specific documentation.
 
 === KCP setup in anticipation of workspace resource controller
 
-- continue to set `QUAY_USERNAME` and `QUAY_TOKEN` like we currently do in our developer flow.
+For our developer flow
+- continue to set `QUAY_USERNAME`, `QUAY_E2E_ORGANIZATION` and `QUAY_TOKEN` like we currently do in our developer flow.
+- admittedly, `QUAY_USERNAME` and `QUAY_E2E_ORGANIZAION` may be the same in the developer flow i.e. your personal quay repository
 - also set `QUAY_TAG` to `dev`
+- image references will become `quay.io/$QUAY_USERNAME/hacbs-jvm-<controller|cache|build-request-processor>:$QUAY_TAG`
+- artifact cache images will be pushed to `quay.io/$QUAY_E2E_ORGANIZATION/....` using `QUAY_TOKEN` to authenticate on the push
 - download `helm` via `curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm`
 - mimic the setting of `CLUSTER_KUBECONFIG` and `KCP_KUBECONFIG` as you have them set in your infra-deployments `preview.env` file
 - from KCP, enter the `hacbs` workspace in the infra-deployments bootstrapped env, i.e. `oc ws hacbs`
@@ -19,3 +23,10 @@ See each component's directory for specific documentation.
 - from KCP, enter that new test namespace i.e. `oc project jvm-bld-test` or `kubectl config set-context --current --namespace=jvm-bld-test`
 - run `./deploy/init-hacbs-user-workspace-sa-rbac.sh` against your compute/workload cluster where you have set `HACBS_WORKSPACE_NAMESPACE` to your KCP test namesapce i.e. `jvm-build-test`
 - run `./deploy/init-hacbs-user-workspace.sh` to initialize you KCP test namespace with the artifact cache and `Tasks` needed to run our test `Pipelines` and `PipelineRuns`
+
+
+For testing against levels from merged PRs
+- either unset `QUAY_USERNAME` or set it to `redhat-appstudio`
+- set `QUAY_TAG` to the specific image/commit sha you want to test against
+- leave `QUAY_E2E_ORGANIZATION` and `QUAY_TOKEN` the same, pointing to your personal quay repo, so that the artifact cache can still push its updates
+- the setting of the `CLUSTER_KUBECONFIG` and `KCP_KUBECONFIG`, workspace/namespace manipulation, and running of the helm scripts remains the same as the developer flow


### PR DESCRIPTION
when testing https://github.com/redhat-appstudio/infra-deployments/pull/842 I realized that the helm charts and related instructions were sufficiently vetted against our `make dev` developer flow, but needed some more flexibility if someone wanted to test against the `quay.io/redhat-appsutdio/hacbs-jvm-*:<commit id>` images created when our PRs merged.

these changes address that 

@stuartwdouglas FYI