### PR TITLE
Drop pod limits

### DIFF
--- a/openshift-with-appstudio-test/e2e/periodic_test.go
+++ b/openshift-with-appstudio-test/e2e/periodic_test.go
@@ -36,7 +36,7 @@ func TestServiceRegistry(t *testing.T) {
 		Spec: quotav1.ClusterResourceQuotaSpec{
 			Quota: corev1.ResourceQuotaSpec{
 				Hard: corev1.ResourceList{
-					corev1.ResourceName("count/pods"): resource.MustParse("150"),
+					corev1.ResourceName("count/pods"): resource.MustParse("70"),
 				},
 			},
 			Selector: quotav1.ClusterResourceQuotaSelector{


### PR DESCRIPTION
The higher limit can sometimes overwhelm the cache