### PR TITLE
Remove colors and correct cross-build command

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -239,14 +239,11 @@ public class LookupBuildInfoCommand implements Runnable {
             if (Files.exists(path.resolve("build.sbt"))) {
                 //TODO: initial SBT support, needs more work
                 Log.infof("Detected SBT build in %s", path);
-
-                var specifiedJavaVersion = "11"; //hard coded for now
-
                 info.tools.put(JDK, new VersionRange("7", "17", "8"));
                 info.tools.put(SBT, new VersionRange("1.8.0", "1.8.0", "1.8.0"));
                 info.toolVersion = "1.8.0";
                 info.invocations.add(new ArrayList<>(
-                        List.of(SBT, "+", "publish"))); //the plus tells it to deploy for every scala version
+                        List.of(SBT, "--no-colors", "+publish"))); //the plus tells it to deploy for every scala version
             }
             if (AntUtils.isAntBuild(path)) {
                 // XXX: It is possible to change the build file location via -buildfile/-file/-f or -find/-s


### PR DESCRIPTION
According to https://www.scala-sbt.org/1.x/docs/Cross-Build.html and https://www.scala-sbt.org/1.x/docs/Cross-Build-Plugins.html there shouldn't be a space between `+` and `publish`.
Also removed colour to avoid in the logs:
```
[0m[[0m[31merror[0m] [0m[0mNot a valid command: +[0m
```
In SBT 1.2.8 it is `-no-color` but that was changed after 1.3.0 to `--no-colors` - and currently SBT 1.8.0 is invoked as the toolVersion which has `--no-colors`