### PR TITLE
untested ingress placeholder for ingressed based access to the artfact cache

### DIFF
--- a/deploy/kcp-hacbs-workspace-init/templates/ingress.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jvm-build-workspace-artifact-cache
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: jvm-build-workspace-artifact-cache
+                port:
+                  number: 80

--- a/deploy/kcp-hacbs-workspace-init/templates/service.yaml
+++ b/deploy/kcp-hacbs-workspace-init/templates/service.yaml
@@ -7,6 +7,7 @@ spec:
   - name: http
     port: 80
     targetPort: 8080
+    protocol: TCP
   selector:
     app: jvm-build-workspace-artifact-cache
   type: ClusterIP


### PR DESCRIPTION
this is a preliminary, very, very, very tiny step in the long journey of developing https://issues.redhat.com/browse/PLNSRVCE-764

so small that I'm not officially linking it to the story

fwiw I tried creating this from a hacbs enabled user workspace off of my kcp cps home workspace to see if kcp-glbc would post an accessible host in the ingress status,  but none of the objects from my hacbs enabled user workspace were getting synced to the kcp cps workload cluster; if I can enlist the SMEs in question to triage, sort out, and try again, I'll post status in https://issues.redhat.com/browse/PLNSRVCE-764

@stuartwdouglas @sbose78 @Mo3m3n FYI
