### PR TITLE
Fix groupId path

### DIFF
--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/CachePomScmLocator.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/CachePomScmLocator.java
@@ -25,7 +25,7 @@ public class CachePomScmLocator extends AbstractPomScmLocator {
         return new PomClient() {
             @Override
             public Optional<Model> getPom(String group, String artifact, String version) {
-                var response = cache.getArtifactFile("default", group, artifact, version, artifact
+                var response = cache.getArtifactFile("default", group.replace(".", "/"), artifact, version, artifact
                         + "-" + version + ".pom", false);
                 if (!response.isPresent()) {
                     return Optional.empty();


### PR DESCRIPTION
This avoids:
```
2023-04-05 11:12:58,639 DEBUG [com.red.hac.art.ser.cli.mav.MavenClient] (executor-thread-0) Retrieving artifact org.glassfish.hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.pom from repo central at https://repo.maven.apache.org/maven2
2023-04-05 11:12:58,883 DEBUG [com.red.hac.art.ser.cli.mav.MavenClient] (executor-thread-0) Could not find sha1 hash for artifact org.glassfish.hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.pom from repo central at https://repo.maven.apache.org/maven2
```
and gives
```
2023-04-05 11:26:02,310 DEBUG [com.red.hac.art.ser.cli.mav.MavenClient] (executor-thread-0) Retrieving artifact org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.pom from repo central at https://repo.maven.apache.org/maven2
2023-04-05 11:26:02,437 DEBUG [com.red.hac.art.ser.cli.mav.MavenClient] (executor-thread-0) Found artifact org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.pom from repo central at https://repo.maven.apache.org/maven2
```