### PR TITLE
Use Gradle init.d directory for init scripts

### DIFF
--- a/java-components/build-request-processor/src/main/resources/gradle/README.md
+++ b/java-components/build-request-processor/src/main/resources/gradle/README.md
@@ -1,0 +1,4 @@
+These Gradle init scripts are listed and processed by [GradlePrepareCommand.java](../../java/com/redhat/hacbs/container/build/preprocessor/gradle/GradlePrepareCommand.java).
+
+They are then moved during the build process to the Gradle user home initialization script directory by gradle-build.sh.
+

--- a/java-components/build-request-processor/src/main/resources/gradle/disable-plugins.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/disable-plugins.gradle
@@ -7,10 +7,11 @@ class DisablePluginsPlugin implements Plugin<Gradle> {
 
     void apply(Gradle gradle) {
         gradle.allprojects {
-            tasks.configureEach({
+            tasks.configureEach({ task ->
                 for (i in PLUGINS) {
-                    if (it.class.getName().contains(i)) {
-                        it.setEnabled(false)
+                    if (task.class.getName().contains(i)) {
+                        println "Disabling plugin ${task.class}"
+                        task.setEnabled(false)
                         return
                     }
                 }

--- a/java-components/build-request-processor/src/test/gradle/src/test/java/com/redhat/hacbs/VerifyInitFilesTest.java
+++ b/java-components/build-request-processor/src/test/gradle/src/test/java/com/redhat/hacbs/VerifyInitFilesTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -45,7 +46,11 @@ public class VerifyInitFilesTest {
         arguments.add("build");
 
         File[] initScripts = new File(gradleRootDirectory.getParent().getParent().toString(), "main/resources/gradle")
-                .listFiles();
+                .listFiles(new FilenameFilter() {
+                    public boolean accept(File dir, String name) {
+                        return name.endsWith(".gradle");
+                    }
+                });
         if (initScripts == null) {
             throw new RuntimeException("Init script directory not found");
         }

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -60,6 +60,9 @@ settingsEvaluated { settings ->
     }
 }
 EOF
+if [ -d .hacbs-init ]; then
+    mv .hacbs-init "${GRADLE_USER_HOME}"/init.d
+fi
 
 #if we run out of memory we want the JVM to die with error code 134
 export JAVA_OPTS="-XX:+CrashOnOutOfMemoryError"
@@ -71,8 +74,7 @@ export PATH="${JAVA_HOME}/bin:${PATH}"
 #so just create one to fool the plugin
 git config user.email "HACBS@redhat.com"
 git config user.name "HACBS"
-if [ -z "$(params.ENFORCE_VERSION)" ]
-then
+if [ -z "$(params.ENFORCE_VERSION)" ]; then
   echo "Enforce version not set, recreating original tag $(params.TAG)"
   git tag -m $(params.TAG) -a $(params.TAG) || true
 else
@@ -94,13 +96,6 @@ esac
 export LANG="en_US.UTF-8"
 export LC_ALL="en_US.UTF-8"
 
-INIT_SCRIPTS=""
-for i in .hacbs-init/*
-do
-  INIT_SCRIPTS="$INIT_SCRIPTS -I $(pwd)/$i"
-done
-echo "INIT SCRIPTS: $INIT_SCRIPTS"
-
 #our dependency tracing breaks verification-metadata.xml
 #TODO: should we disable tracing for these builds? It means we can't track dependencies directly, so we can't detect contaminants
 rm -f gradle/verification-metadata.xml
@@ -109,7 +104,7 @@ echo "Running Gradle command with arguments: $@"
 if [ ! -d $(workspaces.source.path)/source ]; then
   cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
 fi
-gradle $INIT_SCRIPTS -Dmaven.repo.local=$(workspaces.source.path)/artifacts --info --stacktrace "$@"  | tee $(workspaces.source.path)/logs/gradle.log
+gradle -Dmaven.repo.local=$(workspaces.source.path)/artifacts --info --stacktrace "$@"  | tee $(workspaces.source.path)/logs/gradle.log
 
 mkdir -p $(workspaces.source.path)/build-info
 cp -r "${GRADLE_USER_HOME}" $(workspaces.source.path)/build-info/.gradle


### PR DESCRIPTION
Running Gradle with -I doesn't work for all parts of the build (specifically the buildSrc directory) for Gradle versions before 8.0 (https://docs.gradle.org/8.0/release-notes.html) - see this [Gradle issue](https://www.github.com/gradle/gradle/issues/1055). A workaround in https://issues.gradle.org/browse/GRADLE-3197 was suggested to use init.d - see https://docs.gradle.org/current/userguide/init_scripts.html#init_scripts 
