### PR TITLE
Update Ant Ivy default resolver

### DIFF
--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/ant/IvyUtilsTest.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/ant/IvyUtilsTest.java
@@ -28,9 +28,11 @@ class IvyUtilsTest {
     private static final String LOCAL_PATTERN_VALUE = System.getProperty("user.home")
             + "/.m2/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]";
 
-    private static final String DEFAULT_RESOLVER_NAME = "default";
+    private static final String DEFAULT_RESOLVER = "default";
 
-    private static final String LOCAL_RESOLVER_NAME = "local";
+    private static final String DEFAULT_CHAIN = "defaultChain";
+
+    private static final String LOCAL_RESOLVER = "local";
 
     private static Ivy ivy;
 
@@ -55,9 +57,9 @@ class IvyUtilsTest {
         assertThat(localPattern).isEqualTo(LOCAL_PATTERN_VALUE);
         var defaultResolver = settings.getDefaultResolver();
         var name = defaultResolver.getName();
-        assertThat(name).isEqualTo(DEFAULT_RESOLVER_NAME);
+        assertThat(name).isEqualTo(DEFAULT_CHAIN);
         var resolvers = settings.getResolvers();
-        assertThat(resolvers).hasSize(2).extracting("name")
-                .containsExactlyInAnyOrder(DEFAULT_RESOLVER_NAME, LOCAL_RESOLVER_NAME);
+        assertThat(resolvers).hasSize(3).extracting("name")
+                .containsExactlyInAnyOrder(DEFAULT_RESOLVER, DEFAULT_CHAIN, LOCAL_RESOLVER);
     }
 }

--- a/java-components/build-request-processor/src/test/resources/com/redhat/hacbs/container/analyser/build/ant/ivysettings.xml
+++ b/java-components/build-request-processor/src/test/resources/com/redhat/hacbs/container/analyser/build/ant/ivysettings.xml
@@ -2,14 +2,14 @@
     <property name="cache-url" value="$(params.CACHE_URL)"/>
     <property name="default-pattern" value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"/>
     <property name="local-pattern" value="${user.home}/.m2/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"/>
-    <settings defaultResolver="default"/>
+    <settings defaultResolver="defaultChain"/>
     <resolvers>
         <ibiblio name="default" root="${cache-url}" pattern="${default-pattern}" m2compatible="true"/>
         <filesystem name="local" m2compatible="true">
             <artifact pattern="${local-pattern}"/>
             <ivy pattern="${local-pattern}"/>
         </filesystem>
-        <chain name="default">
+        <chain name="defaultChain">
             <resolver ref="local"/>
             <resolver ref="default"/>
         </chain>

--- a/pkg/reconciler/dependencybuild/scripts/ant-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/ant-build.sh
@@ -32,14 +32,14 @@ cat > ivysettings.xml << EOF
     <property name="cache-url" value="$(params.CACHE_URL)"/>
     <property name="default-pattern" value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"/>
     <property name="local-pattern" value="\${user.home}/.m2/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"/>
-    <settings defaultResolver="default"/>
+    <settings defaultResolver="defaultChain"/>
     <resolvers>
         <ibiblio name="default" root="\${cache-url}" pattern="\${default-pattern}" m2compatible="true"/>
         <filesystem name="local" m2compatible="true">
             <artifact pattern="\${local-pattern}"/>
             <ivy pattern="\${local-pattern}"/>
         </filesystem>
-        <chain name="default">
+        <chain name="defaultChain">
             <resolver ref="local"/>
             <resolver ref="default"/>
         </chain>


### PR DESCRIPTION
It was using the cache URL directly. Now it uses a chain which has the m2 local repo and the cache.