### PR TITLE
Add cacheRepoTags option for the ScmLocator to enable repo tag and hash caching between calls

### DIFF
--- a/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipies/scm/ScmLocatorConfig.java
+++ b/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipies/scm/ScmLocatorConfig.java
@@ -32,11 +32,29 @@ public class ScmLocatorConfig {
             return ScmLocatorConfig.this;
         }
 
+        /**
+         * A list of build recipe repo URIs
+         *
+         * @param recipeRepos recipe repo URIs
+         * @return this builder instance
+         */
         public Builder setRecipeRepos(List<String> recipeRepos) {
             ensureNotBuilt();
             if (recipeRepos != null && !recipeRepos.isEmpty()) {
                 ScmLocatorConfig.this.recipeRepos = recipeRepos;
             }
+            return this;
+        }
+
+        /**
+         * Whether to cache code repository tags between {@link ScmLocator.resolveTagInfo(GAV)} calls
+         *
+         * @param cacheRepoTags whether to cache code repository tags
+         * @return this builder instance
+         */
+        public Builder setCacheRepoTags(boolean cacheRepoTags) {
+            ensureNotBuilt();
+            ScmLocatorConfig.this.cacheRepoTags = cacheRepoTags;
             return this;
         }
 
@@ -48,6 +66,7 @@ public class ScmLocatorConfig {
     }
 
     private List<String> recipeRepos = List.of(DEFAULT_RECIPE_REPO_URL);
+    private boolean cacheRepoTags;
     private String cacheUrl;
 
     private ScmLocatorConfig() {
@@ -55,6 +74,10 @@ public class ScmLocatorConfig {
 
     public List<String> getRecipeRepos() {
         return recipeRepos;
+    }
+
+    public boolean isCacheRepoTags() {
+        return cacheRepoTags;
     }
 
     public String getCacheUrl() {


### PR DESCRIPTION
Enabling this new option allows to save ~3 min analyzing Vert.X 3.4.7 dependencies to build in the Domino use-case.

No cache: 4m38.200s
With cache: 1m28.979s

Total number of GAVs to resolve was 643 with 494 resolved successfully.

FYI @stuartwdouglas 