### PR TITLE
Remove gradle cache configuration

### DIFF
--- a/openshift-with-appstudio-test/e2e/util.go
+++ b/openshift-with-appstudio-test/e2e/util.go
@@ -242,9 +242,6 @@ func commonSetup(t *testing.T, gitCloneUrl string, namespace string) *testArgs {
 func setup(t *testing.T, namespace string) *testArgs {
 	return setupConfig(t, namespace, false)
 }
-func setupHermetic(t *testing.T, namespace string) *testArgs {
-	return setupConfig(t, namespace, true)
-}
 func setupConfig(t *testing.T, namespace string, hermetic bool) *testArgs {
 
 	ta := commonSetup(t, gitCloneTaskUrl, namespace)

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -8,7 +8,6 @@ cp -r /maven-artifacts/.gradle/* "$GRADLE_USER_HOME/" || true
 cp -r /maven-artifacts/.m2/* "$HOME/.m2/" || true
 
 cat > "${GRADLE_USER_HOME}"/gradle.properties << EOF
-org.gradle.caching=false
 org.gradle.console=plain
 # For Spring/Nebula Release Plugins
 release.useLastTag=true


### PR DESCRIPTION
By default Gradle caching is not enabled according to https://docs.gradle.org/current/userguide/build_cache.html For those builds that do enable this might interfere so I don't think we need it.