### PR TITLE
STONEBLD-1085 Merge all build steps into a single step

### DIFF
--- a/deploy/crds/base/jvmbuildservice.io_jbsconfigs.yaml
+++ b/deploy/crds/base/jvmbuildservice.io_jbsconfigs.yaml
@@ -54,16 +54,20 @@ spec:
                       of a pipeline
                     type: string
                   taskLimitCPU:
-                    description: The CPU limit for all other steps of a pipeline
+                    description: 'The CPU limit for all other steps of a pipeline
+                      Deprecated: This is no longer used'
                     type: string
                   taskLimitMemory:
-                    description: The memory limit for all other steps of a pipeline
+                    description: 'The memory limit for all other steps of a pipeline
+                      Deprecated: This is no longer used'
                     type: string
                   taskRequestCPU:
-                    description: The requested CPU for all other steps of a pipeline
+                    description: 'The requested CPU for all other steps of a pipeline
+                      Deprecated: This is no longer used'
                     type: string
                   taskRequestMemory:
                     description: The requested memory for all other steps of a pipeline
+                      Deprecated
                     type: string
                 type: object
               cacheSettings:

--- a/pkg/apis/jvmbuildservice/v1alpha1/jbsconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/jbsconfig_types.go
@@ -58,12 +58,16 @@ type BuildSettings struct {
 	// The requested CPU for the build and deploy steps of a pipeline
 	BuildRequestCPU string `json:"buildRequestCPU,omitempty"`
 	// The requested memory for all other steps of a pipeline
+	//Deprecated
 	TaskRequestMemory string `json:"taskRequestMemory,omitempty"`
 	// The requested CPU for all other steps of a pipeline
+	// Deprecated: This is no longer used
 	TaskRequestCPU string `json:"taskRequestCPU,omitempty"`
 	// The memory limit for all other steps of a pipeline
+	// Deprecated: This is no longer used
 	TaskLimitMemory string `json:"taskLimitMemory,omitempty"`
 	// The CPU limit for all other steps of a pipeline
+	// Deprecated: This is no longer used
 	TaskLimitCPU string `json:"taskLimitCPU,omitempty"`
 }
 type ImageRegistry struct {

--- a/pkg/reconciler/dependencybuild/scripts/copy-request-processor.sh
+++ b/pkg/reconciler/dependencybuild/scripts/copy-request-processor.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Copies JDK17 into the system java directory, for use by the build request processor
+cp -r /deployments build-request-processor
+mkdir system-java
+cp -RL  $JAVA_HOME/* system-java/


### PR DESCRIPTION
This provides a significant memory saving, as the pipeline pods now require less that 50% of the memory they required before.

A standard build was consuming close to 3G before this change, now it is slightly over 1G.