### PR TITLE
Fix Java versions in maven-build.sh

### DIFF
--- a/pkg/reconciler/dependencybuild/scripts/maven-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/maven-build.sh
@@ -18,10 +18,10 @@ cat >"$TOOLCHAINS_XML" <<EOF
 <toolchains>
 EOF
 
-if [ "$(params.JAVA_VERSION)" = "1.7" ]; then
-    JAVA_VERSIONS="1.7:1.7.0 1.8:1.8.0 11:11"
+if [ "$(params.JAVA_VERSION)" = "7" ]; then
+    JAVA_VERSIONS="7:1.7.0 8:1.8.0 11:11"
 else
-    JAVA_VERSIONS="1.8:1.8.0 11:11 17:17"
+    JAVA_VERSIONS="8:1.8.0 11:11 17:17 21:21"
 fi
 
 for i in $JAVA_VERSIONS; do


### PR DESCRIPTION
It looks like the Java versions for 1.7 changed to 7 and 1.8 changed to 8 recently. I am seeing in the build log:

```bash
if [ "7" = "1.7" ]; then
    JAVA_VERSIONS="1.7:1.7.0 1.8:1.8.0 11:11"
else
    JAVA_VERSIONS="1.8:1.8.0 11:11 17:17"
fi
```

But is this piece of code still accurate with the current images? I see 21 was missing, and I am not remembering where the ranges of [7, 11] and [8, 17] come from.