### PR TITLE
Fix SBT MavenRepo URL

### DIFF
--- a/pkg/reconciler/dependencybuild/scripts/sbt-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/sbt-build.sh
@@ -33,7 +33,7 @@ EOF
 
 mkdir "$HOME/.sbt/1.0/"
 cat >"$HOME/.sbt/1.0/global.sbt" <<EOF
-publishTo := Some(("MavenRepo" at s"file://$(workspaces.source.path)/artifacts").withAllowInsecureProtocol(true)),
+publishTo := Some(("MavenRepo" at s"file:$(workspaces.source.path)/artifacts").withAllowInsecureProtocol(true)),
 EOF
 #This is replaced when the task is created by the golang code
 cat <<EOF


### PR DESCRIPTION
Although I think it works either way, `file:` URLs should not contain `//` since that is part of the host which you don't have in `file:` URLs.