### PR TITLE
Cache configuration and diagnostic dockerfiles

### DIFF
--- a/java-components/build-request-processor/src/main/resources/gradle/repositories.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/repositories.gradle
@@ -6,15 +6,15 @@ class RepositoryPlugin implements Plugin<Gradle> {
 
     private static String ENTERPRISE_REPOSITORY_URL = System.getenv("CACHE_URL") != null ? System.getenv("CACHE_URL") : "http://localhost:8080/v2/cache/rebuild-default,gradle,gradleplugins/0"
 
-    // Provided to allow this plugin to be completed disabled. Off by default.
-    private static Boolean DISABLE_JBS_REPOSITORY_PLUGIN = System.getenv("DISABLE_JBS_REPOSITORY_PLUGIN") != null;
+    // Provided to allow this plugin (which routes request to the cache) to be completely disabled. Off by default.
+    private static Boolean JBS_DISABLE_CACHE = System.getenv("JBS_DISABLE_CACHE") != null;
 
     // Provided to allow disabling of prior repositories. Off by default.
-    private static Boolean DISABLE_OLD_REPOSITORIES = System.getenv("DISABLE_OLD_REPOSITORIES") != null;
+    private static Boolean JBS_DISABLE_GRADLE_REPOSITORIES = System.getenv("JBS_DISABLE_GRADLE_REPOSITORIES") != null;
 
 
     void apply(Gradle gradle) {
-        if (DISABLE_JBS_REPOSITORY_PLUGIN) {
+        if (JBS_DISABLE_CACHE) {
             return
         }
         if (ENTERPRISE_REPOSITORY_URL.startsWith("file:/")) {
@@ -22,7 +22,7 @@ class RepositoryPlugin implements Plugin<Gradle> {
             return
         }
         def fixRepositories = {
-            if (!DISABLE_OLD_REPOSITORIES) {
+            if (!JBS_DISABLE_GRADLE_REPOSITORIES) {
                 all { ArtifactRepository repo ->
                     try {
                         if (!(repo instanceof MavenArtifactRepository) ||

--- a/pkg/reconciler/dependencybuild/scripts/maven-settings.sh
+++ b/pkg/reconciler/dependencybuild/scripts/maven-settings.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 
-cat >"$(workspaces.build-settings.path)"/settings.xml <<EOF
-<settings>
-  <mirrors>
-    <mirror>
-      <id>mirror.default</id>
-      <url>${CACHE_URL}</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-  </mirrors>
+if [ ! -z ${JBS_DISABLE_CACHE+x} ]; then
+    cat >"$(workspaces.build-settings.path)"/settings.xml <<EOF
+    <settings>
+EOF
+else
+    cat >"$(workspaces.build-settings.path)"/settings.xml <<EOF
+    <settings>
+      <mirrors>
+        <mirror>
+          <id>mirror.default</id>
+          <url>${CACHE_URL}</url>
+          <mirrorOf>*</mirrorOf>
+        </mirror>
+      </mirrors>
+EOF
+fi
 
+cat >>"$(workspaces.build-settings.path)"/settings.xml <<EOF
   <!-- Off by default, but allows a secondary Maven build to use results of prior (e.g. Gradle) deployment -->
   <profiles>
     <profile>


### PR DESCRIPTION
This: 

- Renames some variables for clarity.
- Derives from the preBuildImage
- Allows cache to be disabled for Maven builds
- Resolves building diagnostic files under UBI7