### PR TITLE
Add kube-linter check

### DIFF
--- a/.github/.kube-linter-config.yaml
+++ b/.github/.kube-linter-config.yaml
@@ -1,0 +1,7 @@
+checks:
+  # include explicitly adds checks, by name. You can reference any of the built-in checks.
+  # Note that customChecks defined above are included automatically.
+  include: [ ]
+  # exclude explicitly excludes checks, by name. exclude has the highest priority: if a check is
+  # in exclude, then it is not considered, even if it is in include as well.
+  exclude: [ ]

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -1,0 +1,55 @@
+name: Check Kubernetes YAMLs with kube-linter
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'deploy/crds/base/**.ya?ml'
+      - 'deploy/operator/base/**.ya?ml'
+      - 'deploy/operator/config/**.ya?ml'
+
+jobs:
+  kube-linter:
+    name: Kube linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create ../kube-linter/ for deployment yaml files
+        shell: bash
+        run: mkdir -p ../kube-linter/
+
+      - name: Generate JVM Build Service operator deployment configuration
+        shell: bash
+        run: |
+          kustomize build deploy/crds/base/ >  ../kube-linter/jvm-build-service-crd.yaml && \
+          kustomize build deploy/operator/base/ >  ../kube-linter/jvm-build-service-operator-base.yaml && \
+          kustomize build deploy/operator/config/ >  ../kube-linter/jvm-build-service-operator-config.yaml
+
+      - name: Scan yaml files with kube-linter
+        uses: stackrox/kube-linter-action@v1
+        id: kube-linter-action-scan
+        with:
+          # Where to do scanning
+          directory: ../kube-linter/
+          # Where to search for kube-linter config. Removing the setting make using the default config.
+          config: ./.github/.kube-linter-config.yaml
+          # The following two settings make kube-linter produce scan analysis in SARIF format
+          # which would then be made available in GitHub UI via upload-sarif action below.
+          format: sarif
+          output-file: ../kube-linter/kube-linter.sarif
+        # The following line prevents aborting the workflow immediately in case your files fail kube-linter checks.
+        # This allows the following upload-sarif action to still upload the results to your GitHub repo.
+        continue-on-error: true
+
+      - name: Upload SARIF report files to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ../kube-linter/kube-linter.sarif
+
+      # Ensure the workflow eventually fails if files did not pass kube-linter checks.
+      - name: Verify kube-linter-action succeeded
+        shell: bash
+        run: |
+          echo "If this step fails, kube-linter found issues. Check the output of the scan step above."
+          [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]

--- a/deploy/openshift-ci.sh
+++ b/deploy/openshift-ci.sh
@@ -19,7 +19,7 @@ oc apply -k $DIR/operator/config
 find $DIR -name ci-final -exec rm -r {} \;
 find $DIR -name ci-template -exec cp -r {} {}/../ci-final \;
 # copy deployment yaml, but change the image placeholder, as we employ a simpler/basic substution via env vars in openshift ci
-sed 's/image: hacbs-jvm-operator/image: jvm-build-service-image/' $DIR/operator/base/deployment.yaml > $DIR/operator/overlays/ci-final/base-deployment.yaml
+sed 's/image: hacbs-jvm-operator:next/image: jvm-build-service-image/' $DIR/operator/base/deployment.yaml > $DIR/operator/overlays/ci-final/base-deployment.yaml
 find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-image%${JVM_BUILD_SERVICE_IMAGE}% {} \;
 find $DIR -path \*ci-final\*.yaml -exec sed -i s%jvm-build-service-reqprocessor-image%${JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE}% {} \;
 find $DIR -path \*ci-final\*.yaml -exec sed -i s/ci-template/ci-final/ {} \;

--- a/deploy/operator/base/deployment.yaml
+++ b/deploy/operator/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: hacbs-jvm-operator
-          image: hacbs-jvm-operator
+          image: hacbs-jvm-operator:next
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
This PR adds `kube-linter` check that runs only if change to the operator deployment configuration is made.