### PR TITLE
Use maven-release plugin API to rewrite poms

### DIFF
--- a/java-components/build-request-processor/pom.xml
+++ b/java-components/build-request-processor/pom.xml
@@ -84,6 +84,14 @@
             <artifactId>indexer-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.release</groupId>
+            <artifactId>maven-release-manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.release</groupId>
+            <artifactId>maven-release-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
         </dependency>
@@ -98,6 +106,10 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.commonjava.maven.ext</groupId>
+            <artifactId>pom-manipulation-common</artifactId>
         </dependency>
 
         <dependency>

--- a/java-components/build-request-processor/src/test/resources/mavenbuilds/mavensharedutils/pom.xml
+++ b/java-components/build-request-processor/src/test/resources/mavenbuilds/mavensharedutils/pom.xml
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared</groupId>
+    <artifactId>maven-shared-components</artifactId>
+    <version>34</version>
+  </parent>
+
+  <artifactId>maven-shared-utils</artifactId>
+  <version>3.3.4</version>
+
+  <name>Apache Maven Shared Utils</name>
+  <description>Shared utilities for use by Maven core and plugins</description>
+
+  <scm>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-shared-utils.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-shared-utils.git</developerConnection>
+    <url>https://github.com/apache/maven-shared-utils/tree/${project.scm.tag}</url>
+    <tag>maven-shared-utils-3.3.4</tag>
+ </scm>
+  <issueManagement>
+    <system>jira</system>
+    <url>https://issues.apache.org/jira/issues/?jql=project%20%3D%20MSHARED%20AND%20component%20%3D%20maven-shared-utils</url>
+  </issueManagement>
+  <ciManagement>
+    <system>Jenkins</system>
+    <url>https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-shared-utils/</url>
+  </ciManagement>
+  <distributionManagement>
+    <site>
+      <id>apache.website</id>
+      <url>scm:svn:https://svn.apache.org/repos/asf/maven/website/components/${maven.site.path}</url>
+    </site>
+  </distributionManagement>
+
+  <contributors>
+    <contributor>
+      <name>Kathryn Newbould</name>
+    </contributor>
+  </contributors>
+
+  <properties>
+    <checkstyle.violation.ignore>RedundantThrows,NewlineAtEndOfFile,ParameterNumber,MethodLength,FileLength,ModifierOrder</checkstyle.violation.ignore>
+    <project.build.outputTimestamp>2021-04-26T13:53:43Z</project.build.outputTimestamp>
+    <javaVersion>7</javaVersion>
+    <mavenVersion>3.1.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>2.2.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <!--
+      ! Maven Core was used in context with Maven cause for Toolchain access: avoided through reflection.
+    -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-container-default</artifactId>
+      <version>2.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-testing</groupId>
+      <artifactId>maven-plugin-testing-harness</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>src/test/resources/directorywalker/**/*</exclude>
+            <exclude>src/test/resources/symlinks/**/*</exclude>
+            <exclude>src/test/resources/executable</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>false</reuseForks>
+          <environmentVariables>
+            <TEST_SHARED_ENV>TestValue</TEST_SHARED_ENV>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java-components/build-request-processor/src/test/resources/mavenbuilds/mavensharedutils/pom.xml.expected
+++ b/java-components/build-request-processor/src/test/resources/mavenbuilds/mavensharedutils/pom.xml.expected
@@ -1,0 +1,163 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared</groupId>
+    <artifactId>maven-shared-components</artifactId>
+    <version>34</version>
+  </parent>
+
+  <artifactId>maven-shared-utils</artifactId>
+  <version>3.3.4</version>
+
+  <name>Apache Maven Shared Utils</name>
+  <description>Shared utilities for use by Maven core and plugins</description>
+
+  <scm>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-shared-utils.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-shared-utils.git</developerConnection>
+    <url>https://github.com/apache/maven-shared-utils/tree/${project.scm.tag}</url>
+    <tag>maven-shared-utils-3.3.4</tag>
+ </scm>
+  <issueManagement>
+    <system>jira</system>
+    <url>https://issues.apache.org/jira/issues/?jql=project%20%3D%20MSHARED%20AND%20component%20%3D%20maven-shared-utils</url>
+  </issueManagement>
+  <ciManagement>
+    <system>Jenkins</system>
+    <url>https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-shared-utils/</url>
+  </ciManagement>
+  <distributionManagement>
+    <site>
+      <id>apache.website</id>
+      <url>scm:svn:https://svn.apache.org/repos/asf/maven/website/components/${maven.site.path}</url>
+    </site>
+  </distributionManagement>
+
+  <contributors>
+    <contributor>
+      <name>Kathryn Newbould</name>
+    </contributor>
+  </contributors>
+
+  <properties>
+    <checkstyle.violation.ignore>RedundantThrows,NewlineAtEndOfFile,ParameterNumber,MethodLength,FileLength,ModifierOrder</checkstyle.violation.ignore>
+    <project.build.outputTimestamp>2021-04-26T13:53:43Z</project.build.outputTimestamp>
+    <javaVersion>7</javaVersion>
+    <mavenVersion>3.1.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>2.2.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <!--
+      ! Maven Core was used in context with Maven cause for Toolchain access: avoided through reflection.
+    -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-container-default</artifactId>
+      <version>2.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-testing</groupId>
+      <artifactId>maven-plugin-testing-harness</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>src/test/resources/directorywalker/**/*</exclude>
+            <exclude>src/test/resources/symlinks/**/*</exclude>
+            <exclude>src/test/resources/executable</exclude>
+          </excludes>
+          
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>false</reuseForks>
+          <environmentVariables>
+            <TEST_SHARED_ENV>TestValue</TEST_SHARED_ENV>
+          </environmentVariables>
+          
+        </configuration>
+      </plugin>
+      
+    </plugins>
+  </build>
+
+</project>

--- a/java-components/build-request-processor/src/test/resources/mavenbuilds/narayana/pom.xml.expected
+++ b/java-components/build-request-processor/src/test/resources/mavenbuilds/narayana/pom.xml.expected
@@ -1,342 +1,344 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jboss</groupId>
-    <artifactId>jboss-parent</artifactId>
-    <version>35</version>
-  </parent>
-  <groupId>org.jboss.narayana</groupId>
-  <artifactId>narayana-all</artifactId>
-  <version>5.10.6.Final-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <name>Narayana: all</name>
-  <description>${project.artifactId}</description>
-  <url>http://www.jboss.org/jbosstm/</url>
-  <licenses>
-    <license>
-      <name>LGPL 2.1</name>
-      <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
-    </license>
-  </licenses>
-  <developers>
-    <developer>
-      <id>nmcl</id>
-      <name>Mark Little</name>
-      <email>mlittle@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <roles>
-        <role>JBoss CTO</role>
-      </roles>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>tomjenkinson</id>
-      <name>Tom Jenkinson</name>
-      <email>tom.jenkinson@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <roles>
-        <role>project lead</role>
-      </roles>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>paulrobinson</id>
-      <name>Paul Robinson</name>
-      <email>paul.robinson@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <roles>
-        <role>xts lead</role>
-      </roles>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>mmusgrov</id>
-      <name>Michael Musgrove</name>
-      <email>mmusgrov@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <roles>
-        <role>Core Developer</role>
-      </roles>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>zhfeng</id>
-      <name>Amos Feng</name>
-      <email>zfeng@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <roles>
-        <role>Core Developer</role>
-      </roles>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>istudens</id>
-      <name>Ivo Studensky</name>
-      <email>istudens@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <roles>
-        <role>QA lead</role>
-      </roles>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>jhalliday</id>
-      <name>Jonathan Halliday</name>
-      <email>jonathan.halliday@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <timezone>0</timezone>
-    </developer>
-    <developer>
-      <id>adinn</id>
-      <name>Andrew Dinn</name>
-      <email>adinn@redhat.com</email>
-      <organization>JBoss</organization>
-      <organizationUrl>http://www.jboss.org/</organizationUrl>
-      <timezone>0</timezone>
-    </developer>
-  </developers>
-  <modules>
-    <module>tools</module>
-    <module>ext</module>
-    <module>common</module>
-    <module>ArjunaCore</module>
-    <module>ArjunaJTA</module>
-    <module>ArjunaJTS</module>
-    <module>XTS</module>
-    <module>rts</module>
-    <module>txbridge</module>
-    <module>STM</module>
-    <module>txframework</module>
-    <module>compensations</module>
-    <module>osgi</module>
-    <module>vertx</module>
-  </modules>
-  <scm>
-    <connection>scm:git:git@github.com:jbosstm/narayana.git</connection>
-    <developerConnection>scm:git:git@github.com:jbosstm/narayana.git</developerConnection>
-    <url>https://github.com/jbosstm/narayana</url>
-  </scm>
-  <issueManagement>
-    <system>JIRA</system>
-    <url>https://jira.jboss.org/jira/browse/JBTM/</url>
-  </issueManagement>
-  <ciManagement>
-    <system>hudson</system>
-    <url>http://hudson.qa.jboss.com/hudson/view/JBossTS/</url>
-  </ciManagement>
-  <distributionManagement>
-    <repository>
-      <id>jboss-releases-repository</id>
-      <name>JBoss Release Repository</name>
-      <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
-    </repository>
-    <snapshotRepository>
-      <id>jboss-snapshots-repository</id>
-      <name>JBoss Snapshot Repository</name>
-      <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
-  <properties>
-    <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
-    <version.org.jacoco>0.8.3</version.org.jacoco>
-    <version.org.jboss.logmanager>1.5.1.Final</version.org.jboss.logmanager>
-    <version.javax.inject>1</version.javax.inject>
-    <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
-    <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
-    <version.org.apache.tomcat>9.0.7</version.org.apache.tomcat>
-    <version.mariadb>1.2.2</version.mariadb>
-    <version.org.jboss.arquillian.container.weld>1.0.0.CR9</version.org.jboss.arquillian.container.weld>
-    <jvm.args.memory>-Xms64m -Xmx1024m</jvm.args.memory>
-    <version.org.jboss.spec.jboss-javaee-6.0>3.0.2.Final</version.org.jboss.spec.jboss-javaee-6.0>
-    <jvm.args.debug></jvm.args.debug>
-    <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
-    <version.org.jboss.arquillian.container.tomcat>1.0.1.Final</version.org.jboss.arquillian.container.tomcat>
-    <version.javax.javaee-api>7.0</version.javax.javaee-api>
-    <version.org.jboss.ws>1.0.2.Final</version.org.jboss.ws>
-    <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>
-    <version.org.jboss.spec.javax.servlet>1.0.2.Final</version.org.jboss.spec.javax.servlet>
-    <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
-    <version.mysql>5.1.28</version.mysql>
-    <version.junit>4.11</version.junit>
-    <version.com.ibm>11.5.0.0</version.com.ibm>
-    <version.maven-failsafe-plugin>2.22.0</version.maven-failsafe-plugin>
-    <version.doxia>1.8.1</version.doxia>
-    <testLogToFile>true</testLogToFile>
-    <version.com.github.docker-java>3.0.14</version.com.github.docker-java>
-    <version.org.jboss.resteasy>3.9.1.Final</version.org.jboss.resteasy>
-    <version.org.mockito>2.5.3</version.org.mockito>
-    <version.org.apache.httpcomponents>4.2.1</version.org.apache.httpcomponents>
-    <checkstyle.skip>true</checkstyle.skip>
-    <jvm.args.modular></jvm.args.modular>
-    <jvm.args.other>-server</jvm.args.other>
-    <version.jfree>1.0.9</version.jfree>
-    <version.org.jboss.integration>6.0.0.CR1</version.org.jboss.integration>
-    <version.javax.servlet>3.0.1</version.javax.servlet>
-    <version.sun.jdk>jdk</version.sun.jdk>
-    <version.jacorb>2.3.1jboss.patch01-brew</version.jacorb>
-    <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
-    <version.com.sun.jersey>1.9.1</version.com.sun.jersey>
-    <version.com.github.spotbugs.spotbugs-maven-plugin>3.1.10</version.com.github.spotbugs.spotbugs-maven-plugin>
-    <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
-    <version.org.jboss.spec.javax.transaction>1.1.0.Final</version.org.jboss.spec.javax.transaction>
-    <version.dom4j>1.6.1</version.dom4j>
-    <version.org.jboss.spec.javax.interceptor>1.0.0.Final</version.org.jboss.spec.javax.interceptor>
-    <version.org.jacorb.jacorb>2.3.2-jbossorg-5</version.org.jacorb.jacorb>
-    <version.javax.annotation>1.2</version.javax.annotation>
-    <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-    <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
-    <version.com.microsoft.sqlserver>mssql2005_sqljdbc_2.0</version.com.microsoft.sqlserver>
-    <version.com.oracle>10.2.0.4</version.com.oracle>
-    <version.org.jboss.ironjacamar>1.1.1.Final</version.org.jboss.ironjacamar>
-    <version.rhino.js>1.7R2</version.rhino.js>
-    <version.com.sun.grizzly>1.9.59</version.com.sun.grizzly>
-    <maven.build.timestamp.format>yyyy/MMM/dd HH:mm</maven.build.timestamp.format>
-    <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
-    <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
-    <version.postgresql>9.0-801.jdbc4</version.postgresql>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
-    <version.org.jboss.spec.javax.ejb>1.0.2.Final</version.org.jboss.spec.javax.ejb>
-    <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-    <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
-    <version.asm>3.3.1</version.asm>
-    <version.org.apache.ant>1.8.2</version.org.apache.ant>
-    <version.jnpserver>5.0.3.GA</version.jnpserver>
-    <version.commons-httpclient>3.1-jbossorg-1</version.commons-httpclient>
-    <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
-    <version.org.eclipse.microprofile.openapi>1.1.2</version.org.eclipse.microprofile.openapi>
-    <version.org.jboss.logging.jboss-logging-processor>2.0.0.Final</version.org.jboss.logging.jboss-logging-processor>
-    <jvm.args.jacoco>-javaagent:${project.build.directory}/lib/jacocoagent.jar=destfile=${project.build.directory}/coverage-reports/jacoco-ut.exec,includes=*,append=true,output=file</jvm.args.jacoco>
-    <version.org.jboss.weld>2.3.5.Final</version.org.jboss.weld>
-    <version.log4j>1.2.17</version.log4j>
-    <version.org.jboss.byteman>4.0.10</version.org.jboss.byteman>
-    <version.com.h2database>1.4.195</version.com.h2database>
-    <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
-    <jvm.args.byteman>-Dorg.jboss.byteman.verbose
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>35</version>
+    </parent>
+    <groupId>org.jboss.narayana</groupId>
+    <artifactId>narayana-all</artifactId>
+    <version>5.10.6.Final-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Narayana: all</name>
+    <description>${project.artifactId}</description>
+    <url>http://www.jboss.org/jbosstm/</url>
+    <licenses>
+        <license>
+            <name>LGPL 2.1</name>
+            <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>nmcl</id>
+            <name>Mark Little</name>
+            <email>mlittle@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <roles>
+                <role>JBoss CTO</role>
+            </roles>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>tomjenkinson</id>
+            <name>Tom Jenkinson</name>
+            <email>tom.jenkinson@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <roles>
+                <role>project lead</role>
+            </roles>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>paulrobinson</id>
+            <name>Paul Robinson</name>
+            <email>paul.robinson@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <roles>
+                <role>xts lead</role>
+            </roles>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>mmusgrov</id>
+            <name>Michael Musgrove</name>
+            <email>mmusgrov@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <roles>
+                <role>Core Developer</role>
+            </roles>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>zhfeng</id>
+            <name>Amos Feng</name>
+            <email>zfeng@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <roles>
+                <role>Core Developer</role>
+            </roles>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>istudens</id>
+            <name>Ivo Studensky</name>
+            <email>istudens@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <roles>
+                <role>QA lead</role>
+            </roles>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>jhalliday</id>
+            <name>Jonathan Halliday</name>
+            <email>jonathan.halliday@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <timezone>0</timezone>
+        </developer>
+        <developer>
+            <id>adinn</id>
+            <name>Andrew Dinn</name>
+            <email>adinn@redhat.com</email>
+            <organization>JBoss</organization>
+            <organizationUrl>http://www.jboss.org/</organizationUrl>
+            <timezone>0</timezone>
+        </developer>
+    </developers>
+    <modules>
+        <module>tools</module>
+        <module>ext</module>
+        <module>common</module>
+        <module>ArjunaCore</module>
+        <module>ArjunaJTA</module>
+        <module>ArjunaJTS</module>
+        <module>XTS</module>
+        <module>rts</module>
+        <module>txbridge</module>
+        <module>STM</module>
+        <module>txframework</module>
+        <module>compensations</module>
+        <module>osgi</module>
+        <module>vertx</module>
+    </modules>
+    <scm>
+        <connection>scm:git:git@github.com:jbosstm/narayana.git</connection>
+        <developerConnection>scm:git:git@github.com:jbosstm/narayana.git</developerConnection>
+        <url>https://github.com/jbosstm/narayana</url>
+    </scm>
+    <issueManagement>
+        <system>JIRA</system>
+        <url>https://jira.jboss.org/jira/browse/JBTM/</url>
+    </issueManagement>
+    <ciManagement>
+        <system>hudson</system>
+        <url>http://hudson.qa.jboss.com/hudson/view/JBossTS/</url>
+    </ciManagement>
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Release Repository</name>
+            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>jboss-snapshots-repository</id>
+            <name>JBoss Snapshot Repository</name>
+            <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+    <properties>
+        <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jacoco>0.8.3</version.org.jacoco>
+        <version.org.jboss.logmanager>1.5.1.Final</version.org.jboss.logmanager>
+        <version.javax.inject>1</version.javax.inject>
+        <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
+        <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
+        <version.org.apache.tomcat>9.0.7</version.org.apache.tomcat>
+        <version.mariadb>1.2.2</version.mariadb>
+        <version.org.jboss.arquillian.container.weld>1.0.0.CR9</version.org.jboss.arquillian.container.weld>
+        <jvm.args.memory>-Xms64m -Xmx1024m</jvm.args.memory>
+        <version.org.jboss.spec.jboss-javaee-6.0>3.0.2.Final</version.org.jboss.spec.jboss-javaee-6.0>
+        <jvm.args.debug />
+        <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.container.tomcat>1.0.1.Final</version.org.jboss.arquillian.container.tomcat>
+        <version.javax.javaee-api>7.0</version.javax.javaee-api>
+        <version.org.jboss.ws>1.0.2.Final</version.org.jboss.ws>
+        <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>
+        <version.org.jboss.spec.javax.servlet>1.0.2.Final</version.org.jboss.spec.javax.servlet>
+        <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
+        <version.mysql>5.1.28</version.mysql>
+        <version.junit>4.11</version.junit>
+        <version.com.ibm>11.5.0.0</version.com.ibm>
+        <version.maven-failsafe-plugin>2.22.0</version.maven-failsafe-plugin>
+        <version.doxia>1.8.1</version.doxia>
+        <testLogToFile>true</testLogToFile>
+        <version.com.github.docker-java>3.0.14</version.com.github.docker-java>
+        <version.org.jboss.resteasy>3.9.1.Final</version.org.jboss.resteasy>
+        <version.org.mockito>2.5.3</version.org.mockito>
+        <version.org.apache.httpcomponents>4.2.1</version.org.apache.httpcomponents>
+        <checkstyle.skip>true</checkstyle.skip>
+        <jvm.args.modular />
+        <jvm.args.other>-server</jvm.args.other>
+        <version.jfree>1.0.9</version.jfree>
+        <version.org.jboss.integration>6.0.0.CR1</version.org.jboss.integration>
+        <version.javax.servlet>3.0.1</version.javax.servlet>
+        <version.sun.jdk>jdk</version.sun.jdk>
+        <version.jacorb>2.3.1jboss.patch01-brew</version.jacorb>
+        <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
+        <version.com.sun.jersey>1.9.1</version.com.sun.jersey>
+        <version.com.github.spotbugs.spotbugs-maven-plugin>3.1.10</version.com.github.spotbugs.spotbugs-maven-plugin>
+        <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
+        <version.org.jboss.spec.javax.transaction>1.1.0.Final</version.org.jboss.spec.javax.transaction>
+        <version.dom4j>1.6.1</version.dom4j>
+        <version.org.jboss.spec.javax.interceptor>1.0.0.Final</version.org.jboss.spec.javax.interceptor>
+        <version.org.jacorb.jacorb>2.3.2-jbossorg-5</version.org.jacorb.jacorb>
+        <version.javax.annotation>1.2</version.javax.annotation>
+        <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
+        <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
+        <version.com.microsoft.sqlserver>mssql2005_sqljdbc_2.0</version.com.microsoft.sqlserver>
+        <version.com.oracle>10.2.0.4</version.com.oracle>
+        <version.org.jboss.ironjacamar>1.1.1.Final</version.org.jboss.ironjacamar>
+        <version.rhino.js>1.7R2</version.rhino.js>
+        <version.com.sun.grizzly>1.9.59</version.com.sun.grizzly>
+        <maven.build.timestamp.format>yyyy/MMM/dd HH:mm</maven.build.timestamp.format>
+        <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
+        <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
+        <version.postgresql>9.0-801.jdbc4</version.postgresql>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
+        <version.org.jboss.spec.javax.ejb>1.0.2.Final</version.org.jboss.spec.javax.ejb>
+        <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
+        <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
+        <version.asm>3.3.1</version.asm>
+        <version.org.apache.ant>1.8.2</version.org.apache.ant>
+        <version.jnpserver>5.0.3.GA</version.jnpserver>
+        <version.commons-httpclient>3.1-jbossorg-1</version.commons-httpclient>
+        <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
+        <version.org.eclipse.microprofile.openapi>1.1.2</version.org.eclipse.microprofile.openapi>
+        <version.org.jboss.logging.jboss-logging-processor>2.0.0.Final</version.org.jboss.logging.jboss-logging-processor>
+        <jvm.args.jacoco>-javaagent:${project.build.directory}/lib/jacocoagent.jar=destfile=${project.build.directory}/coverage-reports/jacoco-ut.exec,includes=*,append=true,output=file</jvm.args.jacoco>
+        <version.org.jboss.weld>2.3.5.Final</version.org.jboss.weld>
+        <version.log4j>1.2.17</version.log4j>
+        <version.org.jboss.byteman>4.0.10</version.org.jboss.byteman>
+        <version.com.h2database>1.4.195</version.com.h2database>
+        <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
+        <jvm.args.byteman>-Dorg.jboss.byteman.verbose
             -Djboss.modules.system.pkgs=org.jboss.byteman
             -Dorg.jboss.byteman.transform.all
             -javaagent:${project.build.directory}/lib/byteman.jar=listener:true</jvm.args.byteman>
-    <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
-    <version.surefire.plugin>2.20</version.surefire.plugin>
-    <version.org.jboss.openjdk-orb>8.0.8.Final</version.org.jboss.openjdk-orb>
-    <version.org.apache.activemq>2.9.0</version.org.apache.activemq>
-    <version.org.codehaus.plexus.plexus-archiver>3.0.3</version.org.codehaus.plexus.plexus-archiver>
-    <version.org.jacorb.jacorb-idl-compiler>2.3.1</version.org.jacorb.jacorb-idl-compiler>
-    <version.javax.enterprise>1.2</version.javax.enterprise>
-    <version.javax.ws.rs-api>2.0.1.Final</version.javax.ws.rs-api>
-    <buildproperty.date>${maven.build.timestamp}</buildproperty.date>
-  </properties>
-  <dependencies>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>${version.javax.annotation}</version>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
-  <repositories>
-    <repository>
-      <id>jbossThirdParty</id>
-      <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Maven Repository Group</name>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.jboss.byteman</groupId>
-          <artifactId>byteman-rulecheck-maven-plugin</artifactId>
-          <version>${version.org.jboss.byteman}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-shade-plugin</artifactId>
-          <configuration>
-            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>jboss-maven-plugin</artifactId>
-          <version>${version.org.codehaus.mojo.jboss-maven-plugin}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.jboss.as.plugins</groupId>
-          <artifactId>jboss-as-maven-plugin</artifactId>
-          <version>${version.org.jboss.as.plugins.jboss-as-maven-plugin}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <archive>
-              <manifestEntries>
-                <Implementation-Title>${project.name}</Implementation-Title>
-                <Implementation-URL>http://www.jboss.org/</Implementation-URL>
-                <Implementation-Vendor>JBoss by Red Hat, Inc.</Implementation-Vendor>
-                <Implementation-Vendor-Id>http://www.jboss.org/</Implementation-Vendor-Id>
-              </manifestEntries>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${version.compiler.plugin}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <argLine>${surefireArgLine}</argLine>
-            <forkMode>pertest</forkMode>
-            <workingDirectory>target/test-classes</workingDirectory>
-            <runOrder>alphabetical</runOrder>
-            <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
-            <inherited>true</inherited>
-            <includes>
+        <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
+        <version.surefire.plugin>2.20</version.surefire.plugin>
+        <version.org.jboss.openjdk-orb>8.0.8.Final</version.org.jboss.openjdk-orb>
+        <version.org.apache.activemq>2.9.0</version.org.apache.activemq>
+        <version.org.codehaus.plexus.plexus-archiver>3.0.3</version.org.codehaus.plexus.plexus-archiver>
+        <version.org.jacorb.jacorb-idl-compiler>2.3.1</version.org.jacorb.jacorb-idl-compiler>
+        <version.javax.enterprise>1.2</version.javax.enterprise>
+        <version.javax.ws.rs-api>2.0.1.Final</version.javax.ws.rs-api>
+        <buildproperty.date>${maven.build.timestamp}</buildproperty.date>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${version.javax.annotation}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <repositories>
+        <repository>
+            <id>jbossThirdParty</id>
+            <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jboss.byteman</groupId>
+                    <artifactId>byteman-rulecheck-maven-plugin</artifactId>
+                    <version>${version.org.jboss.byteman}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <configuration>
+                        <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>jboss-maven-plugin</artifactId>
+                    <version>${version.org.codehaus.mojo.jboss-maven-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jboss.as.plugins</groupId>
+                    <artifactId>jboss-as-maven-plugin</artifactId>
+                    <version>${version.org.jboss.as.plugins.jboss-as-maven-plugin}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Implementation-Title>${project.name}</Implementation-Title>
+                                <Implementation-URL>http://www.jboss.org/</Implementation-URL>
+                                <Implementation-Vendor>JBoss by Red Hat, Inc.</Implementation-Vendor>
+                                <Implementation-Vendor-Id>http://www.jboss.org/</Implementation-Vendor-Id>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${version.compiler.plugin}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>${surefireArgLine}</argLine>
+                        <forkMode>pertest</forkMode>
+                        <workingDirectory>target/test-classes</workingDirectory>
+                        <runOrder>alphabetical</runOrder>
+                        <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                        <inherited>true</inherited>
+                        <includes>
               <include>**/*.java</include>
             </includes>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
+                        
+                        
+                        
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <configuration>
+                        <lifecycleMappingMetadata>
               <pluginExecutions>
                 <pluginExecution>
                   <pluginExecutionFilter>
@@ -348,7 +350,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -361,7 +363,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -374,7 +376,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -387,7 +389,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -401,19 +403,29 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                    </configuration>
+                    <version>1.0.0</version>
+                </plugin>
+                
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
           <execution>
             <id>attach-sources</id>
             <goals>
@@ -421,26 +433,26 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>check-style</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>checkstyle</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-style</id>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+                <dependencies>
           <dependency>
             <groupId>org.wildfly.checkstyle</groupId>
             <artifactId>wildfly-checkstyle-config</artifactId>
             <version>${version.org.wildfly.checkstyle-config}</version>
           </dependency>
         </dependencies>
-        <configuration>
+                <configuration>
           <configLocation>wildfly-checkstyle/checkstyle.xml</configLocation>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
@@ -449,288 +461,289 @@
           <useFile />
           <skip>${checkstyle.skip}</skip>
         </configuration>
-      </plugin>
-    </plugins>
-  </build>
-  <profiles>
-    <profile>
-      <id>byteman-rulecheck</id>
-      <activation>
-        <property>
-          <name>!skipTests</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jboss.byteman</groupId>
-            <artifactId>byteman-rulecheck-maven-plugin</artifactId>
-            <version>${version.org.jboss.byteman}</version>
-            <executions>
-              <execution>
-                <id>rulecheck</id>
-                <phase>test-compile</phase>
-                <goals>
-                  <goal>rulecheck</goal>
-                </goals>
-                <configuration>
-                  <includes>
-                    <include>**/*.btm</include>
-                  </includes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>j9</id>
-      <activation>
-        <jdk>[1.9,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="append">
-              <forkMode>pertest</forkMode>
-              <childDelegation>true</childDelegation>
-              <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Djdk.attach.allowAttachSelf=true ${jvm.args.modular}</argLine>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-versions</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <requireJavaVersion>
-                      <version>1.9</version>
-                    </requireJavaVersion>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-      <properties>
-        <version.org.jacorb.jacorb>3.7</version.org.jacorb.jacorb>
-        <server.jvm.args>${jvm.args.other} ${jvm.args.byteman} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
-        <version.org.jacorb.jacorb-idl-compiler>3.7</version.org.jacorb.jacorb-idl-compiler>
-      </properties>
-    </profile>
-    <profile>
-      <id>release</id>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-install-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>default-install</id>
-                  <phase>none</phase>
-                </execution>
-              </executions>
             </plugin>
-          </plugins>
-        </pluginManagement>
-        <plugins>
-          <plugin>
-            <artifactId>maven-install-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-install</id>
-                <phase>install</phase>
-              </execution>
-            </executions>
-            <inherited>false</inherited>
-          </plugin>
+            
         </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>codeCoverage</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${version.org.jacoco}</version>
-            <executions>
-              <execution>
-                <id>pre-unit-test</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-                <configuration>
-                  <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-                  <propertyName>surefireArgLine</propertyName>
-                </configuration>
-              </execution>
-              <execution>
-                <id>post-unit-test</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-                <configuration>
-                  <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-                </configuration>
-              </execution>
-              <execution>
-                <id>check</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <configuration>
-                  <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-                  <rules>
-                    <rule>
-                      <element>BUNDLE</element>
-                      <excludes>
-                        <exclude>*Test</exclude>
-                      </excludes>
-                      <limits>
-                        <limit>
-                          <counter>INSTRUCTION</counter>
-                          <value>COVEREDRATIO</value>
-                          <minimum>0.0</minimum>
-                        </limit>
-                      </limits>
-                    </rule>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${surefireArgLine} ${jvm.args.modular} -Djdk.attach.allowAttachSelf=true -Xss2048k</argLine>
-              <systemProperties>
+    </build>
+    <profiles>
+        <profile>
+            <id>byteman-rulecheck</id>
+            <activation>
                 <property>
-                  <name>com.arjuna.ats.arjuna.common.propertiesFile</name>
-                  <value>jbossts-properties.xml</value>
+                    <name>!skipTests</name>
                 </property>
-              </systemProperties>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack-jacoco-agent</id>
-                <phase>test-compile</phase>
-                <goals>
-                  <goal>unpack-dependencies</goal>
-                </goals>
-                <configuration>
-                  <stripVersion>true</stripVersion>
-                  <includeGroupIds>org.jacoco</includeGroupIds>
-                  <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-      <dependencies>
-        <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.agent</artifactId>
-          <version>${version.org.jacoco}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>debug</id>
-      <properties>
-        <jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</jvm.args.debug>
-      </properties>
-    </profile>
-    <profile>
-      <id>community</id>
-      <modules>
-        <module>narayana-full</module>
-      </modules>
-      <properties>
-        <version.tanukisoft>3.2.3</version.tanukisoft>
-        <version.orson>0.5.0</version.orson>
-      </properties>
-    </profile>
-    <profile>
-      <id>findbugs</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
-            <executions>
-              <execution>
-                <id>spotbugs</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <configuration>
-                  <failOnError>false</failOnError>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-site-plugin</artifactId>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.byteman</groupId>
+                        <artifactId>byteman-rulecheck-maven-plugin</artifactId>
+                        <version>${version.org.jboss.byteman}</version>
+                        <executions>
+                            <execution>
+                                <id>rulecheck</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>rulecheck</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>**/*.btm</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>j9</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration combine.self="append">
+                            <forkMode>pertest</forkMode>
+                            <childDelegation>true</childDelegation>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <argLine>-Djdk.attach.allowAttachSelf=true ${jvm.args.modular}</argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>1.9</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <version.org.jacorb.jacorb>3.7</version.org.jacorb.jacorb>
+                <server.jvm.args>${jvm.args.other} ${jvm.args.byteman} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
+                <version.org.jacorb.jacorb-idl-compiler>3.7</version.org.jacorb.jacorb-idl-compiler>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-install-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-install</id>
+                                    <phase>none</phase>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-install</id>
+                                <phase>install</phase>
+                            </execution>
+                        </executions>
+                        <inherited>false</inherited>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>codeCoverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${version.org.jacoco}</version>
+                        <executions>
+                            <execution>
+                                <id>pre-unit-test</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
+                                    <propertyName>surefireArgLine</propertyName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>post-unit-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>check</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <excludes>
+                                                <exclude>*Test</exclude>
+                                            </excludes>
+                                            <limits>
+                                                <limit>
+                                                    <counter>INSTRUCTION</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.0</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${surefireArgLine} ${jvm.args.modular} -Djdk.attach.allowAttachSelf=true -Xss2048k</argLine>
+                            <systemProperties>
+                                <property>
+                                    <name>com.arjuna.ats.arjuna.common.propertiesFile</name>
+                                    <value>jbossts-properties.xml</value>
+                                </property>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-jacoco-agent</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <stripVersion>true</stripVersion>
+                                    <includeGroupIds>org.jacoco</includeGroupIds>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
             <dependencies>
-              <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-decoration-model</artifactId>
-                <version>${version.doxia}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-skin-model</artifactId>
-                <version>${version.doxia}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-integration-tools</artifactId>
-                <version>${version.doxia}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-site-renderer</artifactId>
-                <version>${version.doxia}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-doc-renderer</artifactId>
-                <version>${version.doxia}</version>
-              </dependency>
+                <dependency>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>org.jacoco.agent</artifactId>
+                    <version>${version.org.jacoco}</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
-            <configuration>
-              <reportPlugins>
-                <plugin>
-                  <groupId>com.github.spotbugs</groupId>
-                  <artifactId>spotbugs-maven-plugin</artifactId>
-                  <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
-                </plugin>
-              </reportPlugins>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+        </profile>
+        <profile>
+            <id>debug</id>
+            <properties>
+                <jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</jvm.args.debug>
+            </properties>
+        </profile>
+        <profile>
+            <id>community</id>
+            <modules>
+                <module>narayana-full</module>
+            </modules>
+            <properties>
+                <version.tanukisoft>3.2.3</version.tanukisoft>
+                <version.orson>0.5.0</version.orson>
+            </properties>
+        </profile>
+        <profile>
+            <id>findbugs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>spotbugs</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <failOnError>false</failOnError>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-site-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.maven.doxia</groupId>
+                                <artifactId>doxia-decoration-model</artifactId>
+                                <version>${version.doxia}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.maven.doxia</groupId>
+                                <artifactId>doxia-skin-model</artifactId>
+                                <version>${version.doxia}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.maven.doxia</groupId>
+                                <artifactId>doxia-integration-tools</artifactId>
+                                <version>${version.doxia}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.maven.doxia</groupId>
+                                <artifactId>doxia-site-renderer</artifactId>
+                                <version>${version.doxia}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.maven.doxia</groupId>
+                                <artifactId>doxia-doc-renderer</artifactId>
+                                <version>${version.doxia}</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <reportPlugins>
+                                <plugin>
+                                    <groupId>com.github.spotbugs</groupId>
+                                    <artifactId>spotbugs-maven-plugin</artifactId>
+                                    <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
+                                </plugin>
+                            </reportPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/java-components/pom.xml
+++ b/java-components/pom.xml
@@ -62,6 +62,7 @@
         <gradle-tooling-api.version>8.7</gradle-tooling-api.version>
         <maven-indexer.version>7.1.3</maven-indexer.version>
         <maven-resolver.version>1.9.20</maven-resolver.version>
+        <maven-release.version>3.0.1</maven-release.version>
         <quarkus-jgit.version>3.1.0</quarkus-jgit.version>
         <!-- QuarkusGitHub extension uses same version as GitHubAPI -->
         <github-api.version>1.321</github-api.version>
@@ -193,6 +194,28 @@
                 <version>${cyclonedx-core-java.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven.release</groupId>
+                <artifactId>maven-release-manager</artifactId>
+                <version>${maven-release.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.release</groupId>
+                <artifactId>maven-release-api</artifactId>
+                <version>${maven-release.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.indexer</groupId>
                 <artifactId>indexer-core</artifactId>
                 <version>${maven-indexer.version}</version>
@@ -281,6 +304,20 @@
                 <artifactId>picocli-shell-jline2</artifactId>
                 <version>4.7.6</version>
             </dependency>
+            <dependency>
+                <groupId>org.commonjava.maven.ext</groupId>
+                <artifactId>pom-manipulation-common</artifactId>
+                <version>4.16</version>
+                <!-- As we only want the immediate dependency and some of the transitives cause -->
+                <!-- clashes then exclude everything for simplicity -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-lambda</artifactId>


### PR DESCRIPTION
@stuartwdouglas I noticed when investigating another issue that the MavenPrepareCommand used MavenXpp3Writer to write the poms back. The problem is that doesn't maintain comments (or order). I have tried switching to use the underlying code from the Maven Release Plugin (as it too has to rewrite poms). This is essentially what PME does with some smalls changes (as we're working with just Models and not parsed projects). I'd be open to alternate methods to rewrite the poms if you know of any.