### PR TITLE
switch from tektonwrappers to pending pipelineruns for throttling

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -145,7 +145,7 @@ func NewManager(cfg *rest.Config, options ctrl.Options, kcp bool) (ctrl.Manager,
 		return nil, err
 	}
 
-	if err := tektonwrapper.SetupNewReconcilerWithManager(mgr, kcp); err != nil {
+	if err := tektonwrapper.SetupPRReconcilerWithManager(mgr); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/artifactbuild/artifactbuild.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild.go
@@ -62,7 +62,7 @@ func newReconciler(mgr ctrl.Manager) reconcile.Reconciler {
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
 		eventRecorder: mgr.GetEventRecorderFor("ArtifactBuild"),
-		prCreator:     &tektonwrapper.BatchedCreate{},
+		prCreator:     &tektonwrapper.PendingCreate{},
 	}
 }
 

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -74,7 +74,7 @@ func newReconciler(mgr ctrl.Manager) reconcile.Reconciler {
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
 		eventRecorder: mgr.GetEventRecorderFor("DependencyBuild"),
-		prCreator:     &tektonwrapper.BatchedCreate{},
+		prCreator:     &tektonwrapper.PendingCreate{},
 	}
 }
 

--- a/pkg/reconciler/tektonwrapper/controller.go
+++ b/pkg/reconciler/tektonwrapper/controller.go
@@ -26,6 +26,11 @@ var (
 	ctrlLog = ctrl.Log.WithName("tektonwrappercontroller")
 )
 
+func SetupPRReconcilerWithManager(mgr ctrl.Manager) error {
+	r := newPRReconciler(mgr)
+	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.PipelineRun{}).Complete(r)
+}
+
 func SetupNewReconcilerWithManager(mgr ctrl.Manager, kcp bool) error {
 	opts := client.Options{Scheme: runtime.NewScheme()}
 	err := quotav1.AddToScheme(opts.Scheme)

--- a/pkg/reconciler/tektonwrapper/pending.go
+++ b/pkg/reconciler/tektonwrapper/pending.go
@@ -1,0 +1,143 @@
+package tektonwrapper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+//TODO add fields for both constants to userconfig, systemconfig, or both
+const abandonAfter = 3 * time.Hour
+const requeueAfter = 1 * time.Minute
+
+type ReconcilePendingPipelineRun struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+}
+
+func newPRReconciler(mgr ctrl.Manager) reconcile.Reconciler {
+	return &ReconcilePendingPipelineRun{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		eventRecorder: mgr.GetEventRecorderFor("PendingPipelineRun"),
+	}
+}
+
+func (r *ReconcilePendingPipelineRun) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+
+	pr := &v1beta1.PipelineRun{}
+	prerr := r.client.Get(ctx, request.NamespacedName, pr)
+	if prerr != nil {
+		if !errors.IsNotFound(prerr) {
+			return ctrl.Result{}, prerr
+		}
+	}
+
+	if prerr != nil {
+		msg := fmt.Sprintf("Reconcile key %s received not found errors for both pipelineruns and tektonwrapper (probably deleted)\"", request.NamespacedName.String())
+		log.Info(msg)
+		return reconcile.Result{}, client.IgnoreNotFound(r.unthrottleNextOnQueuePlusCleanup(ctx, pr.Namespace))
+	}
+
+	// active (not pending) or terminal state, pop a pending item off the queue
+	if pr.IsDone() || pr.IsCancelled() || pr.IsGracefullyCancelled() || pr.IsGracefullyStopped() || !pr.IsPending() {
+		return reconcile.Result{}, client.IgnoreNotFound(r.unthrottleNextOnQueuePlusCleanup(ctx, pr.Namespace))
+	}
+
+	// have a pending PR
+
+	hardPodCount, pcerr := getHardPodCount(ctx, r.client, pr.Namespace)
+	if pcerr != nil {
+		return reconcile.Result{}, pcerr
+	}
+
+	if hardPodCount > 0 {
+		activeCount, pendingCount, doneCount, totalCount, lerr := r.pipelineRunStats(ctx, pr.Namespace)
+		if lerr != nil {
+			return reconcile.Result{}, lerr
+		}
+
+		switch {
+		case (totalCount - doneCount) < hardPodCount:
+			// below hard pod count quota so remove PR pending
+			break
+		case totalCount == pendingCount:
+			// initial race condition possible if controller starts a bunch before we get events:
+			break
+		case (hardPodCount - 4) <= activeCount: //TODO subtracting ` for the artifact cache, then another 3 for safety buffer, but feels like config option long term
+			// pending item still has to wait because non-terminal items beyond pod limit
+			if !r.timedOut(pr) {
+				return reconcile.Result{RequeueAfter: requeueAfter}, nil
+			}
+			// pending item has waited too long, cancel with an event to explain
+			pr.Spec.Status = v1beta1.PipelineRunSpecStatusCancelled
+			r.eventRecorder.Eventf(pr, corev1.EventTypeWarning, "AbandonedPipelineRun", "after throttling, now past throttling timeout and have to abandon %s:%s", pr.Namespace, pr.Name)
+			return reconcile.Result{}, client.IgnoreNotFound(r.client.Update(ctx, pr))
+		}
+	}
+
+	// remove pending bit
+	pr.Spec.Status = ""
+	return reconcile.Result{}, client.IgnoreNotFound(r.client.Update(ctx, pr))
+}
+
+func (r *ReconcilePendingPipelineRun) unthrottleNextOnQueuePlusCleanup(ctx context.Context, namespace string) error {
+	var err error
+	prList := v1beta1.PipelineRunList{}
+	opts := &client.ListOptions{Namespace: namespace}
+	if err = r.client.List(ctx, &prList, opts); err != nil {
+		return err
+	}
+	for i, pr := range prList.Items {
+		if pr.IsPending() {
+			prList.Items[i].Spec.Status = ""
+			return r.client.Update(ctx, &prList.Items[i])
+		}
+	}
+	return nil
+}
+
+func (r *ReconcilePendingPipelineRun) pipelineRunStats(ctx context.Context, namespace string) (activeCount, pendingCount, doneCount, totalCount int, err error) {
+	prList := v1beta1.PipelineRunList{}
+	opts := &client.ListOptions{Namespace: namespace}
+	if err = r.client.List(ctx, &prList, opts); err != nil {
+		return 0, 0, 0, 0, err
+	}
+
+	totalCount = len(prList.Items)
+	activeCount = 0
+	pendingCount = 0
+	doneCount = 0
+	for _, p := range prList.Items {
+		switch {
+		case p.IsPending():
+			pendingCount++
+		case p.IsDone() || p.IsCancelled() || p.IsGracefullyCancelled() || p.IsGracefullyStopped():
+			doneCount++
+		default:
+			activeCount++
+		}
+
+	}
+	return activeCount, pendingCount, doneCount, totalCount, err
+}
+
+func (r *ReconcilePendingPipelineRun) timedOut(pr *v1beta1.PipelineRun) bool {
+	timeout := pr.ObjectMeta.CreationTimestamp.Add(abandonAfter)
+	return timeout.Before(time.Now())
+}

--- a/pkg/reconciler/tektonwrapper/pending_test.go
+++ b/pkg/reconciler/tektonwrapper/pending_test.go
@@ -1,0 +1,95 @@
+package tektonwrapper
+
+import (
+	"context"
+	"testing"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+	fakequotaclientset "github.com/openshift/client-go/quota/clientset/versioned/fake"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/clusterresourcequota"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/node/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/onsi/gomega"
+)
+
+func setupClientAndPRReconciler(useOpenshift bool, objs ...runtimeclient.Object) (runtimeclient.Client, *ReconcilePendingPipelineRun) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+	_ = v1beta1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = quotav1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	if useOpenshift {
+		clusterresourcequota.QuotaClient = fakequotaclientset.NewSimpleClientset()
+	}
+	reconciler := &ReconcilePendingPipelineRun{client: client, scheme: scheme, eventRecorder: &record.FakeRecorder{}}
+	return client, reconciler
+}
+
+func TestPendingPipelineRun(t *testing.T) {
+	g := NewGomegaWithT(t)
+	client, reconciler := setupClientAndPRReconciler(true)
+
+	pr := v1beta1.PipelineRun{}
+	pr.Namespace = metav1.NamespaceDefault
+	pr.Name = "test"
+	pr.Spec.ServiceAccountName = "foo"
+	ctx := context.TODO()
+	c := &PendingCreate{}
+	err := c.CreateWrapperForPipelineRun(ctx, client, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	key := runtimeclient.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusPending)))
+
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}}))
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus("")))
+}
+
+func TestPendingPipelinerunK8sQuota(t *testing.T) {
+	g := NewGomegaWithT(t)
+	quota := &corev1.ResourceQuota{
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("5"),
+			},
+		},
+	}
+	quota.Namespace = metav1.NamespaceDefault
+	quota.Name = "foo"
+	client, reconciler := setupClientAndPRReconciler(false, quota)
+
+	pr := v1beta1.PipelineRun{}
+	pr.Namespace = metav1.NamespaceDefault
+	pr.Name = "test"
+	pr.Spec.ServiceAccountName = "foo"
+	ctx := context.TODO()
+	c := &PendingCreate{}
+	err := c.CreateWrapperForPipelineRun(ctx, client, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	key := runtimeclient.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusPending)))
+
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}}))
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus("")))
+}

--- a/pkg/reconciler/tektonwrapper/tektonwrapper.go
+++ b/pkg/reconciler/tektonwrapper/tektonwrapper.go
@@ -175,7 +175,7 @@ func (r *ReconcileTektonWrapper) Reconcile(ctx context.Context, request reconcil
 	// see if we have quota for this namespace/project
 
 	// process quota
-	hardPodCount, pcerr := r.getHardPodCount(ctx, tw.Namespace)
+	hardPodCount, pcerr := getHardPodCount(ctx, r.client, tw.Namespace)
 	if pcerr != nil {
 		return reconcile.Result{}, pcerr
 	}
@@ -306,9 +306,9 @@ func (r *ReconcileTektonWrapper) unthrottleNextOnQueuePlusCleanup(ctx context.Co
 	return nil
 }
 
-func (r *ReconcileTektonWrapper) getHardPodCount(ctx context.Context, namespace string) (int, error) {
+func getHardPodCount(ctx context.Context, cl client.Client, namespace string) (int, error) {
 	// this should be nil in kcp
-	if clusterresourcequota.QuotaClient != nil && !r.kcp {
+	if clusterresourcequota.QuotaClient != nil {
 		//TODO controller runtime seemed unable to deal with openshift API and its attempt at mapping to CRDs; we were using
 		// a non caching client; but now we've switched to a shared informer based controller and its caching client
 		quotaList, qerr := clusterresourcequota.QuotaClient.QuotaV1().ClusterResourceQuotas().List(ctx, metav1.ListOptions{})
@@ -347,7 +347,7 @@ func (r *ReconcileTektonWrapper) getHardPodCount(ctx context.Context, namespace 
 		return hardPodCount, nil
 	}
 	quotaList := corev1.ResourceQuotaList{}
-	err := r.client.List(ctx, &quotaList)
+	err := cl.List(ctx, &quotaList)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/reconciler/tektonwrapper/util.go
+++ b/pkg/reconciler/tektonwrapper/util.go
@@ -55,3 +55,11 @@ type ImmediateCreate struct {
 func (i *ImmediateCreate) CreateWrapperForPipelineRun(ctx context.Context, client client.Client, run *v1beta1.PipelineRun) error {
 	return client.Create(ctx, run)
 }
+
+type PendingCreate struct {
+}
+
+func (p *PendingCreate) CreateWrapperForPipelineRun(ctx context.Context, client client.Client, run *v1beta1.PipelineRun) error {
+	run.Spec.Status = v1beta1.PipelineRunSpecStatusPending
+	return client.Create(ctx, run)
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/tektonwrapper"
 	"go/build"
 	"os"
 	"path/filepath"
@@ -41,7 +42,6 @@ import (
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/artifactbuild"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/clusterresourcequota"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/dependencybuild"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/tektonwrapper"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/reconciler/util"
 	taskrunapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	//+kubebuilder:scaffold:imports
@@ -137,7 +137,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	err = dependencybuild.SetupNewReconcilerWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
-	err = tektonwrapper.SetupNewReconcilerWithManager(k8sManager, false)
+	//err = tektonwrapper.SetupNewReconcilerWithManager(k8sManager, false)
+	err = tektonwrapper.SetupPRReconcilerWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 	err = clusterresourcequota.SetupNewReconciler(cfg)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
as part of investigating rate limiting / throttling in upstream tekton with an eye towards broadening the use of such concepts beyond jvm-build-service for stonesoup, I discovered that the "pending" bit for pipelineruns was in fact implemented (TEP-0015).

this PR is an initial pass at using the pending bit vs. our `TektonWrapper` ... if we move forward here, I'll make updates to remove that CRD, as well as rename some packages, etc.

the basic e2e passed for me locally (where I could see PRs start in pending state before our controller moved them out of pending state), but the initial apicurio test failed for me in the initial analyse-dependencies stage (which is unrelated to my changes); so I'm getting up a PR here to compare results and if need be engage @stuartwdouglas for debug