### PR TITLE
Revert konflux pinning

### DIFF
--- a/.tekton/build-request-processor-pull-request.yaml
+++ b/.tekton/build-request-processor-pull-request.yaml
@@ -22,7 +22,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/build-request-processor-pull-request.yaml
+++ b/.tekton/build-request-processor-pull-request.yaml
@@ -22,7 +22,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/build-request-processor-push.yaml
+++ b/.tekton/build-request-processor-push.yaml
@@ -24,7 +24,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/build-request-processor-push.yaml
+++ b/.tekton/build-request-processor-push.yaml
@@ -24,7 +24,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cache-pull-request.yaml
+++ b/.tekton/cache-pull-request.yaml
@@ -22,7 +22,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cache-pull-request.yaml
+++ b/.tekton/cache-pull-request.yaml
@@ -22,7 +22,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cache-push.yaml
+++ b/.tekton/cache-push.yaml
@@ -24,7 +24,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cache-push.yaml
+++ b/.tekton/cache-push.yaml
@@ -24,7 +24,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cli-pull-request.yaml
+++ b/.tekton/cli-pull-request.yaml
@@ -22,7 +22,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cli-pull-request.yaml
+++ b/.tekton/cli-pull-request.yaml
@@ -22,7 +22,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cli-push.yaml
+++ b/.tekton/cli-push.yaml
@@ -24,7 +24,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/cli-push.yaml
+++ b/.tekton/cli-push.yaml
@@ -24,7 +24,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/controller-pull-request.yaml
+++ b/.tekton/controller-pull-request.yaml
@@ -18,7 +18,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/controller-pull-request.yaml
+++ b/.tekton/controller-pull-request.yaml
@@ -18,7 +18,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -29,7 +29,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:f525e78a0209aca83b63b956291b825b10dc225aedba8cfab91987d3fd6a64ca
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -29,7 +29,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest@sha256:3c01c83d966c90c4b0581704c56780eb6979a4cc23a02ffb037f491f91ad1147
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind


### PR DESCRIPTION
Experimental - see if this avoids the continuous failures I'm seeing.

It looks like when new builds arrive in https://quay.io/repository/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build?tab=history the pinned SHA disappears breaking any CI - this assumes that a new pinned PR has been created and hasn't been merged (e.g. https://github.com/redhat-appstudio/jvm-build-service/pull/1896 ) 

This also might be [CWFHEALTH-3198](https://issues.redhat.com/browse/CWFHEALTH-3198)