### PR TITLE
Update build-definitions references to new org

### DIFF
--- a/hack/examples/kustomization.yaml
+++ b/hack/examples/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 - gradle-v0.1.yaml
-- https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/task/git-clone/0.1/git-clone.yaml
+- https://raw.githubusercontent.com/konflux-ci/build-definitions/main/task/git-clone/0.1/git-clone.yaml
 - maven-v0.2.yaml
 - pipeline.yaml
 - pipeline-gradle.yaml

--- a/openshift-with-appstudio-test/e2e/const.go
+++ b/openshift-with-appstudio-test/e2e/const.go
@@ -5,5 +5,5 @@ const (
 	maxNameLength          = 63
 	randomLength           = 5
 	maxGeneratedNameLength = maxNameLength - randomLength
-	gitCloneTaskUrl        = "https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/task/git-clone/0.1/git-clone.yaml"
+	gitCloneTaskUrl        = "https://raw.githubusercontent.com/konflux-ci/build-definitions/main/task/git-clone/0.1/git-clone.yaml"
 )


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
