### PR TITLE
Cache start order fix

### DIFF
--- a/pkg/reconciler/jbsconfig/jbsconfig.go
+++ b/pkg/reconciler/jbsconfig/jbsconfig.go
@@ -299,7 +299,10 @@ func (r *ReconcilerJBSConfig) validations(ctx context.Context, log logr.Logger, 
 	}
 
 	if jbsConfig.ImageRegistry().Owner == "" {
-		return r.handleNoOwnerSpecified(ctx, log, jbsConfig)
+		err := r.handleNoOwnerSpecified(ctx, log, jbsConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	registrySecret := &corev1.Secret{}
@@ -734,7 +737,7 @@ func (r *ReconcilerJBSConfig) handleNoOwnerSpecified(ctx context.Context, log lo
 
 	// Create secret with the repository credentials
 	imageURL := fmt.Sprintf("quay.io/%s/%s", r.quayOrgName, repo.Name)
-	robotAccountSecret := generateSecret(config, *robotAccount, imageURL, false) //TODO: at this point we are not using the SPI for this
+	robotAccountSecret := generateSecret(config, *robotAccount, imageURL, r.spiPresent)
 
 	robotAccountSecretKey := types.NamespacedName{Namespace: config.Namespace, Name: v1alpha1.ImageSecretName}
 	existingRobotAccountSecret := &corev1.Secret{}


### PR DESCRIPTION
Don't let the cache start until the access token is injected