### PR TITLE
Go 1.18

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Check out code
         uses: actions/checkout@v3
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7-13.1655148239 as builder
+FROM golang:1.18 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-appstudio/jvm-build-service
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.2


### PR DESCRIPTION
@gabemontero everything else seems to require 1.18 so it seems like we might as well use it as well?