### PR TITLE
add abandoned reason/message

### DIFF
--- a/pkg/reconciler/pendingpipelinerun/pending_test.go
+++ b/pkg/reconciler/pendingpipelinerun/pending_test.go
@@ -3,6 +3,7 @@ package pendingpipelinerun
 import (
 	"context"
 	"testing"
+	"time"
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	fakequotaclientset "github.com/openshift/client-go/quota/clientset/versioned/fake"
@@ -19,6 +20,8 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"knative.dev/pkg/apis"
 
 	. "github.com/onsi/gomega"
 )
@@ -39,7 +42,7 @@ func setupClientAndPRReconciler(useOpenshift bool, objs ...runtimeclient.Object)
 
 func TestPendingPipelineRun(t *testing.T) {
 	g := NewGomegaWithT(t)
-	client, reconciler := setupClientAndPRReconciler(true)
+	client, reconciler := setupClientAndPRReconciler(false)
 
 	pr := v1beta1.PipelineRun{}
 	pr.Namespace = metav1.NamespaceDefault
@@ -61,7 +64,7 @@ func TestPendingPipelineRun(t *testing.T) {
 	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus("")))
 }
 
-func TestPendingPipelinerunK8sQuota(t *testing.T) {
+func TestPendingPipelinerunUnderK8sQuota(t *testing.T) {
 	g := NewGomegaWithT(t)
 	quota := &corev1.ResourceQuota{
 		Spec: corev1.ResourceQuotaSpec{
@@ -92,4 +95,110 @@ func TestPendingPipelinerunK8sQuota(t *testing.T) {
 	err = client.Get(ctx, key, &pr)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus("")))
+}
+
+func TestExceedK8sQuota(t *testing.T) {
+	g := NewGomegaWithT(t)
+	quota := &corev1.ResourceQuota{
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("5"),
+			},
+		},
+	}
+	quota.Namespace = metav1.NamespaceDefault
+	quota.Name = "foo"
+	client, reconciler := setupClientAndPRReconciler(false, quota)
+	prs := []v1beta1.PipelineRun{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test1"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test2"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test3"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test4"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test5"}},
+	}
+	ctx := context.TODO()
+	c := &PendingCreate{}
+	for _, pr := range prs {
+		err := c.CreateWrapperForPipelineRun(ctx, client, &pr)
+		g.Expect(err).NotTo(HaveOccurred())
+		key := runtimeclient.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}
+		err = client.Get(ctx, key, &pr)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusPending)))
+	}
+
+	// this goes down the totalCount == pendingCount path, after not falling into the below quota path
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: prs[0].Namespace, Name: prs[0].Name}}))
+	key := runtimeclient.ObjectKey{Namespace: prs[0].Namespace, Name: prs[0].Name}
+	pr := v1beta1.PipelineRun{}
+	err := client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus("")))
+
+	// now, with at least 1 non pending pr, finagle creation time to be timed out
+	key = runtimeclient.ObjectKey{Namespace: prs[1].Namespace, Name: prs[1].Name}
+	err = client.Get(ctx, key, &pr)
+	pr.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Unix(0, 0))
+	err = client.Update(ctx, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: prs[1].Namespace, Name: prs[1].Name}}))
+	key = runtimeclient.ObjectKey{Namespace: prs[1].Namespace, Name: prs[1].Name}
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Annotations).NotTo(BeNil())
+	val, ok := pr.Annotations[AbandonedAnnotation]
+	g.Expect(ok).To(BeTrue())
+	g.Expect(val).To(Equal("true"))
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusCancelled)))
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: prs[1].Namespace, Name: prs[1].Name}}))
+	key = runtimeclient.ObjectKey{Namespace: prs[1].Namespace, Name: prs[1].Name}
+	err = client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Status.GetCondition(apis.ConditionSucceeded).Reason).To(Equal(AbandonedReason))
+
+}
+
+func TestExceedK8sQuotaNotTimedOut(t *testing.T) {
+	g := NewGomegaWithT(t)
+	quota := &corev1.ResourceQuota{
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("5"),
+			},
+		},
+	}
+	quota.Namespace = metav1.NamespaceDefault
+	quota.Name = "foo"
+	client, reconciler := setupClientAndPRReconciler(false, quota)
+	prs := []v1beta1.PipelineRun{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test1", CreationTimestamp: metav1.NewTime(time.Now())}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test2", CreationTimestamp: metav1.NewTime(time.Now())}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test3", CreationTimestamp: metav1.NewTime(time.Now())}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test4", CreationTimestamp: metav1.NewTime(time.Now())}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test5", CreationTimestamp: metav1.NewTime(time.Now())}},
+	}
+	ctx := context.TODO()
+	c := &PendingCreate{}
+	for _, pr := range prs {
+		err := c.CreateWrapperForPipelineRun(ctx, client, &pr)
+		g.Expect(err).NotTo(HaveOccurred())
+		key := runtimeclient.ObjectKey{Namespace: pr.Namespace, Name: pr.Name}
+		err = client.Get(ctx, key, &pr)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusPending)))
+	}
+
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: prs[0].Namespace, Name: prs[0].Name}}))
+	key := runtimeclient.ObjectKey{Namespace: prs[0].Namespace, Name: prs[0].Name}
+	pr := v1beta1.PipelineRun{}
+	err := client.Get(ctx, key, &pr)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus("")))
+
+	// with start time set, the PR should registered as timed out
+	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: prs[1].Namespace, Name: prs[1].Name}}))
+	key = runtimeclient.ObjectKey{Namespace: prs[1].Namespace, Name: prs[1].Name}
+	err = client.Get(ctx, key, &pr)
+	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusPending)))
+
 }

--- a/pkg/reconciler/pendingpipelinerun/pending_test.go
+++ b/pkg/reconciler/pendingpipelinerun/pending_test.go
@@ -137,7 +137,7 @@ func TestExceedK8sQuota(t *testing.T) {
 
 	// now, with at least 1 non pending pr, finagle creation time to be timed out
 	key = runtimeclient.ObjectKey{Namespace: prs[1].Namespace, Name: prs[1].Name}
-	err = client.Get(ctx, key, &pr)
+	g.Expect(client.Get(ctx, key, &pr)).NotTo(HaveOccurred())
 	pr.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Unix(0, 0))
 	err = client.Update(ctx, &pr)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -198,7 +198,7 @@ func TestExceedK8sQuotaNotTimedOut(t *testing.T) {
 	// with start time set, the PR should registered as timed out
 	g.Expect(reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: prs[1].Namespace, Name: prs[1].Name}}))
 	key = runtimeclient.ObjectKey{Namespace: prs[1].Namespace, Name: prs[1].Name}
-	err = client.Get(ctx, key, &pr)
+	g.Expect(client.Get(ctx, key, &pr)).NotTo(HaveOccurred())
 	g.Expect(pr.Spec.Status).To(Equal(v1beta1.PipelineRunSpecStatus(v1beta1.PipelineRunSpecStatusPending)))
 
 }


### PR DESCRIPTION
a stab at providing data on a pipelinerun cacnelled because of throtting that we in fact cancelled because we could never thorttle in a reasonable time

I could see this being reflected in other existing ways (a new condition, results) which I can detail for discussion in a forthcoming ADR in the "book" repo

I also think we could propose a tweak to TEP-0015 upstream where we augment pr.spec.status to allow for reason/message in additional to pending vs. active vs. cancelled state.

also added more unit tests around abandoning and exceeding quota