### PR TITLE
Increase timeout

### DIFF
--- a/openshift-with-appstudio-test/e2e/util.go
+++ b/openshift-with-appstudio-test/e2e/util.go
@@ -113,7 +113,7 @@ func setup(t *testing.T, ta *testArgs) *testArgs {
 	if ta == nil {
 		ta = &testArgs{
 			t:        t,
-			timeout:  time.Minute * 10,
+			timeout:  time.Minute * 15,
 			interval: time.Second * 15,
 		}
 	}


### PR DESCRIPTION
In some cases if the builds are a bit slow the tests can timeout