### PR TITLE
Ignore local dependencies for rennovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,11 @@
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^io.github.redhat-appstudio.jvmbuild:"],
+      "matchCurrentValue": "/-SNAPSHOT$/",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Workaround for https://www.github.com/renovatebot/renovate/issues/18117

Aim is to remove the warning:
```
Some dependencies could not be looked up. Check the Dependency Dashboard for more information.
```
on e.g. https://github.com/redhat-appstudio/jvm-build-service/pull/1879 
