### PR TITLE
Ensure path is using current version of java

### DIFF
--- a/pkg/reconciler/dependencybuild/scripts/build-entry.sh
+++ b/pkg/reconciler/dependencybuild/scripts/build-entry.sh
@@ -11,7 +11,11 @@ then
     cd $(params.CONTEXT_DIR)
 fi
 
-echo "JAVA_HOME:$JAVA_HOME"
+if [ ! -z ${JAVA_HOME+x} ]; then
+    echo "JAVA_HOME:$JAVA_HOME"
+    PATH="${JAVA_HOME}/bin:$PATH"
+fi
+
 if [ ! -z ${MAVEN_HOME+x} ]; then
     echo "MAVEN_HOME:$MAVEN_HOME"
     PATH="${MAVEN_HOME}/bin:$PATH"


### PR DESCRIPTION
@dwalluck This should fix org.eclipse.parsson:parsson:1.1.1 as it was using a default JDK8 when execing from inside the build instead of the current JDK (found that using the diagnostic dockerfiles)