### PR TITLE
Configure Renovate to ignore tekton updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,6 @@
   "extends": ["config:recommended"],
   "pinDigests": true,
   "postUpdateOptions": ["gomodTidy"],
-  "addLabels": ["ok-to-test"]
+  "addLabels": ["ok-to-test"],
+  "ignoreDeps": ["github.com/tektoncd/cli", "github.com/tektoncd/pipeline"]
 }


### PR DESCRIPTION
This tries to avoid problems like https://github.com/redhat-appstudio/jvm-build-service/pull/1510 and repeated closing of PRs like https://github.com/redhat-appstudio/jvm-build-service/pull/1512 by configuring Renovate to ignore these dependencies ( https://docs.renovatebot.com/configuration-options/#ignoredeps ) 

We should be locked to the OpenShift Pipelines 1.13 versions (components detailed in https://docs.openshift.com/pipelines/1.13/about/op-release-notes.html ) 