### PR TITLE
Add -Dmaven.site.deploy.skip

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -549,6 +549,7 @@ public class LookupBuildInfoCommand implements Runnable {
                             "-Dgpg.skip",
                             "-Djapicmp.skip",
                             "-Dmaven.javadoc.failOnError=false",
+                            "-Dmaven.site.deploy.skip",
                             "-Dpgpverify.skip",
                             "-Drat.skip=true",
                             "-Drevapi.skip",


### PR DESCRIPTION
Maven site plugin is apparently not honoring `-DaltDeploymentRespository`:

https://github.com/apache/geronimo-xbean/blob/f143113673a4c546148b192c091ebb8d40e9d826/pom.xml#L435-L440