### PR TITLE
Use the git hash for checkout

### DIFF
--- a/deploy/crds/base/jvmbuildservice.io_artifactbuilds.yaml
+++ b/deploy/crds/base/jvmbuildservice.io_artifactbuilds.yaml
@@ -53,6 +53,8 @@ spec:
                 type: string
               scm:
                 properties:
+                  commitHash:
+                    type: string
                   path:
                     type: string
                   private:

--- a/deploy/crds/base/jvmbuildservice.io_dependencybuilds.yaml
+++ b/deploy/crds/base/jvmbuildservice.io_dependencybuilds.yaml
@@ -50,6 +50,8 @@ spec:
             properties:
               scm:
                 properties:
+                  commitHash:
+                    type: string
                   path:
                     type: string
                   private:

--- a/pkg/apis/jvmbuildservice/v1alpha1/common_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/common_types.go
@@ -1,9 +1,10 @@
 package v1alpha1
 
 type SCMInfo struct {
-	SCMURL  string `json:"scmURL,omitempty"`
-	SCMType string `json:"scmType,omitempty"`
-	Tag     string `json:"tag,omitempty"`
-	Path    string `json:"path,omitempty"`
-	Private bool   `json:"private,omitempty"`
+	SCMURL     string `json:"scmURL,omitempty"`
+	SCMType    string `json:"scmType,omitempty"`
+	Tag        string `json:"tag,omitempty"`
+	CommitHash string `json:"commitHash,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Private    bool   `json:"private,omitempty"`
 }

--- a/pkg/reconciler/artifactbuild/artifactbuild.go
+++ b/pkg/reconciler/artifactbuild/artifactbuild.go
@@ -40,6 +40,7 @@ const (
 	ArtifactBuildIdLabel          = "jvmbuildservice.io/abr-id"
 	PipelineResultScmUrl          = "scm-url"
 	PipelineResultScmTag          = "scm-tag"
+	PipelineResultScmHash         = "scm-hash"
 	PipelineResultScmType         = "scm-type"
 	PipelineResultContextPath     = "context"
 	PipelineResultMessage         = "message"
@@ -224,6 +225,8 @@ func (r *ReconcileArtifactBuild) handlePipelineRunReceived(ctx context.Context, 
 			abr.Status.SCMInfo.SCMURL = res.Value
 		case PipelineResultScmTag:
 			abr.Status.SCMInfo.Tag = res.Value
+		case PipelineResultScmHash:
+			abr.Status.SCMInfo.CommitHash = res.Value
 		case PipelineResultScmType:
 			abr.Status.SCMInfo.SCMType = res.Value
 		case PipelineResultMessage:
@@ -414,11 +417,12 @@ func (r *ReconcileArtifactBuild) handleStateDiscovering(ctx context.Context, log
 			return reconcile.Result{}, err
 		}
 		db.Spec = v1alpha1.DependencyBuildSpec{ScmInfo: v1alpha1.SCMInfo{
-			SCMURL:  abr.Status.SCMInfo.SCMURL,
-			SCMType: abr.Status.SCMInfo.SCMType,
-			Tag:     abr.Status.SCMInfo.Tag,
-			Path:    abr.Status.SCMInfo.Path,
-			Private: abr.Status.SCMInfo.Private,
+			SCMURL:     abr.Status.SCMInfo.SCMURL,
+			SCMType:    abr.Status.SCMInfo.SCMType,
+			Tag:        abr.Status.SCMInfo.Tag,
+			CommitHash: abr.Status.SCMInfo.CommitHash,
+			Path:       abr.Status.SCMInfo.Path,
+			Private:    abr.Status.SCMInfo.Private,
 		}, Version: abr.Spec.GAV[strings.LastIndex(abr.Spec.GAV, ":")+1:]}
 		if err := r.client.Status().Update(ctx, abr); err != nil {
 			return reconcile.Result{}, err
@@ -661,6 +665,7 @@ func (r *ReconcileArtifactBuild) createLookupScmInfoTask(ctx context.Context, lo
 		Results: []pipelinev1beta1.TaskResult{
 			{Name: PipelineResultScmUrl},
 			{Name: PipelineResultScmTag},
+			{Name: PipelineResultScmHash},
 			{Name: PipelineResultScmType},
 			{Name: PipelineResultContextPath},
 			{Name: PipelineResultPrivate},
@@ -678,6 +683,8 @@ func (r *ReconcileArtifactBuild) createLookupScmInfoTask(ctx context.Context, lo
 					"$(results." + PipelineResultScmUrl + ".path)",
 					"--scm-tag",
 					"$(results." + PipelineResultScmTag + ".path)",
+					"--scm-hash",
+					"$(results." + PipelineResultScmHash + ".path)",
 					"--scm-type",
 					"$(results." + PipelineResultScmType + ".path)",
 					"--message",

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -493,7 +493,7 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, log 
 	pr.Spec.Params = []pipelinev1beta1.Param{
 		{Name: PipelineBuildId, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Name}},
 		{Name: PipelineScmUrl, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.ScmInfo.SCMURL}},
-		{Name: PipelineScmTag, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.ScmInfo.Tag}},
+		{Name: PipelineScmTag, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.ScmInfo.CommitHash}},
 		{Name: PipelinePath, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Spec.ScmInfo.Path}},
 		{Name: PipelineImage, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: db.Status.CurrentBuildRecipe.Image}},
 		{Name: PipelineRequestProcessorImage, Value: pipelinev1beta1.ArrayOrString{Type: pipelinev1beta1.ParamTypeString, StringVal: buildRequestProcessorImage}},
@@ -760,7 +760,7 @@ func (r *ReconcileDependencyBuild) createLookupBuildInfoPipeline(ctx context.Con
 		"--scm-url",
 		build.ScmInfo.SCMURL,
 		"--scm-tag",
-		build.ScmInfo.Tag,
+		build.ScmInfo.CommitHash,
 		"--context",
 		path,
 		"--version",

--- a/pkg/reconciler/dependencybuild/dependencybuild_test.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild_test.go
@@ -159,6 +159,7 @@ func TestStateDetect(t *testing.T) {
 		db.Status.State = v1alpha1.DependencyBuildStateNew
 		db.Spec.ScmInfo.SCMURL = "some-url"
 		db.Spec.ScmInfo.Tag = "some-tag"
+		db.Spec.ScmInfo.CommitHash = "some-hash"
 		db.Spec.ScmInfo.Path = "some-path"
 		db.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: hashToString(db.Spec.ScmInfo.SCMURL + db.Spec.ScmInfo.Tag + db.Spec.ScmInfo.Path)}
 
@@ -209,7 +210,7 @@ func TestStateDetect(t *testing.T) {
 			for _, param := range pr.Spec.Params {
 				switch param.Name {
 				case PipelineScmTag:
-					g.Expect(param.Value.StringVal).Should(Equal("some-tag"))
+					g.Expect(param.Value.StringVal).Should(Equal("some-hash"))
 				case PipelinePath:
 					g.Expect(param.Value.StringVal).Should(Equal("some-path"))
 				case PipelineScmUrl:


### PR DESCRIPTION
When performing the tag mapping note the git hash and use this hash for all further steps.

This will let us record the hash that was used for a particular build.