### PR TITLE
Rename workspace and mount paths

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/TagDeployCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/TagDeployCommand.java
@@ -94,6 +94,7 @@ public class TagDeployCommand implements Runnable {
                 if (reuseRepository) {
                     git.initialise(scmUri);
                 } else {
+                    Log.warnf("Not reusing repository; creating under %s", scmUri);
                     git.create(scmUri);
                 }
                 Log.infof("Pushing changes back to URL %s", git.getName());

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/git/Git.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/git/Git.java
@@ -139,7 +139,9 @@ public abstract class Git {
                 // No tag found - might be using a branch; default to commit.
                 tagName = commit;
             }
-            var ref = jGit.checkout().setStartPoint(tagName).setName(tagName + "-jbs-branch").setCreateBranch(true).call();
+            var branchName = tagName + "-jbs-branch";
+            var createBranch = jGit.branchList().call().stream().map(Ref::getName).noneMatch(("refs/heads/" + branchName)::equals);
+            var ref = jGit.checkout().setStartPoint(tagName).setName(branchName).setCreateBranch(createBranch).call();
             StoredConfig jConfig = jRepo.getConfig();
             Log.infof("Updating current origin of %s to %s", jConfig.getString("remote", "origin", "url"),
                     httpTransportUrl);

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -554,18 +554,6 @@ mv $(workspaces.source.path)/workspace/*.sh $(workspaces.source.path)
 					Script: artifactbuild.InstallKeystoreIntoBuildRequestProcessor(preprocessorArgs),
 				},
 				{
-					Name:            "create-pre-build-image",
-					Image:           strings.TrimSpace(strings.Split(buildTrustedArtifacts, "FROM")[1]),
-					ImagePullPolicy: v1.PullIfNotPresent,
-					SecurityContext: &v1.SecurityContext{RunAsUser: &zero},
-					Env:             secretVariables,
-					ComputeResources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultRequestCPU},
-						Limits:   v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultLimitCPU},
-					},
-					Script: preBuildImageArgs,
-				},
-				{
 					Name:            "create-pre-build-source",
 					Image:           buildRequestProcessorImage,
 					ImagePullPolicy: pullPolicy,
@@ -576,6 +564,18 @@ mv $(workspaces.source.path)/workspace/*.sh $(workspaces.source.path)
 						Limits:   v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultLimitCPU},
 					},
 					Script: createKonfluxScripts(kf, konfluxScript) + "\n" + artifactbuild.InstallKeystoreIntoBuildRequestProcessor(konfluxArgs),
+				},
+				{
+					Name:            "create-pre-build-image",
+					Image:           strings.TrimSpace(strings.Split(buildTrustedArtifacts, "FROM")[1]),
+					ImagePullPolicy: v1.PullIfNotPresent,
+					SecurityContext: &v1.SecurityContext{RunAsUser: &zero},
+					Env:             secretVariables,
+					ComputeResources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultRequestCPU},
+						Limits:   v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultLimitCPU},
+					},
+					Script: preBuildImageArgs,
 				},
 			},
 		}

--- a/pkg/reconciler/dependencybuild/scripts/ant-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/ant-build.sh
@@ -26,8 +26,8 @@ cat > ivysettings.xml << EOF
 </ivysettings>
 EOF
 
-if [ ! -d $(workspaces.source.path)/source ]; then
-    cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
+if [ ! -d $(workspaces.source.path)/source-archive ]; then
+    cp -r $(workspaces.source.path)/source $(workspaces.source.path)/source-archive
 fi
 echo "Running $(which ant) with arguments: $@"
 eval "ant $@" | tee $(workspaces.source.path)/logs/ant.log

--- a/pkg/reconciler/dependencybuild/scripts/build-entry.sh
+++ b/pkg/reconciler/dependencybuild/scripts/build-entry.sh
@@ -3,7 +3,7 @@ set -o verbose
 set -eu
 set -o pipefail
 
-cd $(workspaces.source.path)/workspace
+cd $(workspaces.source.path)/source
 
 if [ -n "$(params.CONTEXT_DIR)" ]
 then

--- a/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/gradle-build.sh
@@ -4,8 +4,8 @@ mkdir -p "${GRADLE_USER_HOME}"
 mkdir -p "${HOME}/.m2/repository"
 
 #copy back the gradle folder for hermetic
-cp -r $(workspaces.source.path)/source/maven-artifacts/.gradle/* "$GRADLE_USER_HOME/" || true
-cp -r $(workspaces.source.path)/source/maven-artifacts/* "$HOME/.m2/repository/" || true
+cp -r $(workspaces.source.path)/maven-artifacts/.gradle/* "$GRADLE_USER_HOME/" || true
+cp -r $(workspaces.source.path)/maven-artifacts/* "$HOME/.m2/repository/" || true
 
 cat > "${GRADLE_USER_HOME}"/gradle.properties << EOF
 org.gradle.console=plain
@@ -63,8 +63,8 @@ export LC_ALL="en_US.UTF-8"
 rm -f gradle/verification-metadata.xml
 
 echo "Running Gradle command with arguments: $@"
-if [ ! -d $(workspaces.source.path)/source ]; then
-  cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
+if [ ! -d $(workspaces.source.path)/source-archive ]; then
+    cp -r $(workspaces.source.path)/source $(workspaces.source.path)/source-archive
 fi
 gradle -Dmaven.repo.local=$(workspaces.source.path)/artifacts --info --stacktrace "$@" | tee $(workspaces.source.path)/logs/gradle.log
 

--- a/pkg/reconciler/dependencybuild/scripts/hermetic-entry.sh
+++ b/pkg/reconciler/dependencybuild/scripts/hermetic-entry.sh
@@ -3,5 +3,5 @@ set -o verbose
 set -eu
 set -o pipefail
 
-TASK="ip link set dev lo up && /workspace/source/build.sh $@"
+TASK="ip link set dev lo up && /var/workdir/build.sh $@"
 unshare -n -Ufp -r --  sh -c "$TASK"

--- a/pkg/reconciler/dependencybuild/scripts/maven-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/maven-build.sh
@@ -2,7 +2,7 @@
 
 mkdir -p "${HOME}/.m2/repository"
 #copy back the maven folder for hermetic
-cp -r $(workspaces.source.path)/source/maven-artifacts/* "$HOME/.m2/repository/" || true
+cp -r $(workspaces.source.path)/maven-artifacts/* "$HOME/.m2/repository/" || true
 
 echo "MAVEN_HOME=${MAVEN_HOME}"
 
@@ -54,8 +54,8 @@ export MAVEN_OPTS="-XX:+CrashOnOutOfMemoryError"
 
 echo "Running Maven command with arguments: $@"
 
-if [ ! -d $(workspaces.source.path)/source ]; then
-  cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
+if [ ! -d $(workspaces.source.path)/source-archive ]; then
+    cp -r $(workspaces.source.path)/source $(workspaces.source.path)/source-archive
 fi
 #we can't use array parameters directly here
 #we pass them in as goals

--- a/pkg/reconciler/dependencybuild/scripts/sbt-build.sh
+++ b/pkg/reconciler/dependencybuild/scripts/sbt-build.sh
@@ -38,8 +38,8 @@ fi
 
 
 
-if [ ! -d $(workspaces.source.path)/source ]; then
-    cp -r $(workspaces.source.path)/workspace $(workspaces.source.path)/source
+if [ ! -d $(workspaces.source.path)/source-archive ]; then
+    cp -r $(workspaces.source.path)/source $(workspaces.source.path)/source-archive
 fi
 echo "Running SBT command with arguments: $@"
 


### PR DESCRIPTION
This is meant to change our layout to be closer to the Konflux standard (which bases sources in `$(workspaces.source.path)/source` and stores the git repository in the oci artifact in the root directory not in a subdirectory.

