### PR TITLE
Minikube CI and development changes

### DIFF
--- a/.github/workflows/minikube.yaml
+++ b/.github/workflows/minikube.yaml
@@ -68,6 +68,8 @@ jobs:
           export DEV_IP=172.16.1.1
           export JBS_WORKER_NAMESPACE=jvm-build-service-test-namespace-$(shuf -er -n5 {a..z} {0..9} | tr -d '\n')
 
+          echo "Using worker namespace $JBS_WORKER_NAMESPACE and DEV_IP $DEV_IP"
+
           eval $(minikube -p minikube docker-env)
 
           docker pull quay.io/redhat-user-workloads/konflux-jbs-pnc-tenant/jvm-build-service/build-request-processor:on-pr-${{ github.event.pull_request.head.sha }}
@@ -78,6 +80,7 @@ jobs:
           docker tag quay.io/redhat-user-workloads/konflux-jbs-pnc-tenant/jvm-build-service/controller:on-pr-${{ github.event.pull_request.head.sha }} quay.io/minikube/hacbs-jvm-controller:dev
 
           export ABTESTSET=${{ matrix.abtestsets }}
+          echo "Using ABTESTSET $ABTESTSET"
 
           ./deploy/minikube-ci.sh
           make minikube-test
@@ -126,6 +129,8 @@ jobs:
           export DEV_IP=172.16.1.1
           export JBS_WORKER_NAMESPACE=jvm-build-service-test-namespace-$(shuf -er -n5 {a..z} {0..9} | tr -d '\n')
 
+          echo "Using worker namespace $JBS_WORKER_NAMESPACE and DEV_IP $DEV_IP"
+
           eval $(minikube -p minikube docker-env)
 
           docker pull quay.io/redhat-user-workloads/konflux-jbs-pnc-tenant/jvm-build-service/build-request-processor:on-pr-${{ github.event.pull_request.head.sha }}
@@ -136,6 +141,7 @@ jobs:
           docker tag quay.io/redhat-user-workloads/konflux-jbs-pnc-tenant/jvm-build-service/controller:on-pr-${{ github.event.pull_request.head.sha }} quay.io/minikube/hacbs-jvm-controller:dev
 
           export DBTESTSET=${{ matrix.dbtestsets }}
+          echo "Using DBTESTSET $DBTESTSET"
 
           ./deploy/minikube-ci.sh
           make minikube-test

--- a/README.adoc
+++ b/README.adoc
@@ -40,8 +40,8 @@ The following environment variables are configurable and may be set by the user 
 | JBS_GIT_CREDENTIALS | Support for private repositories (See below)
 | JBS_MAX_MEMORY | Maximum additional memory allowed
 | JBS_RECIPE_DATABASE | Recipe database to use (defaults to `https://github.com/redhat-appstudio/jvm-build-data`)
-| JBS_S3_SYNC_ENABLED | Whether to enable Amazon S3 sync for storage
-| JBS_WORKER_NAMESPACE | Default 'worker' namespace (`test-jvm-namespace`) may be customised by setting this
+| JBS_S3_SYNC_ENABLED | Whether to enable Amazon S3 sync for storage (default: `false`)
+| JBS_WORKER_NAMESPACE | Worker namespace (default: `test-jvm-namespace`) may be customised by setting this
 | MAVEN_PASSWORD | Password for the Maven repository
 | MAVEN_REPOSITORY | The URL for the external Maven repository to deploy to
 | MAVEN_USERNAME | Username for the Maven repository

--- a/deploy/minikube-ci.sh
+++ b/deploy/minikube-ci.sh
@@ -1,90 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=`dirname $0`
-kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.59.2/release.yaml
-timeout=600 #10 minutes in seconds
-endTime=$(( $(date +%s) + timeout ))
 
-while ! oc get pods -n tekton-pipelines | grep tekton-pipelines-controller | grep "1/1"; do
-    sleep 1
-    if [ $(date +%s) -gt $endTime ]; then
-        exit 1
-    fi
-done
-while ! oc get pods -n tekton-pipelines | grep tekton-pipelines-webhook | grep "1/1"; do
-    sleep 1
-    if [ $(date +%s) -gt $endTime ]; then
-        exit 1
-    fi
-done
-#we need to make sure the tekton webhook has its rules installed
-kubectl wait --for=jsonpath='{.webhooks[0].rules}' --timeout=300s mutatingwebhookconfigurations.admissionregistration.k8s.io webhook.pipeline.tekton.dev
-echo "Tekton controller is running"
-
-#CRDS are sometimes racey
-kubectl apply -k $DIR/crds/base
-## Up to commit https://github.com/openshift/api/commit/60b796dbf3a2d90b6960bb04585a9f9289b0ca1f the flie has been changed, renamed and finally moved
-## kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/quota/v1/zz_generated.crd-manifests/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
-sleep 2
-
-kubectl delete --ignore-not-found deployments.apps hacbs-jvm-operator -n jvm-build-service
-kubectl delete --ignore-not-found deployments.apps jvm-build-workspace-artifact-cache
-
-echo "Using QUAY_USERNAME: $QUAY_USERNAME"
-echo "Using JBS_WORKER_NAMESPACE: $JBS_WORKER_NAMESPACE"
-export JBS_QUAY_IMAGE=$QUAY_USERNAME
-export JVM_BUILD_SERVICE_IMAGE=quay.io/$QUAY_USERNAME/hacbs-jvm-controller
-# Represents an empty dockerconfig.json
-if [ -z "$JBS_BUILD_IMAGE_SECRET" ]; then
-    export JBS_BUILD_IMAGE_SECRET="ewogICAgImF1dGhzIjogewogICAgfQp9Cg==" # notsecret
+# DEV_IP is only set in .github/workflows/minikube.yaml and only used in CI
+if [ -n "$DEV_IP" ]; then
+    echo "Altering templates to never pull images"
+    #huge hack to deal with minikube local images, make sure they are never pulled
+    find $DIR -path \*dev-template\*.yaml -exec sed -i s/Always/Never/ {} \;
 fi
-export JBS_S3_SYNC_ENABLED="\"false\""
-export JBS_CONTAINER_BUILDS=false
-export JBS_MAX_MEMORY=4096
 
-cat $DIR/base/namespace/namespace.yaml | envsubst '${JBS_WORKER_NAMESPACE}' | kubectl apply -f -
-kubectl config set-context --current --namespace=${JBS_WORKER_NAMESPACE}
-
-#huge hack to deal with minikube local images, make sure they are never pulled
-find $DIR -path \*dev-template\*.yaml -exec sed -i s/Always/Never/ {} \;
-
-kustomize build $DIR/overlays/dev-template | envsubst '
-${AWS_ACCESS_KEY_ID}
-${AWS_PROFILE}
-${AWS_SECRET_ACCESS_KEY}
-${GIT_DEPLOY_IDENTITY}
-${GIT_DEPLOY_TOKEN}
-${GIT_DEPLOY_URL}
-${GIT_DISABLE_SSL_VERIFICATION}
-${JBS_BUILD_IMAGE_SECRET}
-${JBS_CONTAINER_BUILDS}
-${JBS_GIT_CREDENTIALS}
-${JBS_QUAY_IMAGE}
-${JBS_MAX_MEMORY}
-${JBS_RECIPE_DATABASE}
-${JBS_S3_SYNC_ENABLED}
-${JBS_WORKER_NAMESPACE}
-${MAVEN_PASSWORD}
-${MAVEN_REPOSITORY}
-${MAVEN_USERNAME}
-${QUAY_USERNAME}' \
-    | kubectl apply -f -
-
-echo "Completed overlays"
-#this tells JBS we are in test mode and won't have a secure registry
-kubectl annotate --overwrite jbsconfigs.jvmbuildservice.io --all jvmbuildservice.io/test-registry=true
+$DIR/minikube-development.sh --clean
 
 # Deleting the jvm-build-config as its created with different settings in util.go::setupMinikube
 kubectl delete --ignore-not-found=true jbsconfigs.jvmbuildservice.io jvm-build-config
-# Following are created in code
-kubectl delete --ignore-not-found=true tasks.tekton.dev git-clone
-kubectl delete --ignore-not-found=true tasks.tekton.dev maven
-kubectl delete --ignore-not-found=true pipelines.tekton.dev sample-component-build
-kubectl delete --ignore-not-found=true clusterrolebindings.rbac.authorization.k8s.io pipeline-test-jvm-namespace
-kubectl delete --ignore-not-found=true artifactbuilds.jvmbuildservice.io --all
 
-cat $DIR/minikube-rbac.yaml | envsubst '${JBS_WORKER_NAMESPACE}' | kubectl apply -f -
-
-#revert hack above to avoid edits in place
-find $DIR -path \*dev-template\*.yaml -exec sed -i s/Never/Always/ {} \;
+# Revert hack above to avoid edits in place
+if [ -n "$DEV_IP" ]; then
+    find $DIR -path \*dev-template\*.yaml -exec sed -i s/Never/Always/ {} \;
+fi

--- a/deploy/minikube-development.sh
+++ b/deploy/minikube-development.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=`dirname $0`
 kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.59.2/release.yaml
@@ -24,25 +24,27 @@ echo -e "\033[0;32mTekton controller is running\033[0m"
 
 #CRDS are sometimes racey
 kubectl apply -k $DIR/crds/base
+# TODO: Don't think this below CRD is needed.
 #Load missing CRD
-kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.69.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+#kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.69.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ## Up to commit https://github.com/openshift/api/commit/60b796dbf3a2d90b6960bb04585a9f9289b0ca1f the flie has been changed, renamed and finally moved
 ## kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
 kubectl apply -f https://raw.githubusercontent.com/openshift/api/master/quota/v1/zz_generated.crd-manifests/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
 sleep 2
 
-$DIR/base-development.sh  $1
+$DIR/base-development.sh $1
 
 # base-development.sh switches to the test-jvm-namespace namespace
-kubectl create --dry-run=client -o=yaml sa pipeline | kubectl apply -f -
 if [ -z "$JBS_WORKER_NAMESPACE" ]; then
     export JBS_WORKER_NAMESPACE=test-jvm-namespace
 fi
 cat $DIR/minikube-rbac.yaml | envsubst '${JBS_WORKER_NAMESPACE}' | kubectl apply -f -
 
+# TODO: Unknown if we still need these.
 #minikube cannot access registry.redhat.io by default
 #you need to have these credentials in your docker config
-kubectl create --dry-run=client -o=yaml secret docker-registry minikube-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json | kubectl apply -f -
-kubectl patch serviceaccount pipeline -p '{"imagePullSecrets": [{"name": "minikube-pull-secret"}]}'
-kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "minikube-pull-secret"}]}'
-kubectl patch --type=merge jbsconfigs.jvmbuildservice.io jvm-build-config -p '{"spec":{"cacheSettings":{"disableTLS": true}}}'
+#kubectl create --dry-run=client -o=yaml secret docker-registry minikube-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json | kubectl apply -f -
+#kubectl patch serviceaccount pipeline -p '{"imagePullSecrets": [{"name": "minikube-pull-secret"}]}'
+#kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "minikube-pull-secret"}]}'
+#kubectl patch --type=merge jbsconfigs.jvmbuildservice.io jvm-build-config -p '{"spec":{"cacheSettings":{"disableTLS": true}}}'
+

--- a/deploy/minikube-images.sh
+++ b/deploy/minikube-images.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=`dirname $0`/..
 eval $(minikube -p minikube docker-env)

--- a/deploy/openshift-ci.sh
+++ b/deploy/openshift-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This is referenced by:
 # https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/jvm-build-service/redhat-appstudio-jvm-build-service-main.yaml

--- a/deploy/openshift-development.sh
+++ b/deploy/openshift-development.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=`dirname $0`
 $DIR/base-development.sh $1


### PR DESCRIPTION
These changes follow on from #2066 and #2067 in order to make it easier for developers to run the minikube CI tests locally. 
In this PR I've vastly simplified the `minikube-ci.sh` script so it mostly completely relies upon the `minikube-development.sh` script but also passes the `--clean` option which in `base-development.sh` will clean out old runs. This allows local users to reuse it. All defaults have been moved to `base-development.sh` which makes long term maintenance simpler. All scripts now use `/bin/bash` as on GHActions `/bin/sh` links to dash giving unexpected side-affects.

**NOTE** : I have set JBS_S3_SYNC_ENABLED to default to false in this PR.

While there are still two `TODO` given its unclear if those CRD or secrets are actually needed for minikube development I've left them commented out for now so this could be potentially revisited in future.