### PR TITLE
Prefer assemble to build

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
@@ -54,12 +54,12 @@ public final class GradleUtils {
     /**
      * Default Gradle arguments.
      */
-    public static final List<String> DEFAULT_GRADLE_ARGS = List.of("build", "publishToMavenLocal");
+    public static final List<String> DEFAULT_GRADLE_ARGS = List.of("assemble", "publishToMavenLocal");
 
     /**
      * Gradle arguments if 'maven' plugin is detected.
      */
-    public static final List<String> MAVEN_PLUGIN_GRADLE_ARGS = List.of("build", "uploadArchives");
+    public static final List<String> MAVEN_PLUGIN_GRADLE_ARGS = List.of("assemble", "uploadArchives");
 
     private GradleUtils() {
 


### PR DESCRIPTION
Build will also run tests which we don't need. 

In some cases (graphql) build versus assemble versus shadowJar combined with publishToMavenLocal depending upon the order can lead to unexpected failures.