### PR TITLE
Set versionSuffix for kotlinx.team.infra plugin

### DIFF
--- a/java-components/build-request-processor/src/main/resources/gradle/test.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/test.gradle
@@ -11,7 +11,7 @@ class TestPlugin implements Plugin<Gradle> {
                 project ->
                     // Using org.gradle.api.tasks.testing.AbstractTestTask instead of Test as that then
                     // covers Kotlin tests as well.
-                    project.tasks.withType(org.gradle.api.tasks.testing.AbstractTestTask).configureEach({ task ->
+                    project.tasks.withType(AbstractTestTask).configureEach({ task ->
                         project.logger.lifecycle "Skipping tests for ${project.name} task ${task.name}"
                         task.setEnabled(false)
                     })

--- a/java-components/build-request-processor/src/main/resources/gradle/version.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/version.gradle
@@ -8,10 +8,11 @@ class VersionPlugin implements Plugin<Gradle> {
         if (VERSION == null || VERSION.isEmpty()) {
             return
         }
-        gradle.allprojects({
-            afterEvaluate {
+        gradle.allprojects {
+            project -> project.afterEvaluate {
+                project.logger.lifecycle "Overriding version for ${project.name} to ${VERSION}"
                 version VERSION
             }
-        })
+        }
     }
 }

--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommandTest.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommandTest.java
@@ -136,6 +136,7 @@ class LookupBuildInfoCommandTest {
 
         lookupBuildInfoCommand.mavenContext = new BootstrapMavenContext();
         lookupBuildInfoCommand.toolVersions = toolVersions;
+        lookupBuildInfoCommand.tag = "02d3e524110982ec2b420ff8f9126707d483374f";
         lookupBuildInfoCommand.commit = "02d3e524110982ec2b420ff8f9126707d483374f";
         var info = lookupBuildInfoCommand.doBuildAnalysis(
                 "https://github.com/jtablesaw/tablesaw",

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -13,6 +13,9 @@ org.gradle.console=plain
 release.useLastTag=true
 release.stage=final
 
+# For https://github.com/Kotlin/kotlinx.team.infra
+versionSuffix=
+
 # Increase timeouts
 systemProp.org.gradle.internal.http.connectionTimeout=600000
 systemProp.org.gradle.internal.http.socketTimeout=600000
@@ -27,6 +30,7 @@ mavenCentralPassword=
 EOF
 
 if [ -d .hacbs-init ]; then
+    rm -rf "${GRADLE_USER_HOME}"/init.d
     mv .hacbs-init "${GRADLE_USER_HOME}"/init.d
 fi
 


### PR DESCRIPTION
The kotlinx.team.infra plugin calls https://github.com/Kotlin/kotlinx.team.infra/blob/v0.3.0-dev-64/main/src/kotlinx/team/infra/Publishing.kt#L85 which will append the `versionSuffix` if its set. It is set in datetime - https://github.com/Kotlin/kotlinx-datetime/blob/v0.4.0/gradle.properties#L6 
Therefore following https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties override it in the Gradle user home.

Also requires https://github.com/redhat-appstudio/jvm-build-data/pull/163 