### PR TITLE
Fix template substitution

### DIFF
--- a/pkg/reconciler/dependencybuild/scripts/install-package.sh
+++ b/pkg/reconciler/dependencybuild/scripts/install-package.sh
@@ -10,7 +10,7 @@ if [ "rpm" = "{TYPE}" ]; then
 else
     export PATH="$(workspaces.source.path)/packages:${PATH}"
 
-    wget --no-verbose --output-document=$(workspaces.source.path)/packages/{FILENAME} {URL} \
+    wget --no-verbose --output-document=$(workspaces.source.path)/packages/{FILENAME} {URI} \
     && echo "${SHA256} $(workspaces.source.path)/packages/{FILENAME}" | sha256sum --check -
 
     if [ "executable" = "{TYPE}" ]; then


### PR DESCRIPTION
In https://github.com/redhat-appstudio/jvm-build-service/blob/main/pkg/reconciler/dependencybuild/buildrecipeyaml.go#L770 it uses URI not URL

(cc @tecarter94 as I saw that error in your test)