### PR TITLE
Add commitHash

### DIFF
--- a/java-components/resource-model/src/main/java/com/redhat/hacbs/resources/model/v1alpha1/ScmInfo.java
+++ b/java-components/resource-model/src/main/java/com/redhat/hacbs/resources/model/v1alpha1/ScmInfo.java
@@ -6,6 +6,7 @@ public class ScmInfo {
     private String scmType;
     private String scmURL;
     private String tag;
+    private String commitHash;
 
     private String path;
 
@@ -54,6 +55,15 @@ public class ScmInfo {
 
     public ScmInfo setPrivateRepo(boolean privateRepo) {
         this.privateRepo = privateRepo;
+        return this;
+    }
+
+    public String getCommitHash() {
+        return commitHash;
+    }
+
+    public ScmInfo setCommitHash(String commitHash) {
+        this.commitHash = commitHash;
         return this;
     }
 }


### PR DESCRIPTION
As https://github.com/redhat-appstudio/jvm-build-service/commit/ba8f32bfc53eb9934ac0051e72c6bd2c55651d9d add commitHash the Apheleia download-sources gets
```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "commitHash" (class com.redhat.hacbs.resources.model.v1alpha1.ScmInfo), not marked as ignorable (5 known properties: "scmURL", "private", "path", "scmType", "tag"])
 at [Source: (BufferedInputStream); line: 1, column: 1444] (through reference chain: com.redhat.hacbs.resources.model.v1alpha1.DependencyBuild["spec"]->com.redhat.hacbs.resources.model.v1alpha1.DependencyBuildSpec["scm"]->com.redhat.hacbs.resources.model.v1alpha1.ScmInfo["commitHash"])
```
unless I add this.