### PR TITLE
Handle Nebula and StageVoteRelease plugins

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -533,8 +533,12 @@ public class LookupBuildInfoCommand implements Runnable {
             inv.add("-DdisableTests");
         }
         if (GradleUtils.isInBuildGradle(gradleFile, GradleUtils.NEBULA_PLUGIN)) {
-            Log.infof("Found Nebula plugin to add 'release.version=%s'", version );
+            Log.infof("Found Nebula plugin to add '-Prelease.version=%s'", version );
             inv.add("-Prelease.version=" + version);
+        }
+        if (GradleUtils.isInBuildGradle(gradleFile, GradleUtils.STAGE_VOTE_RELEASE_PLUGIN)) {
+            Log.infof("Found StageVoteRelease plugin to add '-Prelease");
+            inv.add("-Prelease");
         }
 
         final Collection<File> files = FileUtils.listFiles(

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -489,7 +489,7 @@ public class LookupBuildInfoCommand implements Runnable {
         return paths;
     }
 
-    private static void handleAntBuild(InvocationBuilder builder, Path antFile) {
+    private void handleAntBuild(InvocationBuilder builder, Path antFile) {
         //TODO: this needs work, too much hard coded stuff, just try all and builds
         // XXX: It is possible to change the build file location via -buildfile/-file/-f or -find/-s
         Log.infof("Detected Ant build file %s", antFile);
@@ -507,13 +507,13 @@ public class LookupBuildInfoCommand implements Runnable {
         builder.addToolInvocation(ANT, inv);
     }
 
-    private static void handleSbtBuild(InvocationBuilder builder, Path sbtFile) {
+    private void handleSbtBuild(InvocationBuilder builder, Path sbtFile) {
         //TODO: initial SBT support, needs more work
         Log.infof("Detected SBT build file %s", sbtFile);
         builder.addToolInvocation(SBT, List.of("--no-colors", "+publish"));
     }
 
-    private static void handleGradleBuild(InvocationBuilder builder, Path gradleFile, boolean skipTests) throws IOException {
+    private void handleGradleBuild(InvocationBuilder builder, Path gradleFile, boolean skipTests) throws IOException {
         Log.infof("Detected Gradle build file %s", gradleFile);
         var optionalGradleVersion = GradleUtils
                 .getGradleVersionFromWrapperProperties(GradleUtils.getPropertiesFile(gradleFile.getParent()));
@@ -531,6 +531,10 @@ public class LookupBuildInfoCommand implements Runnable {
             // that exclusion would ignore them. Instead pass a property to activate
             // java-components/build-request-processor/src/main/resources/gradle/test.gradle
             inv.add("-DdisableTests");
+        }
+        if (GradleUtils.isInBuildGradle(gradleFile, GradleUtils.NEBULA_PLUGIN)) {
+            Log.infof("Found Nebula plugin to add 'release.version=%s'", version );
+            inv.add("-Prelease.version=" + version);
         }
 
         final Collection<File> files = FileUtils.listFiles(

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
@@ -32,6 +32,11 @@ public final class GradleUtils {
      */
     public static final String MAVEN_PUBLISH_PLUGIN = String.format(PLUGIN_FORMAT, "maven-publish", "maven-publish");
 
+    /**
+     * Code for applying the plugin {@code nebula-plugin}.
+     */
+    public static final String NEBULA_PLUGIN = String.format(PLUGIN_FORMAT, "nebula.release", "nebula.release");
+
     public static final String BUILD_GRADLE = "build.gradle";
 
     public static final String BUILD_GRADLE_KTS = "build.gradle.kts";

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtils.java
@@ -19,23 +19,34 @@ public final class GradleUtils {
     /**
      * Format for applying plugins.
      */
-    public static final String PLUGIN_FORMAT = "^\\s*(" + "apply\\s*\\(\\s*plugin:\\s*[\"']%s[\"']\\s*\\)\\s*;?" + "|"
-            + "apply\\s+plugin:\\s*[\"']%s[\"']\\s*;?" + ")";
+    public static final String PLUGIN_FORMAT = "^\\s*(" +
+        "apply\\s*\\(\\s*plugin:\\s*[\"']%s[\"']\\s*\\)\\s*;?"
+        + "|"
+        + "apply\\s+plugin:\\s*[\"']%s[\"']\\s*;?" + ")"
+        + "|"
+        + "id\\s*\\(\\s*[\"']%s[\"']\\s*\\)\\s*;?"
+        + "|"
+        + "id\\s*[\"']%s[\"']\\s*;?";
 
     /**
      * Code for applying the plugin {@code maven}.
      */
-    public static final String MAVEN_PLUGIN = String.format(PLUGIN_FORMAT, "maven", "maven");
+    public static final String MAVEN_PLUGIN = String.format(PLUGIN_FORMAT, "maven", "maven", "maven", "maven");
 
     /**
      * Code for applying the plugin {@code maven-publish}.
      */
-    public static final String MAVEN_PUBLISH_PLUGIN = String.format(PLUGIN_FORMAT, "maven-publish", "maven-publish");
+    public static final String MAVEN_PUBLISH_PLUGIN = String.format(PLUGIN_FORMAT, "maven-publish", "maven-publish", "maven-publish", "maven-publish");
 
     /**
-     * Code for applying the plugin {@code nebula-plugin}.
+     * Code for handling the plugin {@code nebula-plugin}. See <a href="https://github.com/nebula-plugins/nebula-release-plugin">here</a>
      */
-    public static final String NEBULA_PLUGIN = String.format(PLUGIN_FORMAT, "nebula.release", "nebula.release");
+    public static final String NEBULA_PLUGIN = String.format(PLUGIN_FORMAT, "nebula.release", "nebula.release", "nebula.release", "nebula.release");
+
+    /**
+     * Code for handling the plugin {@code stage-vote-release-plugin}. See <a href="https://github.com/vlsi/vlsi-release-plugins/blob/master/plugins/stage-vote-release-plugin/README.md">here</a>
+     */
+    public static final String STAGE_VOTE_RELEASE_PLUGIN = String.format(PLUGIN_FORMAT, "com.github.vlsi.stage-vote-release", "com.github.vlsi.stage-vote-release", "com.github.vlsi.stage-vote-release", "com.github.vlsi.stage-vote-release");
 
     public static final String BUILD_GRADLE = "build.gradle";
 

--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtilsTest.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/analyser/build/gradle/GradleUtilsTest.java
@@ -4,6 +4,7 @@ import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.DEFAU
 import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.MAVEN_PLUGIN;
 import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.MAVEN_PLUGIN_GRADLE_ARGS;
 import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.MAVEN_PUBLISH_PLUGIN;
+import static com.redhat.hacbs.container.analyser.build.gradle.GradleUtils.STAGE_VOTE_RELEASE_PLUGIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -119,6 +120,17 @@ class GradleUtilsTest {
         assertThat(GradleUtils.isInBuildGradle(buildGradle, MAVEN_PUBLISH_PLUGIN)).isTrue();
         assertThat(GradleUtils.isInBuildGradle(buildGradle, MAVEN_PLUGIN)).isFalse();
         assertThat(GradleUtils.getGradleArgs(buildGradle)).isEqualTo(DEFAULT_GRADLE_ARGS);
+    }
+
+    @Test
+    void testFindStageReleasePlugin(@TempDir Path basedir) throws IOException {
+        Path buildGradle = basedir.resolve(GradleUtils.BUILD_GRADLE_KTS);
+        Files.writeString(buildGradle, "id('com.github.vlsi.stage-vote-release')  version '1.90'" + System.lineSeparator());
+        assertThat(GradleUtils.isInBuildGradle(buildGradle, STAGE_VOTE_RELEASE_PLUGIN)).isTrue();
+        Files.writeString(buildGradle, "id('com.github.vlsi.stage-vote-release')" + System.lineSeparator());
+        assertThat(GradleUtils.isInBuildGradle(buildGradle, STAGE_VOTE_RELEASE_PLUGIN)).isTrue();
+        Files.writeString(buildGradle, "id \"com.github.vlsi.stage-vote-release\"  version \"1.90\"" + System.lineSeparator());
+        assertThat(GradleUtils.isInBuildGradle(buildGradle, STAGE_VOTE_RELEASE_PLUGIN)).isTrue();
     }
 
     @Test

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -9,9 +9,6 @@ cp -r /maven-artifacts/.m2/* "$HOME/.m2/" || true
 
 cat > "${GRADLE_USER_HOME}"/gradle.properties << EOF
 org.gradle.console=plain
-# For Spring/Nebula Release Plugins
-release.useLastTag=true
-release.stage=final
 
 # For https://github.com/Kotlin/kotlinx.team.infra
 versionSuffix=
@@ -69,7 +66,7 @@ echo "Running Gradle command with arguments: $@"
 if [ ! -d $(workspaces.source.path)/source ]; then
   cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
 fi
-gradle -Dmaven.repo.local=$(workspaces.source.path)/artifacts --info --stacktrace "$@"  | tee $(workspaces.source.path)/logs/gradle.log
+gradle -Dmaven.repo.local=$(workspaces.source.path)/artifacts --info --stacktrace "$@" | tee $(workspaces.source.path)/logs/gradle.log
 
 mkdir -p $(workspaces.source.path)/build-info
 cp -r "${GRADLE_USER_HOME}" $(workspaces.source.path)/build-info/.gradle


### PR DESCRIPTION
~~Ideally we would be able to encapsulate this within an init script and only activate it if the Nebula plugin is being used ; however I couldn't find any way of setting release.version there as opposed to from the cmd line.~~

This is for micrometer and pgjdbc builds.