### PR TITLE
Revert "Bump quarkus.platform.version from 3.2.0.Final to 3.2.1.Final in /java-components"

### DIFF
--- a/java-components/pom.xml
+++ b/java-components/pom.xml
@@ -42,7 +42,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.2.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.2.0.Final</quarkus.platform.version>
 
         <!-- Plugin Versions-->
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>


### PR DESCRIPTION
Reverts redhat-appstudio/jvm-build-service#760

There seems to be a jib issue affecting local development