### PR TITLE
Rename taskServiceAccountName to serviceAccountName for Tekton v1 api

### DIFF
--- a/.tekton/build-request-processor-pull-request.yaml
+++ b/.tekton/build-request-processor-pull-request.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-build-request-processor-on-pull-request

--- a/.tekton/build-request-processor-push.yaml
+++ b/.tekton/build-request-processor-push.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-build-request-processor-on-push

--- a/.tekton/cache-pull-request.yaml
+++ b/.tekton/cache-pull-request.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-build-cache-on-pull-request

--- a/.tekton/cache-push.yaml
+++ b/.tekton/cache-push.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-build-cache-on-push

--- a/.tekton/cli-pull-request.yaml
+++ b/.tekton/cli-pull-request.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-cli-on-pull-request

--- a/.tekton/cli-push.yaml
+++ b/.tekton/cli-push.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-cli-on-push

--- a/.tekton/controller-pull-request.yaml
+++ b/.tekton/controller-pull-request.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-build-controller-on-pull-request

--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: jvm-build-controller-on-push

--- a/hack/examples/run-e2e-shaded-app.yaml
+++ b/hack/examples/run-e2e-shaded-app.yaml
@@ -23,4 +23,4 @@ spec:
               storage: 100Mi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
+      serviceAccountName: pipeline

--- a/hack/examples/run-jvm-build-service.yaml
+++ b/hack/examples/run-jvm-build-service.yaml
@@ -27,5 +27,4 @@ spec:
               storage: 5Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
-
+      serviceAccountName: pipeline

--- a/hack/examples/run-quarkus-quickstart.yaml
+++ b/hack/examples/run-quarkus-quickstart.yaml
@@ -23,5 +23,4 @@ spec:
               storage: 5Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
-
+      serviceAccountName: pipeline

--- a/hack/examples/run-quarkus.yaml
+++ b/hack/examples/run-quarkus.yaml
@@ -25,5 +25,4 @@ spec:
               storage: 5Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
-
+      serviceAccountName: pipeline

--- a/hack/examples/run-service-registry.yaml
+++ b/hack/examples/run-service-registry.yaml
@@ -25,5 +25,4 @@ spec:
               storage: 5Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
-
+      serviceAccountName: pipeline

--- a/hack/examples/run-spring-boot-quickstart.yaml
+++ b/hack/examples/run-spring-boot-quickstart.yaml
@@ -23,5 +23,4 @@ spec:
               storage: 5Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
-
+      serviceAccountName: pipeline

--- a/hack/examples/run-wildfly.yaml
+++ b/hack/examples/run-wildfly.yaml
@@ -25,5 +25,4 @@ spec:
               storage: 5Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
-
+      serviceAccountName: pipeline

--- a/hack/examples/run.yaml
+++ b/hack/examples/run.yaml
@@ -21,4 +21,4 @@ spec:
               storage: 1Gi
   taskRunSpecs:
     - pipelineTaskName: maven-run
-      taskServiceAccountName: pipeline
+      serviceAccountName: pipeline


### PR DESCRIPTION
v1beta1 uses https://github.com/tektoncd/pipeline/blob/main/pkg/apis/pipeline/v1beta1/pipelinerun_types.go#L598 while v1 uses https://github.com/tektoncd/pipeline/blob/main/pkg/apis/pipeline/v1/pipelinerun_types.go#L620