### PR TITLE
add quota def from service registry dev script

### DIFF
--- a/deploy/openshift-development.sh
+++ b/deploy/openshift-development.sh
@@ -4,3 +4,5 @@ DIR=`dirname $0`
 $DIR/install-openshift-pipelines.sh
 $DIR/base-development.sh $1
 
+oc apply -f $DIR/openshift-quota.yaml
+

--- a/deploy/openshift-quota.yaml
+++ b/deploy/openshift-quota.yaml
@@ -1,0 +1,14 @@
+apiVersion: quota.openshift.io/v1
+kind: ClusterResourceQuota
+metadata:
+  name: for-test-jvm-namespace-deployments
+spec:
+  quota:
+    hard:
+      count/deployments.apps: "30"
+      count/deploymentconfigs.apps: "30"
+      count/pods: "50"
+  selector:
+    annotations:
+      openshift.io/requester: test-jvm-namespace
+    labels: null


### PR DESCRIPTION
in theory we could create k8s quota and make a similar addition for the minikube dev flow, but minimizing the change for now

do know that the staging cluster will be getting openshift based quota applied like it did in the pre-kcp days