### PR TITLE
Upgrade impsort-maven-plugin to 1.9.0 and force line ending to LF

### DIFF
--- a/java-components/pom.xml
+++ b/java-components/pom.xml
@@ -47,7 +47,7 @@
         <!-- Plugin Versions-->
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>
-        <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
+        <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
 
         <assertj.version>3.23.1</assertj.version>
         <aws-java-sdk-s3.version>1.12.261</aws-java-sdk-s3.version>
@@ -267,6 +267,7 @@
                         <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                         <groups>java.,javax.,jakarta.,org.,com.</groups>
                         <staticGroups>*</staticGroups>
+                        <lineEnding>LF</lineEnding>
                         <skip>${format.skip}</skip>
                         <removeUnused>true</removeUnused>
                     </configuration>


### PR DESCRIPTION
Fixes minor issue with line endings if building on, e.g., Cygwin.