### PR TITLE
Add option to allow Ivy Repo

### DIFF
--- a/java-components/build-request-processor/src/main/resources/gradle/repositories.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/repositories.gradle
@@ -11,7 +11,7 @@ class RepositoryPlugin implements Plugin<Gradle> {
             all { ArtifactRepository repo ->
                 if (!(repo instanceof MavenArtifactRepository) ||
                         (repo.url.toString() != ENTERPRISE_REPOSITORY_URL && repo.url.toString() != BINTRAY_URL )) {
-                    if (repo.toString().contains("PluginArtifactRepository")) {
+                    if (repo.toString().contains("PluginArtifactRepository") || (Boolean.getBoolean("ALLOW_IVY_REPO") && repo.toString().contains("DefaultIvyArtifactRepository"))) {
                         return
                     }
                     if (repo instanceof MavenArtifactRepository) {


### PR DESCRIPTION
Some builds use this to download things like the Android SDK, NodeJS etc.