### PR TITLE
Skip spotless

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java
@@ -605,7 +605,9 @@ public class LookupBuildInfoCommand implements Runnable {
                             "-Drat.skip=true",
                             "-Drevapi.skip",
                             "-Dsort.skip", // https://github.com/Ekryd/sortpom
-                            "-Dspotbugs.skip"));
+                            "-Dspotbugs.skip",
+                            "-Dspotless.check.skip=true" // https://github.com/diffplug/spotless/tree/main/plugin-maven
+                    ));
             if (skipTests) {
                 //we assume private repos are essentially fresh tags we have control of
                 //so we should run the tests


### PR DESCRIPTION
For https://github.com/apache/maven-resolver.git@maven-resolver-1.9.20 which inherits https://github.com/apache/maven-parent/blob/maven-parent-42/pom.xml which applies spotless to everything.