### PR TITLE
Make verifier ignore Enum.valueOf method changes

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/AsmUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/AsmUtils.java
@@ -1,6 +1,7 @@
 package com.redhat.hacbs.container.verifier.asm;
 
 import static org.objectweb.asm.Opcodes.ACC_BRIDGE;
+import static org.objectweb.asm.Opcodes.ACC_ENUM;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
 
@@ -47,4 +48,7 @@ public final class AsmUtils {
         return ((access & b) == b);
     }
 
+    public static boolean isEnumVaueOf(int access, String name) {
+        return ((access & ACC_ENUM) != 0 && "valueOf".equals(name));
+    }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/ClassInfo.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/ClassInfo.java
@@ -1,5 +1,6 @@
 package com.redhat.hacbs.container.verifier.asm;
 
+import static com.redhat.hacbs.container.verifier.asm.AsmUtils.isEnumVaueOf;
 import static com.redhat.hacbs.container.verifier.asm.AsmUtils.isPublic;
 import static com.redhat.hacbs.container.verifier.asm.AsmUtils.isSyntheticBridge;
 
@@ -58,7 +59,8 @@ public record ClassInfo(ClassVersion version, AccessSet<ClassAccess> access, Str
                         : Collections.emptyMap(),
                 node.fields.stream().filter(field -> isPublic(field.access))
                         .collect(Collectors.toMap(n -> n.name, FieldInfo::new, (x, y) -> x, LinkedHashMap::new)),
-                node.methods.stream().filter(method -> isPublic(method.access) && !isSyntheticBridge(method.access))
+                node.methods.stream().filter(method -> isPublic(method.access) && !isSyntheticBridge(method.access)
+                        && !isEnumVaueOf(node.access, method.name))
                         .collect(Collectors.toMap(n -> n.name + n.desc, MethodInfo::new, (x, y) -> x, LinkedHashMap::new)));
     }
 

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/ParameterInfo.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/ParameterInfo.java
@@ -14,6 +14,6 @@ public record ParameterInfo(String name, AccessSet<ParameterAccess> access) impl
 
     @Override
     public String toString() {
-        return getName();
+        return "parameter: " + "name=" + name + ", access=" + access;
     }
 }


### PR DESCRIPTION
`Enum.valueOf` method parameter access flags added `mandated`.

Just ignoring this method.