### PR TITLE
Make MaxAdditionalMemory easier to configure. Add logging

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,7 @@ The following environment variables are configurable and may be set by the user 
 | JBS_QUAY_IMAGE | JBS images are pulled by default from the `QUAY_USERNAME` organization. This may be overridden by changing this
 | JBS_BUILD_IMAGE_SECRET | Secret for accessing Quay.io (See below)
 | JBS_GIT_CREDENTIALS | Support for private repositories (See below)
+| JBS_MAX_MEMORY | Maximum additional memory allowed
 | JBS_RECIPE_DATABASE | Recipe database to use (defaults to `https://github.com/redhat-appstudio/jvm-build-data`)
 | JBS_S3_SYNC_ENABLED | Whether to enable Amazon S3 sync for storage
 | JBS_WORKER_NAMESPACE | Default 'worker' namespace (`test-jvm-namespace`) may be customised by setting this

--- a/deploy/base-development.sh
+++ b/deploy/base-development.sh
@@ -26,6 +26,9 @@ fi
 if [ -z "$JBS_S3_SYNC_ENABLED" ]; then
     export JBS_S3_SYNC_ENABLED=true
 fi
+if [ -z "$JBS_MAX_MEMORY" ]; then
+    export JBS_MAX_MEMORY=4096
+fi
 # Horrendous hack to work around
 # https://github.com/kubernetes-sigs/kustomize/issues/5124
 # given an env var is a string (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/)
@@ -64,6 +67,7 @@ ${GIT_DISABLE_SSL_VERIFICATION}
 ${JBS_BUILD_IMAGE_SECRET}
 ${JBS_GIT_CREDENTIALS}
 ${JBS_QUAY_IMAGE}
+${JBS_MAX_MEMORY}
 ${JBS_RECIPE_DATABASE}
 ${JBS_S3_SYNC_ENABLED}
 ${JBS_WORKER_NAMESPACE}

--- a/deploy/minikube-ci.sh
+++ b/deploy/minikube-ci.sh
@@ -36,6 +36,7 @@ export JVM_BUILD_SERVICE_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-controller
 # Represents an empty dockerconfig.json
 export JBS_BUILD_IMAGE_SECRET="ewogICAgImF1dGhzIjogewogICAgfQp9Cg==" # notsecret
 export JBS_S3_SYNC_ENABLED="\"false\""
+export JBS_MAX_MEMORY=4096
 
 cat $DIR/base/namespace/namespace.yaml | envsubst '${JBS_WORKER_NAMESPACE}' | kubectl apply -f -
 kubectl config set-context --current --namespace=test-jvm-namespace
@@ -54,6 +55,7 @@ ${GIT_DISABLE_SSL_VERIFICATION}
 ${JBS_BUILD_IMAGE_SECRET}
 ${JBS_GIT_CREDENTIALS}
 ${JBS_QUAY_IMAGE}
+${JBS_MAX_MEMORY}
 ${JBS_RECIPE_DATABASE}
 ${JBS_S3_SYNC_ENABLED}
 ${JBS_WORKER_NAMESPACE}

--- a/deploy/overlays/dev-template/system-config.yaml
+++ b/deploy/overlays/dev-template/system-config.yaml
@@ -4,5 +4,5 @@ kind: SystemConfig
 metadata:
   name: cluster
 spec:
-  maxAdditionalMemory: 4096
+  maxAdditionalMemory: ${JBS_MAX_MEMORY}
   recipeDatabase: "${JBS_RECIPE_DATABASE}"

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -575,7 +575,7 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, log 
 		Pipeline: &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 		Tasks:    &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 	}
-	pr.Spec.PipelineSpec, diagnostic, err = createPipelineSpec(attempt.Recipe.Tool, db.Status.CommitTime, jbsConfig, &systemConfig, attempt.Recipe, db, paramValues, buildRequestProcessorImage, attempt.BuildId, preBuildImages)
+	pr.Spec.PipelineSpec, diagnostic, err = createPipelineSpec(log, attempt.Recipe.Tool, db.Status.CommitTime, jbsConfig, &systemConfig, attempt.Recipe, db, paramValues, buildRequestProcessorImage, attempt.BuildId, preBuildImages)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
We have several projects (e.g. Spring, Quarkus, Kotlin) that are specified with `6144` additionalMemory. This will have no affect in the majority of cases unless maxAdditionalMemory is easier to configure. 

Although rebuilding Spring just now, I see it hits a maximum of 4.63GB in the metrics so could potentially be changed.