### PR TITLE
Fix kube-linter issues for hacbs-jvm-operator pod/container

### DIFF
--- a/deploy/operator/base/deployment.yaml
+++ b/deploy/operator/base/deployment.yaml
@@ -18,6 +18,8 @@ spec:
           secret:
             optional: false
             secretName: quaytoken
+      securityContext:
+        runAsNonRoot: true
       containers:
         - name: hacbs-jvm-operator
           image: hacbs-jvm-operator
@@ -39,4 +41,6 @@ spec:
             - mountPath: "/workspace"
               name: quaytoken
               readOnly: true
+          securityContext:
+            readOnlyRootFilesystem: true
       serviceAccountName: hacbs-jvm-operator


### PR DESCRIPTION
Set runAsNonRoot and readOnlyRootFilesystem to true.

[STONEBLD-1640](https://issues.redhat.com//browse/STONEBLD-1640)