### PR TITLE
save more controller-push pac jobs to help debug flakes

### DIFF
--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/max-keep-runs: "2"
+    pipelinesascode.tekton.dev/max-keep-runs: "15"
 spec:
   params:
     - name: git-url


### PR DESCRIPTION
hopefully 15 is enough even on a busy merge day that if we hit that intermittent flake again it won't get purged before we have a chance to look at it