### PR TITLE
Fix overriding release date for tool versions

### DIFF
--- a/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipes/tools/BuildToolInfo.java
+++ b/java-components/build-recipes-database/src/main/java/com/redhat/hacbs/recipes/tools/BuildToolInfo.java
@@ -42,4 +42,14 @@ public class BuildToolInfo {
         this.maxJdkVersion = maxJdkVersion;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "BuildToolInfo{" +
+                "version='" + version + '\'' +
+                ", releaseDate='" + releaseDate + '\'' +
+                ", minJdkVersion='" + minJdkVersion + '\'' +
+                ", maxJdkVersion='" + maxJdkVersion + '\'' +
+                '}';
+    }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -123,6 +123,9 @@ public class LookupBuildInfoCommand implements Runnable {
     @Inject
     BootstrapMavenContext mavenContext;
 
+    // Variable so can be overridden by the tests.
+    String CACHE_PATH = "/v2/cache/rebuild-default/0";
+
     @Override
     public void run() {
         try {
@@ -268,7 +271,7 @@ public class LookupBuildInfoCommand implements Runnable {
 
             if (artifact != null && (buildRecipeInfo == null || buildRecipeInfo.getJavaVersion() == null)) {
                 Log.infof("Lookup Build JDK for artifact %s", artifact);
-                var optBuildJdk = getBuildJdk(cacheUrl + "/v2/cache/rebuild-default/0", artifact);
+                var optBuildJdk = getBuildJdk(cacheUrl + CACHE_PATH, artifact);
                 if (optBuildJdk.isPresent()) {
                     var buildJdk = optBuildJdk.get();
                     Log.infof("Setting build JDK to %s for artifact %s", buildJdk.version(), artifact);


### PR DESCRIPTION
With Smallrye I noticed that we were only getting a single invocation returned (3.9.5). This then broke smallrye as it needs Maven 3.8.8 to build. The reason is the prior calculations only normalised the date for the 3.9 series but not the 3.8 which started from 3.8.1. This then meant the 3.9.x series had a date earlier than 3.8.8 and was used in preference. 