### PR TITLE
Improve cache file serving

### DIFF
--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/relocation/RelocationRepositoryClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/relocation/RelocationRepositoryClient.java
@@ -52,7 +52,7 @@ public class RelocationRepositoryClient implements RepositoryClient {
 
     private Optional<ArtifactResult> getGavRelocation(String group, String artifact, String version) {
         byte[] b = getGavRelocationBytes(group, artifact, version);
-        return Optional.of(new ArtifactResult(new ByteArrayInputStream(b), b.length, Optional.of(HashUtil.sha1(b)),
+        return Optional.of(new ArtifactResult(null, new ByteArrayInputStream(b), b.length, Optional.of(HashUtil.sha1(b)),
                 Collections.emptyMap()));
     }
 
@@ -60,7 +60,7 @@ public class RelocationRepositoryClient implements RepositoryClient {
         var res = getGavRelocation(group, artifact, version);
         if (res.isPresent() && res.get().getExpectedSha().isPresent()) {
             byte[] bytes = res.get().getExpectedSha().get().getBytes(StandardCharsets.UTF_8);
-            return Optional.of(new ArtifactResult(new ByteArrayInputStream(bytes), bytes.length, Optional.empty(),
+            return Optional.of(new ArtifactResult(null, new ByteArrayInputStream(bytes), bytes.length, Optional.empty(),
                     Collections.emptyMap()));
         }
         return Optional.empty();

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/resources/V2CacheMavenResource.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/resources/V2CacheMavenResource.java
@@ -61,7 +61,7 @@ public class V2CacheMavenResource {
         Log.debugf("Retrieving artifact %s/%s/%s/%s", group, artifact, version, target);
         var result = facade.getArtifactFile("", group, artifact, version, target, true);
         if (result.isPresent()) {
-            var builder = Response.ok(result.get().getData());
+            var builder = Response.ok(result.get().getFileOrStream());
             if (result.get().getMetadata().containsKey("maven-repo")) {
                 builder.header("X-maven-repo", result.get().getMetadata().get("maven-repo"))
                         .build();

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/ArtifactResult.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/ArtifactResult.java
@@ -1,6 +1,7 @@
 package com.redhat.hacbs.artifactcache.services;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -11,14 +12,16 @@ import io.quarkus.logging.Log;
 
 public class ArtifactResult implements AutoCloseable {
 
+    private final Path file;
     private final InputStream data;
     private final long size;
     private final Optional<String> expectedSha;
     private final Map<String, String> metadata;
     private final List<Runnable> closeTasks;
 
-    public ArtifactResult(InputStream data, long size, Optional<String> expectedSha, Map<String, String> metadata,
+    public ArtifactResult(Path file, InputStream data, long size, Optional<String> expectedSha, Map<String, String> metadata,
             Runnable... closeTasks) {
+        this.file = file;
         this.data = data;
         this.size = size;
         this.expectedSha = expectedSha;
@@ -27,6 +30,19 @@ public class ArtifactResult implements AutoCloseable {
     }
 
     public InputStream getData() {
+        return data;
+    }
+
+    /**
+     * Returns a Path if present, otherwise the InputStream that can be used to read the data.
+     *
+     * As the Path object can be served more efficiently, JAX-RS will get improved performance when the Path is in use.
+     *
+     */
+    public Object getFileOrStream() {
+        if (file != null) {
+            return file;
+        }
         return data;
     }
 

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/RepositoryCache.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/RepositoryCache.java
@@ -84,7 +84,8 @@ public class RepositoryCache {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            return Optional.of(new ArtifactResult(new ByteArrayInputStream(bytes), bytes.length, Optional.empty(), Map.of()));
+            return Optional
+                    .of(new ArtifactResult(null, new ByteArrayInputStream(bytes), bytes.length, Optional.empty(), Map.of()));
 
         } else {
             //TODO: we don't really care about the policy when using standard maven repositories
@@ -169,7 +170,8 @@ public class RepositoryCache {
                 sha = Files.readString(originalSha1, StandardCharsets.UTF_8);
             }
             return Optional
-                    .of(new ArtifactResult(Files.newInputStream(downloaded), Files.size(downloaded), Optional.ofNullable(sha),
+                    .of(new ArtifactResult(downloaded, Files.newInputStream(downloaded), Files.size(downloaded),
+                            Optional.ofNullable(sha),
                             headerMap));
         }
 
@@ -218,11 +220,12 @@ public class RepositoryCache {
                     sha = Files.readString(instrumentedSha, StandardCharsets.UTF_8);
                 }
                 return Optional
-                        .of(new ArtifactResult(Files.newInputStream(trackedJarFile), Files.size(trackedJarFile),
+                        .of(new ArtifactResult(trackedJarFile, Files.newInputStream(trackedJarFile), Files.size(trackedJarFile),
                                 Optional.ofNullable(sha), headerMap));
             } else {
                 return Optional
-                        .of(new ArtifactResult(Files.newInputStream(instrumentedSha), Files.size(instrumentedSha),
+                        .of(new ArtifactResult(instrumentedSha, Files.newInputStream(instrumentedSha),
+                                Files.size(instrumentedSha),
                                 Optional.empty(), Map.of()));
             }
         }
@@ -232,7 +235,8 @@ public class RepositoryCache {
             sha = Files.readString(originalSha1, StandardCharsets.UTF_8);
         }
         return Optional
-                .of(new ArtifactResult(Files.newInputStream(downloaded), Files.size(downloaded), Optional.ofNullable(sha),
+                .of(new ArtifactResult(downloaded, Files.newInputStream(downloaded), Files.size(downloaded),
+                        Optional.ofNullable(sha),
                         headerMap));
 
     }
@@ -314,25 +318,27 @@ public class RepositoryCache {
                                             transformedOut, overwriteExistingBytecodeMarkers);
                                 }
                                 Files.delete(tempFile);
-                                return Optional.of(new ArtifactResult(Files.newInputStream(tempTransformedFile),
-                                        Files.size(tempTransformedFile),
-                                        Optional.empty(), result.get().getMetadata(), () -> {
-                                            try {
-                                                Files.delete(tempTransformedFile);
-                                            } catch (IOException e) {
-                                                throw new RuntimeException(e);
-                                            }
-                                        }));
+                                return Optional
+                                        .of(new ArtifactResult(tempTransformedFile, Files.newInputStream(tempTransformedFile),
+                                                Files.size(tempTransformedFile),
+                                                Optional.empty(), result.get().getMetadata(), () -> {
+                                                    try {
+                                                        Files.delete(tempTransformedFile);
+                                                    } catch (IOException e) {
+                                                        throw new RuntimeException(e);
+                                                    }
+                                                }));
 
                             } else {
-                                return Optional.of(new ArtifactResult(Files.newInputStream(tempFile), Files.size(tempFile),
-                                        Optional.empty(), result.get().getMetadata(), () -> {
-                                            try {
-                                                Files.delete(tempFile);
-                                            } catch (IOException e) {
-                                                throw new RuntimeException(e);
-                                            }
-                                        }));
+                                return Optional
+                                        .of(new ArtifactResult(tempFile, Files.newInputStream(tempFile), Files.size(tempFile),
+                                                Optional.empty(), result.get().getMetadata(), () -> {
+                                                    try {
+                                                        Files.delete(tempFile);
+                                                    } catch (IOException e) {
+                                                        throw new RuntimeException(e);
+                                                    }
+                                                }));
                             }
                         }
                     }

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/maven/MavenClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/maven/MavenClient.java
@@ -126,9 +126,10 @@ public class MavenClient implements RepositoryClient {
                     headers.put(i.getName(), i.getValue());
                 }
                 Log.debugf("Found artifact %s/%s/%s/%s from repo %s at %s", group, artifact, version, target, name, uri);
-                return Optional.of(new ArtifactResult(new CloseDelegateInputStream(response.getEntity().getContent(), response),
-                        response.getEntity().getContentLength(),
-                        Optional.ofNullable(sha1), headers));
+                return Optional
+                        .of(new ArtifactResult(null, new CloseDelegateInputStream(response.getEntity().getContent(), response),
+                                response.getEntity().getContentLength(),
+                                Optional.ofNullable(sha1), headers));
             } catch (Exception e) {
                 try {
                     if (response != null) {

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/ociregistry/OCIRegistryRepositoryClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/ociregistry/OCIRegistryRepositoryClient.java
@@ -189,7 +189,7 @@ public class OCIRegistryRepositoryClient implements RepositoryClient {
                 boolean exists = Files.exists(fileWeAreAfter);
                 if (exists) {
                     return Optional.of(
-                            new ArtifactResult(Files.newInputStream(fileWeAreAfter), Files.size(fileWeAreAfter),
+                            new ArtifactResult(null, Files.newInputStream(fileWeAreAfter), Files.size(fileWeAreAfter),
                                     getSha1(fileWeAreAfter),
                                     Map.of()));
                 } else {

--- a/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/s3/S3RepositoryClient.java
+++ b/java-components/cache/src/main/java/com/redhat/hacbs/artifactcache/services/client/s3/S3RepositoryClient.java
@@ -42,7 +42,7 @@ public class S3RepositoryClient implements RepositoryClient {
             String s3key = i + "/" + fullTarget;
             try {
                 var response = client.getObject(buildGetRequest(s3key));
-                return Optional.of(new ArtifactResult(response, response.response().contentLength(),
+                return Optional.of(new ArtifactResult(null, response, response.response().contentLength(),
                         Optional.ofNullable(response.response().metadata().get(SHA_1)), response.response().metadata()));
 
             } catch (NoSuchKeyException ignore) {

--- a/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/services/LocalCacheTest.java
+++ b/java-components/cache/src/test/java/com/redhat/hacbs/artifactcache/services/LocalCacheTest.java
@@ -55,7 +55,7 @@ public class LocalCacheTest {
         runTest((localCache, path) -> {
             try {
                 current = new ArtifactResult(
-                        new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), 4, Optional.of("wrong sha"),
+                        null, new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), 4, Optional.of("wrong sha"),
                         Map.of());
                 localCache.getArtifactFile("default", "test", "test", "1.0", "test.pom", false);
                 Files.walkFileTree(path, new SimpleFileVisitor<>() {
@@ -70,7 +70,7 @@ public class LocalCacheTest {
 
                 //now try with the correct hash
                 current = new ArtifactResult(
-                        new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), 4,
+                        null, new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), 4,
                         Optional.of(HashUtil.sha1("test")), Map.of());
                 localCache.getArtifactFile("default", "test", "test", "1.0", "test.pom", false);
                 AtomicReference<Path> cachedFile = new AtomicReference<>();
@@ -100,7 +100,7 @@ public class LocalCacheTest {
             try {
                 byte[] jarFile = createJarFile();
                 current = new ArtifactResult(
-                        new ByteArrayInputStream(jarFile), jarFile.length, Optional.of(HashUtil.sha1(jarFile)),
+                        null, new ByteArrayInputStream(jarFile), jarFile.length, Optional.of(HashUtil.sha1(jarFile)),
                         Map.of());
                 localCache.getArtifactFile("default", "test", "test", "1.0", "test.jar.sha1", true);
                 var result = localCache.getArtifactFile("default", "test", "test", "1.0", "test.jar", true);


### PR DESCRIPTION
Use zero copy file serving in the cache where possible. This should reduce load significantly as it does not required a blocking thread.