### PR TITLE
Don't verify empty parameters

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/AccessSet.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/AccessSet.java
@@ -1,5 +1,6 @@
 package com.redhat.hacbs.container.verifier.asm;
 
+import static com.redhat.hacbs.container.verifier.asm.AsmUtils.accessSetToString;
 import static com.redhat.hacbs.container.verifier.asm.AsmUtils.accessToSet;
 
 import java.util.Objects;
@@ -37,6 +38,6 @@ public class AccessSet<E extends Enum<E> & Access> {
 
     @Override
     public String toString() {
-        return AsmUtils.accessSetToString(set);
+        return accessSetToString(set);
     }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/AsmUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/AsmUtils.java
@@ -1,7 +1,6 @@
 package com.redhat.hacbs.container.verifier.asm;
 
 import static org.objectweb.asm.Opcodes.ACC_BRIDGE;
-import static org.objectweb.asm.Opcodes.ACC_ENUM;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
 
@@ -46,9 +45,5 @@ public final class AsmUtils {
     public static boolean isSyntheticBridge(int access) {
         var b = ACC_BRIDGE | ACC_SYNTHETIC;
         return ((access & b) == b);
-    }
-
-    public static boolean isEnumVaueOf(int access, String name) {
-        return ((access & ACC_ENUM) != 0 && "valueOf".equals(name));
     }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/ClassInfo.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/ClassInfo.java
@@ -1,6 +1,5 @@
 package com.redhat.hacbs.container.verifier.asm;
 
-import static com.redhat.hacbs.container.verifier.asm.AsmUtils.isEnumVaueOf;
 import static com.redhat.hacbs.container.verifier.asm.AsmUtils.isPublic;
 import static com.redhat.hacbs.container.verifier.asm.AsmUtils.isSyntheticBridge;
 
@@ -59,8 +58,7 @@ public record ClassInfo(ClassVersion version, AccessSet<ClassAccess> access, Str
                         : Collections.emptyMap(),
                 node.fields.stream().filter(field -> isPublic(field.access))
                         .collect(Collectors.toMap(n -> n.name, FieldInfo::new, (x, y) -> x, LinkedHashMap::new)),
-                node.methods.stream().filter(method -> isPublic(method.access) && !isSyntheticBridge(method.access)
-                        && !isEnumVaueOf(node.access, method.name))
+                node.methods.stream().filter(method -> isPublic(method.access) && !isSyntheticBridge(method.access))
                         .collect(Collectors.toMap(n -> n.name + n.desc, MethodInfo::new, (x, y) -> x, LinkedHashMap::new)));
     }
 

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/MethodInfo.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/verifier/asm/MethodInfo.java
@@ -4,6 +4,7 @@ import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +37,9 @@ public record MethodInfo(AccessSet<MethodAccess> access, String name, String des
                 node.name, node.desc, node.signature,
                 List.copyOf(node.exceptions),
                 node.parameters != null
-                        ? node.parameters.stream()
+                        ? node.parameters.stream().filter(p -> p.name == null && p.access == 0)
                                 .collect(Collectors.toMap(n -> n.name, ParameterInfo::new, (x, y) -> x, LinkedHashMap::new))
-                        : null,
+                        : Collections.emptyMap(),
                 node.visibleAnnotations != null
                         ? node.visibleAnnotations.stream()
                                 .collect(Collectors.toMap(n -> n.desc, AnnotationInfo::new, (x, y) -> x, LinkedHashMap::new))


### PR DESCRIPTION
This is a more general fix for the `Enum.valueOf()` issue where we have a parameter with `name = null` and `access = 0` as opposed to none whatsoever.
