### PR TITLE
Fix: Removes timeout issue when deploying large artifact containers

### DIFF
--- a/java-components/build-request-processor/src/main/docker/Dockerfile.all-in-one
+++ b/java-components/build-request-processor/src/main/docker/Dockerfile.all-in-one
@@ -17,5 +17,5 @@ EXPOSE 8080
 USER 1001
 
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djib.httpTimeout=0"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"


### PR DESCRIPTION
Removes the timeout for uploading container images using the jib plugin