### PR TITLE
Gradle & EnforceVersion

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/InvocationBuilder.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/InvocationBuilder.java
@@ -133,7 +133,7 @@ public class InvocationBuilder {
     public BuildInfo build(CacheBuildInfoLocator buildInfoLocator) {
         if (buildRecipeInfo != null) {
             if (buildRecipeInfo.isEnforceVersion() && !versionCorrect) {
-                info.enforceVersion = version;
+                info.enforceVersion = "true";
             }
             if (buildRecipeInfo.getRepositories() != null && !buildRecipeInfo.getRepositories().isEmpty()) {
                 info.setRepositories(buildRecipeInfo.getRepositories());

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -563,7 +563,7 @@ public class LookupBuildInfoCommand implements Runnable {
             //TODO: we should do discovery on the whole tree
             if (model.getVersion() != null && model.getVersion().endsWith("-SNAPSHOT")) {
                 //not tagged properly, deal with it automatically
-                builder.enforceVersion(version);
+                builder.enforceVersion("true");
             } else if (model.getVersion() == null || Objects.equals(version, model.getVersion())) {
                 //if the version is null we can't run enforce version at this point
                 //version is correct, don't run enforce version as it can fail on things

--- a/java-components/build-request-processor/src/main/resources/gradle/version.gradle
+++ b/java-components/build-request-processor/src/main/resources/gradle/version.gradle
@@ -2,16 +2,16 @@ apply plugin: VersionPlugin
 
 class VersionPlugin implements Plugin<Gradle> {
 
-    private static String VERSION = System.getenv("ENFORCE_VERSION")
+    private static String ENFORCE_VERSION = System.getenv("ENFORCE_VERSION")
+    private static String PROJECT_VERSION = System.getenv("PROJECT_VERSION")
 
     void apply(Gradle gradle) {
-        if (VERSION == null || VERSION.isEmpty()) {
-            return
-        }
-        gradle.allprojects {
-            project -> project.afterEvaluate {
-                project.logger.lifecycle "Overriding version for ${project.name} to ${VERSION}"
-                version VERSION
+        if ("true".equals(ENFORCE_VERSION)) {
+            gradle.allprojects {
+                project -> project.afterEvaluate {
+                    project.logger.lifecycle "Overriding version for ${project.name} to ${PROJECT_VERSION}"
+                    version PROJECT_VERSION
+                }
             }
         }
     }

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -27,6 +27,10 @@ RELEASE_REPOSITORY_URL=file:$(workspaces.source.path)/artifacts
 RELEASE_SIGNING_ENABLED=false
 mavenCentralUsername=
 mavenCentralPassword=
+
+# Default values for common enforced properties
+sonatypeUsername=jbs
+sonatypePassword=jbs
 EOF
 
 if [ -d .hacbs-init ]; then

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -44,12 +44,9 @@ export PATH="${JAVA_HOME}/bin:${PATH}"
 #so just create one to fool the plugin
 git config user.email "HACBS@redhat.com"
 git config user.name "HACBS"
-if [ -z "$(params.ENFORCE_VERSION)" ]; then
-  echo "Enforce version not set, recreating original tag $(params.TAG)"
-  git tag -m $(params.TAG) -a $(params.TAG) || true
-else
-  echo "Creating tag $(params.ENFORCE_VERSION) to match enforced version"
-  git tag -m $(params.ENFORCE_VERSION) -a $(params.ENFORCE_VERSION) || true
+if [ -n "$(params.ENFORCE_VERSION)" ]; then
+  echo "Creating tag $(params.PROJECT_VERSION) to match enforced version"
+  git tag -m $(params.PROJECT_VERSION) -a $(params.PROJECT_VERSION) || true
 fi
 
 if [ ! -d "${GRADLE_HOME}" ]; then

--- a/pkg/reconciler/dependencybuild/scripts/maven-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/maven-build.sh
@@ -44,15 +44,10 @@ cat >>"$TOOLCHAINS_XML" <<EOF
 </toolchains>
 EOF
 
-
-if [ -z "$(params.ENFORCE_VERSION)" ]
-then
-  echo "Enforce version not set, skipping"
-else
-  echo "Setting version to $(params.ENFORCE_VERSION)"
-  mvn -B -e -s "$(workspaces.build-settings.path)/settings.xml" -t "$(workspaces.build-settings.path)/toolchains.xml" org.codehaus.mojo:versions-maven-plugin:2.8.1:set -DnewVersion="$(params.ENFORCE_VERSION)"  | tee $(workspaces.source.path)/logs/enforce-version.log
+if [ -n "$(params.ENFORCE_VERSION)" ]; then
+  echo "Setting version to $(params.PROJECT_VERSION) to match enforced version"
+  mvn -B -e -s "$(workspaces.build-settings.path)/settings.xml" -t "$(workspaces.build-settings.path)/toolchains.xml" org.codehaus.mojo:versions-maven-plugin:2.8.1:set -DnewVersion="$(params.PROJECT_VERSION)" | tee $(workspaces.source.path)/logs/enforce-version.log
 fi
-
 
 #if we run out of memory we want the JVM to die with error code 134
 export MAVEN_OPTS="-XX:+CrashOnOutOfMemoryError"


### PR DESCRIPTION
Fixes https://github.com/apheleia-project/jbs-build-issues/issues/5

This resolves building btf and changes some Gradle build behaviour - it will only create a tag if enforceVersion is set now (as I don't believe the other route is required). Finally, while I would have preferred to change enforceVersion to a bool throughout, I realise that could affect the crds and backwards compatibility so I've just changed it look like a bool and be consistent from the jvm-build-data source.