### PR TITLE
Don't set deploy.skip=false

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -352,7 +352,7 @@ public class LookupBuildInfoCommand implements Runnable {
 
                 var invocations = new ArrayList<>(
                         List.of("install", "-Denforcer.skip", "-Dcheckstyle.skip",
-                                "-Drat.skip=true", "-Dmaven.deploy.skip=false", "-Dgpg.skip", "-Drevapi.skip",
+                                "-Drat.skip=true", "-Dgpg.skip", "-Drevapi.skip",
                                 "-Djapicmp.skip", "-Dmaven.javadoc.failOnError=false", "-Dcobertura.skip=true",
                                 "-Dpgpverify.skip", "-Dspotbugs.skip", "-DallowIncompleteProjects"));
                 if (skipTests) {


### PR DESCRIPTION
This can cause problems for some builds, for builds that actually need it we will need to set this manually, or detect when it is set to false at the top level.