### PR TITLE
Add jvm-build-image-secrets to pipeline to avoid using REGISTRY_TOKEN

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - namespace
   - secrets
   - config.yaml
+  - sa.yaml

--- a/deploy/base/sa.yaml
+++ b/deploy/base/sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+  namespace: ${JBS_WORKER_NAMESPACE}
+secrets:
+  - name: jvm-build-image-secrets

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -1181,6 +1181,8 @@ func (r *ReconcileDependencyBuild) createLookupBuildInfoPipeline(ctx context.Con
 		{Name: "GIT_TOKEN", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.GitSecretName}, Key: v1alpha1.GitSecretTokenKey, Optional: &trueBool}}},
 	}
 	if jbsConfig.ImageRegistry().SecretName != "" {
+		// Builds or tooling mostly use the .docker/config.json directly which is updated via Tekton/Kubernetes secrets. But the
+		// Java code may require the token as well.
 		envVars = append(envVars, v1.EnvVar{Name: "REGISTRY_TOKEN", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: jbsConfig.ImageRegistry().SecretName}, Key: v1alpha1.ImageSecretTokenKey, Optional: &secretOptional}}})
 	}
 	return &tektonpipeline.PipelineSpec{

--- a/pkg/reconciler/jbsconfig/jbsconfig.go
+++ b/pkg/reconciler/jbsconfig/jbsconfig.go
@@ -512,6 +512,8 @@ func (r *ReconcilerJBSConfig) cacheDeployment(ctx context.Context, log logr.Logg
 		cache = setEnvVarValue(strconv.FormatBool(imageRegistry.Insecure), "REGISTRY_INSECURE", cache)
 		cache = setEnvVarValue(imageRegistry.PrependTag, "REGISTRY_PREPEND_TAG", cache)
 		if jbsConfig.ImageRegistry().SecretName != "" {
+			// Builds or tooling mostly use the .docker/config.json directly which is updated via Tekton/Kubernetes secrets. But the
+			// Java code may require the token as well.
 			cache = setEnvVar(corev1.EnvVar{
 				Name:      "REGISTRY_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: jbsConfig.ImageRegistry().SecretName}, Key: v1alpha1.ImageSecretTokenKey, Optional: &secretOptional}},


### PR DESCRIPTION
Following up on #1824 

This links to secret to the serviceaccount being used by the pipeline. As the secret is a dockerconfigjson this is then used by Tekton to create a `.docker/config.json`. See https://tekton.dev/docs/pipelines/auth/#configuring-docker-authentication-for-docker 