### PR TITLE
Remove tar.gz file from deployment

### DIFF
--- a/deploy/base/gradle-v0.1.yaml
+++ b/deploy/base/gradle-v0.1.yaml
@@ -148,7 +148,7 @@ spec:
         systemProp.http.nonProxyHosts=$(params.PROXY_NON_PROXY_HOSTS)
 
         # Settings for <https://github.com/vanniktech/gradle-maven-publish-plugin>
-        RELEASE_REPOSITORY_URL=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo
+        RELEASE_REPOSITORY_URL=file:$(workspaces.source.path)/artifacts
         RELEASE_SIGNING_ENABLED=false
         EOF
         cat > ${GRADLE_USER_HOME}/init.gradle << EOF
@@ -281,12 +281,12 @@ spec:
         export LC_ALL="en_US.UTF-8"
 
         if [ -n "$(params.ENFORCE_VERSION)" ]; then
-            gradle-manipulator -DAProxDeployUrl=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo --no-colour --info --stacktrace -l "${GRADLE_HOME}" $(params.GRADLE_MANIPULATOR_ARGS) -DversionOverride=$(params.ENFORCE_VERSION) generateAlignmentMetadata || exit 1
+            gradle-manipulator -DAProxDeployUrl=file:$(workspaces.source.path)/artifacts --no-colour --info --stacktrace -l "${GRADLE_HOME}" $(params.GRADLE_MANIPULATOR_ARGS) -DversionOverride=$(params.ENFORCE_VERSION) generateAlignmentMetadata || exit 1
         else
-            gradle-manipulator -DAProxDeployUrl=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo --no-colour --info --stacktrace -l "${GRADLE_HOME}" $(params.GRADLE_MANIPULATOR_ARGS) generateAlignmentMetadata || exit 1
+            gradle-manipulator -DAProxDeployUrl=file:$(workspaces.source.path)/artifacts --no-colour --info --stacktrace -l "${GRADLE_HOME}" $(params.GRADLE_MANIPULATOR_ARGS) generateAlignmentMetadata || exit 1
         fi
 
-        gradle -DAProxDeployUrl=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo $@ || exit 1
+        gradle -DAProxDeployUrl=file:$(workspaces.source.path)/artifacts $@ || exit 1
 
         # fix-permissions-for-builder
         chown 1001:1001 -R $(workspaces.source.path)

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/ContainerDeployCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/ContainerDeployCommand.java
@@ -2,6 +2,7 @@ package com.redhat.hacbs.container.analyser.deploy;
 
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import javax.enterprise.inject.spi.BeanManager;
@@ -38,7 +39,7 @@ public class ContainerDeployCommand extends DeployCommand {
     }
 
     @Override
-    protected void doDeployment(Path deployFile, Path sourcePath, Path logsPath) throws Exception {
+    protected void doDeployment(Path deployDir, Path sourcePath, Path logsPath, Set<String> gavs) throws Exception {
         ContainerRegistryDeployer deployer = new ContainerRegistryDeployer(host, port, owner, token.orElse(""), repository,
                 insecure,
                 prependTag, new Consumer<String>() {
@@ -47,7 +48,7 @@ public class ContainerDeployCommand extends DeployCommand {
                         imageName = s;
                     }
                 });
-        deployer.deployArchive(deployFile, sourcePath, logsPath);
+        deployer.deployArchive(deployDir, sourcePath, logsPath, gavs);
 
     }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/DeployData.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/DeployData.java
@@ -15,6 +15,21 @@ public final class DeployData {
         this.gavs = gavs;
     }
 
+    public DeployData(Path artifactsPath, Set<String> gavs, String prependTag) {
+        this.artifactsPath = artifactsPath;
+        this.gavs = gavs.stream().map((s) -> {
+            var parts = s.split(":");
+            String tag = DeployerUtil.sha256sum(parts[0], parts[1], parts[2]);
+            if (!prependTag.isBlank()) {
+                tag = prependTag + "_" + tag;
+            }
+            if (tag.length() > 128) {
+                tag = tag.substring(0, 128);
+            }
+            return new Gav(parts[0], parts[1], parts[2], tag);
+        }).collect(Collectors.toSet());
+    }
+
     public Path getArtifactsPath() {
         return artifactsPath;
     }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/Deployer.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/Deployer.java
@@ -1,9 +1,10 @@
 package com.redhat.hacbs.container.analyser.deploy;
 
 import java.nio.file.Path;
+import java.util.Set;
 
 public interface Deployer {
 
-    public void deployArchive(Path tarGzFile, Path sourcePath, Path logsPath) throws Exception;
+    public void deployArchive(Path tarGzFile, Path sourcePath, Path logsPath, Set<String> gavs) throws Exception;
 
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/S3DeployCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/deploy/S3DeployCommand.java
@@ -1,6 +1,7 @@
 package com.redhat.hacbs.container.analyser.deploy;
 
 import java.nio.file.Path;
+import java.util.Set;
 
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
@@ -29,8 +30,8 @@ public class S3DeployCommand extends DeployCommand {
     }
 
     @Override
-    protected void doDeployment(Path deployFile, Path sourcePath, Path logsPath) throws Exception {
+    protected void doDeployment(Path deployFile, Path sourcePath, Path logsPath, Set<String> gavs) throws Exception {
         S3Deployer deployer = new S3Deployer(s3Client, deploymentBucket, prefix);
-        deployer.deployArchive(deployFile, sourcePath, logsPath);
+        deployer.deployArchive(deployFile, sourcePath, logsPath, gavs);
     }
 }

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -47,7 +47,7 @@ func createPipelineSpec(tool string, commitTime int64, jbsConfig *v1alpha12.JBSC
 		"--repository-url=$(params.CACHE_URL)",
 		"--global-settings=/usr/share/maven/conf/settings.xml",
 		"--settings=$(workspaces.build-settings.path)/settings.xml",
-		"--deploy-path=$(workspaces.source.path)/hacbs-jvm-deployment-repo",
+		"--deploy-path=$(workspaces.source.path)/artifacts",
 		"--results-file=$(results." + artifactbuild.PassedVerification + ".path)",
 	}
 
@@ -56,7 +56,7 @@ func createPipelineSpec(tool string, commitTime int64, jbsConfig *v1alpha12.JBSC
 	}
 	deployArgs := []string{
 		"deploy-container",
-		"--tar-path=$(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz",
+		"--path=$(workspaces.source.path)/artifacts",
 		"--logs-path=$(workspaces.source.path)/logs",
 		"--source-path=$(workspaces.source.path)/source",
 		"--task-run=$(context.taskRun.name)",

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -612,7 +612,7 @@ func (r *ReconcileDependencyBuild) handleBuildPipelineRunReceived(ctx context.Co
 					if err != nil {
 						return reconcile.Result{}, err
 					}
-				} else if i.Name == artifactbuild.DeployedResources {
+				} else if i.Name == artifactbuild.DeployedResources && len(i.Value) > 0 {
 					//we need to create 'DeployedArtifact' resources for the objects that were deployed
 					deployed := strings.Split(i.Value, ",")
 					db.Status.DeployedArtifacts = deployed

--- a/pkg/reconciler/dependencybuild/scripts/ant-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/ant-build.sh
@@ -60,4 +60,3 @@ echo "$(which ant) $@"
 
 eval "ant $@" | tee $(workspaces.source.path)/logs/ant.log
 
-tar czf "$(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz" -C "$(workspaces.source.path)/hacbs-jvm-deployment-repo" .

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -75,11 +75,8 @@ EOF
 #TODO: should we disable tracing for these builds? It means we can't track dependencies directly, so we can't detect contaminants
 rm -f gradle/verification-metadata.xml
 
-gradle-manipulator $INIT_SCRIPTS -DAProxDeployUrl=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo --no-colour --info --stacktrace -l "${GRADLE_HOME}" -DdependencySource=NONE -DignoreUnresolvableDependencies=true -DpluginRemoval=ALL -DversionModification=false "${ADDITIONAL_ARGS}" generateAlignmentMetadata  | tee $(workspaces.source.path)/logs/gme.log
+gradle-manipulator $INIT_SCRIPTS -DAProxDeployUrl=file:$(workspaces.source.path)/artifacts --no-colour --info --stacktrace -l "${GRADLE_HOME}" -DdependencySource=NONE -DignoreUnresolvableDependencies=true -DpluginRemoval=ALL -DversionModification=false "${ADDITIONAL_ARGS}" generateAlignmentMetadata  | tee $(workspaces.source.path)/logs/gme.log
 
 cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
 
-gradle $INIT_SCRIPTS -DAProxDeployUrl=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo --info --stacktrace -x test -Prelease.version=$(params.ENFORCE_VERSION) "$@"  | tee $(workspaces.source.path)/logs/gradle.log
-
-tar -czf "$(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz" -C "$(workspaces.source.path)/hacbs-jvm-deployment-repo" .
-
+gradle $INIT_SCRIPTS -DAProxDeployUrl=file:$(workspaces.source.path)/artifacts --info --stacktrace -x test -Prelease.version=$(params.ENFORCE_VERSION) "$@"  | tee $(workspaces.source.path)/logs/gradle.log

--- a/pkg/reconciler/dependencybuild/scripts/gradle-settings.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-settings.sh
@@ -20,7 +20,7 @@ systemProp.http.socketTimeout=600000
 systemProp.http.connectionTimeout=600000
 
 # Settings for <https://github.com/vanniktech/gradle-maven-publish-plugin>
-RELEASE_REPOSITORY_URL=file:$(workspaces.source.path)/hacbs-jvm-deployment-repo
+RELEASE_REPOSITORY_URL=file:$(workspaces.source.path)/artifacts
 RELEASE_SIGNING_ENABLED=false
 EOF
 cat > "${GRADLE_USER_HOME}"/init.gradle << EOF

--- a/pkg/reconciler/dependencybuild/scripts/maven-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/maven-build.sh
@@ -26,7 +26,4 @@ EOF
 cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
 #we can't use array parameters directly here
 #we pass them in as goals
-mvn -B -e -s "$(workspaces.build-settings.path)/settings.xml" $@ "-DaltDeploymentRepository=local::file:$(workspaces.source.path)/hacbs-jvm-deployment-repo" "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy" | tee $(workspaces.source.path)/logs/maven.log
-
-
-tar -czf "$(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz" -C "$(workspaces.source.path)/hacbs-jvm-deployment-repo" .
+mvn -B -e -s "$(workspaces.build-settings.path)/settings.xml" $@ "-DaltDeploymentRepository=local::file:$(workspaces.source.path)/artifacts" "org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy" | tee $(workspaces.source.path)/logs/maven.log

--- a/pkg/reconciler/dependencybuild/scripts/sbt-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/sbt-build.sh
@@ -32,7 +32,7 @@ EOF
 
 mkdir "$HOME/.sbt/1.0/"
 cat >"$HOME/.sbt/1.0/global.sbt" <<EOF
-publishTo := Some(("MavenRepo" at s"file://$(workspaces.source.path)/hacbs-jvm-deployment-repo").withAllowInsecureProtocol(true)),
+publishTo := Some(("MavenRepo" at s"file://$(workspaces.source.path)/artifacts").withAllowInsecureProtocol(true)),
 EOF
 #This is replaced when the task is created by the golang code
 cat <<EOF
@@ -46,6 +46,3 @@ echo "Command is:"
 echo "sbt $@ "
 
 eval "sbt $@" | tee $(workspaces.source.path)/logs/sbt.log
-
-
-tar -czf "$(workspaces.source.path)/hacbs-jvm-deployment-repo.tar.gz" -C "$(workspaces.source.path)/hacbs-jvm-deployment-repo" .


### PR DESCRIPTION
This is left over from when this file was POSTed to the cache. There is no need for it now, and it significantly complicates the code.