### PR TITLE
fix: give priority to image name from env var

### DIFF
--- a/pkg/reconciler/util/util.go
+++ b/pkg/reconciler/util/util.go
@@ -42,6 +42,14 @@ func GetImageName(ctx context.Context, client client.Client, log logr.Logger, su
 			return "", err
 		}
 	}
+
+	// Get the image name using a controller's env var (if the env var value is specified)
+	ciImageName := os.Getenv(envvar)
+	if len(ciImageName) != 0 {
+		log.Info(fmt.Sprintf("GetImageName using %s for hacbs-jvm-%s", ciImageName, substr))
+		return ciImageName, nil
+	}
+
 	// not found errors are either fake/unit test path, or that we are on KCP and don't have access to the namespace
 	// name the controller is running under, and hence cannot inspect its image ref; we distinguish between the two
 	// via an env var that is set from infra-deployments as part of KCP+workload cluster bootstrap, or the test setup
@@ -62,17 +70,8 @@ func GetImageName(ctx context.Context, client client.Client, log logr.Logger, su
 	}
 
 	retImg := ""
-	switch {
-	case strings.Contains(depImg, "controller"):
+	if strings.Contains(depImg, "controller") {
 		retImg = strings.Replace(depImg, "controller", substr, 1)
-	default:
-		ciImageName := os.Getenv(envvar)
-		if len(ciImageName) == 0 {
-			return "", fmt.Errorf("none of our image name patterns exist; controller image %s, %s not set", depImg, envvar)
-		}
-		retImg = ciImageName
-	}
-	if len(retImg) > 0 {
 		log.Info(fmt.Sprintf("GetImageName using %s for hacbs-jvm-%s", retImg, substr))
 		return retImg, nil
 	}

--- a/pkg/reconciler/util/util.go
+++ b/pkg/reconciler/util/util.go
@@ -75,5 +75,5 @@ func GetImageName(ctx context.Context, client client.Client, log logr.Logger, su
 		log.Info(fmt.Sprintf("GetImageName using %s for hacbs-jvm-%s", retImg, substr))
 		return retImg, nil
 	}
-	return retImg, fmt.Errorf("could not determine image for %s where image var is %s IMAGE_TAG env is %s and deployment get error is %s", substr, depImg, imgTag, err.Error())
+	return retImg, fmt.Errorf("could not determine image for %s where image var is %s IMAGE_TAG env is %s and deployment get error is %+v", substr, depImg, imgTag, err)
 }

--- a/pkg/reconciler/util/util_test.go
+++ b/pkg/reconciler/util/util_test.go
@@ -1,0 +1,111 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	v1core "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	imageRepoTestValue            = "image-repo"
+	imageTagTestValue             = "image-tag"
+	controllerDeploymentImageName = "deployment-test-controller-image-name"
+	reqprocessorImageEnvVarName   = "JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE"
+	reqprocessorImageEnvVarValue  = "reqprocessor_image"
+	substr                        = "build-request-processor"
+)
+
+var logger = logr.New(logr.Discard().GetSink())
+
+func setupControllerDeployment(noContainers bool) *appsv1.Deployment {
+	var containers []v1core.Container
+
+	if !noContainers {
+		containers = append(containers, v1core.Container{Image: controllerDeploymentImageName})
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ControllerDeploymentName,
+			Namespace: ControllerNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: v1core.PodTemplateSpec{
+				Spec: v1core.PodSpec{
+					Containers: containers,
+				},
+			},
+		},
+	}
+}
+
+func TestGetImageName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+
+	tests := []struct {
+		name             string
+		envKey           string
+		envValue         string
+		imageRepo        string
+		imageTag         string
+		noContainerImage bool
+		want             string
+		wantErr          bool
+	}{
+		{
+			name:     "should get the reqprocesor image from the env var",
+			envKey:   reqprocessorImageEnvVarName,
+			envValue: reqprocessorImageEnvVarValue,
+			want:     reqprocessorImageEnvVarValue,
+			wantErr:  false,
+		},
+		{
+			name:      "should get the reqprocessor image name based on the values in ImageTag and ImageRepo variables",
+			imageRepo: imageRepoTestValue,
+			imageTag:  imageTagTestValue,
+			want:      fmt.Sprintf("quay.io/%s/hacbs-jvm-%s:%s", imageRepoTestValue, substr, imageTagTestValue),
+			wantErr:   false,
+		},
+		{
+			name:    "should get the reqprocessor image name based on the image name specified in the controller's deployment",
+			want:    strings.Replace(controllerDeploymentImageName, "controller", substr, 1),
+			wantErr: false,
+		},
+		{
+			name:             "should fail to get the reqprocessor image if the controller deployment does not contain containers in template spec",
+			want:             "",
+			noContainerImage: true,
+			wantErr:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.envKey) > 0 {
+				t.Setenv(tt.envKey, tt.envValue)
+			}
+			ImageTag = tt.imageTag
+			ImageRepo = tt.imageRepo
+
+			d := setupControllerDeployment(tt.noContainerImage)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(d).Build()
+
+			got, err := GetImageName(context.Background(), fakeClient, logger, substr, reqprocessorImageEnvVarName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetImageName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetImageName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Recently I stumbled upon an issue with rebuilding dependencies. the issue was caused by a wrong image name specified for a reqprocessor, that was generated by a controller.

I expected the image name from env vars (`JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE`, `JVM_BUILD_SERVICE_CACHE_IMAGE`) should have a priority, i.e. first check if these env vars exist and if not, then generate the image names based on the controller image name etc. But currently it's not the case.

This update should solve it. 

If it makes sense, I will add some unit test.