### PR TITLE
Error handling and build phase change

### DIFF
--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -95,7 +95,8 @@ func createPipelineSpec(tool string, commitTime int64, jbsConfig *v1alpha12.JBSC
 	if recipe.ToolVersions["sbt"] != "" {
 		toolEnv = append(toolEnv, v1.EnvVar{Name: "SBT_DIST", Value: "/opt/sbt/" + recipe.ToolVersions["sbt"]})
 	}
-	toolEnv = append(toolEnv, v1.EnvVar{Name: "TOOL_VERSION", Value: recipe.ToolVersion})
+	toolEnv = append(toolEnv, v1.EnvVar{Name: PipelineParamToolVersion, Value: recipe.ToolVersion})
+	toolEnv = append(toolEnv, v1.EnvVar{Name: PipelineParamProjectVersion, Value: db.Spec.Version})
 
 	additionalMemory := recipe.AdditionalMemory
 	if systemConfig.Spec.MaxAdditionalMemory > 0 && additionalMemory > systemConfig.Spec.MaxAdditionalMemory {
@@ -175,6 +176,7 @@ func createPipelineSpec(tool string, commitTime int64, jbsConfig *v1alpha12.JBSC
 		{Name: PipelineParamToolVersion, Type: tektonpipeline.ParamTypeString},
 		{Name: PipelineParamPath, Type: tektonpipeline.ParamTypeString},
 		{Name: PipelineParamEnforceVersion, Type: tektonpipeline.ParamTypeString},
+		{Name: PipelineParamProjectVersion, Type: tektonpipeline.ParamTypeString},
 		{Name: PipelineParamCacheUrl, Type: tektonpipeline.ParamTypeString, Default: &tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: cacheUrl + buildRepos + "/" + strconv.FormatInt(commitTime, 10)}},
 	}
 	secretVariables := make([]v1.EnvVar, 0)

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -51,6 +51,7 @@ const (
 	PipelineParamJavaVersion         = "JAVA_VERSION"
 	PipelineParamToolVersion         = "TOOL_VERSION"
 	PipelineParamEnforceVersion      = "ENFORCE_VERSION"
+	PipelineParamProjectVersion      = "PROJECT_VERSION"
 	PipelineParamCacheUrl            = "CACHE_URL"
 	PipelineResultImage              = "IMAGE_URL"
 	PipelineResultImageDigest        = "IMAGE_DIGEST"
@@ -549,6 +550,7 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, log 
 		{Name: PipelineParamPath, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: contextDir}},
 		{Name: PipelineParamGoals, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeArray, ArrayVal: attempt.Recipe.CommandLine}},
 		{Name: PipelineParamEnforceVersion, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: attempt.Recipe.EnforceVersion}},
+		{Name: PipelineParamProjectVersion, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: db.Spec.Version}},
 		{Name: PipelineParamToolVersion, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: attempt.Recipe.ToolVersion}},
 		{Name: PipelineParamJavaVersion, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: attempt.Recipe.JavaVersion}},
 	}

--- a/pkg/reconciler/dependencybuild/dependencybuild_test.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild_test.go
@@ -221,7 +221,7 @@ func TestStateDetect(t *testing.T) {
 					g.Expect(or.Name).Should(Equal(db.Name))
 				}
 			}
-			g.Expect(len(pr.Spec.Params)).Should(Equal(11))
+			g.Expect(len(pr.Spec.Params)).Should(Equal(12))
 			for _, param := range pr.Spec.Params {
 				switch param.Name {
 				case PipelineParamScmHash:


### PR DESCRIPTION
By adding the project version this allows postBuildScripts to access the version which is useful for Ant deployments - https://github.com/redhat-appstudio/jvm-build-data/pull/157