### PR TITLE
Remove use of GME

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
@@ -53,7 +53,7 @@ public final class GradleUtils {
     /**
      * Default Gradle arguments.
      */
-    public static final List<String> DEFAULT_GRADLE_ARGS = List.of("build", "publish");
+    public static final List<String> DEFAULT_GRADLE_ARGS = List.of("build", "publishToMavenLocal");
 
     /**
      * Gradle arguments if 'maven' plugin is detected.

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/gradle/GradlePrepareCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/gradle/GradlePrepareCommand.java
@@ -15,7 +15,7 @@ import io.quarkus.logging.Log;
 import picocli.CommandLine;
 
 /**
- * A simple preprocessor that attempts to get gradle build files into a state where GME can work on them.
+ * A simple preprocessor that attempts to get gradle build files into a state where they can be built.
  * <p>
  * At present it just sets up the init script
  */
@@ -23,10 +23,11 @@ import picocli.CommandLine;
 public class GradlePrepareCommand extends AbstractPreprocessor {
 
     public static final String[] INIT_SCRIPTS = {
+            "disable-plugins.gradle",
+            "info.gradle",
+            "javadoc.gradle",
             "repositories.gradle",
             "uploadArchives.gradle",
-            "javadoc.gradle",
-            "disable-plugins.gradle",
             "version.gradle"
     };
 

--- a/java-components/build-request-processor/src/main/resources/gradle/info.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/info.gradle
@@ -1,0 +1,5 @@
+// Ideally we would use --show-version in gradle.sh but that command
+// was only added in https://docs.gradle.org/7.5/release-notes.html
+println("------------------------------------------------------------")
+println("JDK: " + JavaVersion.current())
+println("-----------------------------------------------------------")

--- a/java-components/build-request-processor/src/main/resources/gradle/uploadArchives.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/uploadArchives.gradle
@@ -1,10 +1,11 @@
 gradle.allprojects {
     project -> pluginManager.withPlugin('maven') {
         afterEvaluate {
-            def url = System.getProperty('AProxDeployUrl')
+            // Using the same property as maven-publish plugin to avoid having two different ones
+            def url = "file://" + System.getProperty('maven.repo.local')
 
             if (!url) {
-                throw new GradleException('You must set system property \'AProxDeployUrl\' to the Maven deployment repository URL')
+                throw new GradleException('You must set system property \'maven.repo.local\' to the Maven deployment repository URL')
             }
 
             uploadArchives {

--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommandTest.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommandTest.java
@@ -173,14 +173,44 @@ class LookupBuildInfoCommandTest {
     }
 
     @Test
-    public void testBuildAnalysisGradleRelease()
+    public void testBuildAnalysisAnt()
             throws Exception {
         LookupBuildInfoCommand lookupBuildInfoCommand = new LookupBuildInfoCommand();
         lookupBuildInfoCommand.toolVersions = toolVersions;
+        // https://gitlab.ow2.org/asm/asm/-/tree/ASM_6_0?ref_type=tags
+        lookupBuildInfoCommand.commit = "016a5134e8bab1d4239fc8dcc47baef11e05d33e";
+        var info = lookupBuildInfoCommand.doBuildAnalysis("https://gitlab.ow2.org/asm/asm.git", new BuildRecipeInfo(),
+                cacheBuildInfoLocator);
+        assertThat(info.invocations).isNotEmpty();
+        assertTrue(info.invocations.get(0).getCommands().contains("-v"));
+        assertTrue(info.invocations.get(0).getTool().contains("ant"));
+    }
+
+    @Test
+    public void testBuildAnalysisGradleReleaseLegacy()
+            throws Exception {
+        LookupBuildInfoCommand lookupBuildInfoCommand = new LookupBuildInfoCommand();
+        lookupBuildInfoCommand.toolVersions = toolVersions;
+        // https://gitlab.ow2.org/asm/asm/-/tree/ASM_7_0?ref_type=tags
         lookupBuildInfoCommand.commit = "1f6020a3f17d9d88dfd54a31370e91e3361c216b";
         var info = lookupBuildInfoCommand.doBuildAnalysis("https://gitlab.ow2.org/asm/asm.git", new BuildRecipeInfo(),
                 cacheBuildInfoLocator);
         assertThat(info.invocations).isNotEmpty();
+        assertTrue(info.invocations.get(0).getCommands().contains("uploadArchives"));
+        assertTrue(info.invocations.get(0).getCommands().contains("-Prelease"));
+    }
+
+    @Test
+    public void testBuildAnalysisGradleReleaseCurrent()
+            throws Exception {
+        LookupBuildInfoCommand lookupBuildInfoCommand = new LookupBuildInfoCommand();
+        lookupBuildInfoCommand.toolVersions = toolVersions;
+        // https://gitlab.ow2.org/asm/asm/-/tree/ASM_9_6?ref_type=tags
+        lookupBuildInfoCommand.commit = "85cf1aeb0d08be8446f6efbda962817d2a9707dd";
+        var info = lookupBuildInfoCommand.doBuildAnalysis("https://gitlab.ow2.org/asm/asm.git", new BuildRecipeInfo(),
+                cacheBuildInfoLocator);
+        assertThat(info.invocations).isNotEmpty();
+        assertTrue(info.invocations.get(0).getCommands().contains("publishToMavenLocal"));
         assertTrue(info.invocations.get(0).getCommands().contains("-Prelease"));
     }
 


### PR DESCRIPTION
While this has worked on the test builds I have done I suspect there may be failures if some plugins are not being handled. Equally it should fix some of the failures we are seeing though.

Related : https://github.com/redhat-appstudio/jvm-build-service-builder-images/pull/53 