### PR TITLE
Add maven deployment task

### DIFF
--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -57,7 +57,6 @@ spec:
         AARCHIVE=$(oras manifest fetch $ORAS_OPTIONS $URL@$DIGEST | jq --raw-output '.layers[0].digest')
         echo "URL $URL DIGEST $DIGEST AARCHIVE $AARCHIVE"
         use-archive oci:$URL@$AARCHIVE=/var/workdir/artifacts
-        ls -lR /var/workdir
       env:
         - name: ORAS_OPTIONS
           value: $(params.ORAS_OPTIONS)
@@ -77,8 +76,6 @@ spec:
           cpu: 50m
           memory: 512Mi
       env:
-#        - name: MAVEN_OPTS
-#          value: "-Dmaven.wagon.http.ssl.insecure=true"
         - name: MVN_REPO
           value: $(params.MVN_REPO)
         - name: MVN_USERNAME
@@ -88,8 +85,6 @@ spec:
             secretKeyRef:
               name: $(params.MVN_PASSWORD)
               key: mavenpassword
-#        - name: SSL_CERT_DIR
-#          value: /tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs
       args:
         - deploy
         - --directory=/var/workdir/artifacts

--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -13,18 +13,11 @@ spec:
   description: |-
     Takes a OCI archive and deploys the result
   params:
-    - name: ORAS_OPTIONS
-      type: string
-      description: Optional environment variable string for build-trusted-artifacts
-      default: ""
     - name: IMAGE_URL
       description: Reference to the OCI archive
       type: string
     - name: IMAGE_DIGEST
       description: Digest to use
-      type: string
-    - name: PRE_BUILD_IMAGE_DIGEST
-      description: PreBuilddDigest to use
       type: string
     - name: MVN_REPO
       description: Maven repository to deploy to
@@ -35,6 +28,14 @@ spec:
     - name: MVN_PASSWORD
       description: Name of the secret holding the Maven repository password
       type: string
+    - name: ORAS_OPTIONS
+      type: string
+      description: Optional environment variable string for build-trusted-artifacts
+      default: ""
+    - name: JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE
+      description: Name of the processor image. Useful to override for development.
+      type: string
+      default: "quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:dev"
   volumes:
     - name: shared
       emptyDir: {}
@@ -50,9 +51,7 @@ spec:
     - name: restore-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:d6f57d97d19008437680190908fe5444cda380f9c77d0e9efde7153720412e05
       script: |
-        set -x
-        echo "Restoring artifacts and source to workspace"
-        use-archive $PRE_BUILD_IMAGE_DIGEST=/var/workdir/source
+        echo "Restoring artifacts to workspace"
         URL=$IMAGE_URL
         DIGEST=$IMAGE_DIGEST
         AARCHIVE=$(oras manifest fetch $ORAS_OPTIONS $URL@$DIGEST | jq --raw-output '.layers[0].digest')
@@ -66,10 +65,8 @@ spec:
           value: $(params.IMAGE_DIGEST)
         - name: IMAGE_URL
           value: $(params.IMAGE_URL)
-        - name: PRE_BUILD_IMAGE_DIGEST
-          value: $(params.PRE_BUILD_IMAGE_DIGEST)
     - name: deploy
-      image: quay.io/ncross/hacbs-jvm-build-request-processor:dev
+      image: $(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE)
       securityContext:
         runAsUser: 0
       computeResources:
@@ -80,8 +77,8 @@ spec:
           cpu: 50m
           memory: 512Mi
       env:
-        - name: MAVEN_OPTS
-          value: "-Dmaven.wagon.http.ssl.insecure=true"
+#        - name: MAVEN_OPTS
+#          value: "-Dmaven.wagon.http.ssl.insecure=true"
         - name: MVN_REPO
           value: $(params.MVN_REPO)
         - name: MVN_USERNAME
@@ -91,8 +88,8 @@ spec:
             secretKeyRef:
               name: $(params.MVN_PASSWORD)
               key: mavenpassword
-        - name: SSL_CERT_DIR
-          value: /tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs
+#        - name: SSL_CERT_DIR
+#          value: /tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs
       args:
         - deploy
         - --directory=/var/workdir/artifacts

--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: maven-deployment
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+spec:
+  description: |-
+    Takes a OCI archive and deploys the result
+  params:
+    - name: ORAS_OPTIONS
+      type: string
+      description: Optional environment variable string for build-trusted-artifacts
+      default: ""
+    - name: IMAGE_URL
+      description: Reference to the OCI archive
+      type: string
+    - name: IMAGE_DIGEST
+      description: Digest to use
+      type: string
+    - name: PRE_BUILD_IMAGE_DIGEST
+      description: PreBuilddDigest to use
+      type: string
+    - name: MVN_REPO
+      description: Maven repository to deploy to
+      type: string
+    - name: MVN_USERNAME
+      description: Maven repository username
+      type: string
+    - name: MVN_PASSWORD
+      description: Name of the secret holding the Maven repository password
+      type: string
+  volumes:
+    - name: shared
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: restore-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:d6f57d97d19008437680190908fe5444cda380f9c77d0e9efde7153720412e05
+      script: |
+        set -x
+        echo "Restoring artifacts and source to workspace"
+        use-archive $PRE_BUILD_IMAGE_DIGEST=/var/workdir/source
+        URL=$IMAGE_URL
+        DIGEST=$IMAGE_DIGEST
+        AARCHIVE=$(oras manifest fetch $ORAS_OPTIONS $URL@$DIGEST | jq --raw-output '.layers[0].digest')
+        echo "URL $URL DIGEST $DIGEST AARCHIVE $AARCHIVE"
+        use-archive oci:$URL@$AARCHIVE=/var/workdir/artifacts
+        ls -lR /var/workdir
+      env:
+        - name: ORAS_OPTIONS
+          value: $(params.ORAS_OPTIONS)
+        - name: IMAGE_DIGEST
+          value: $(params.IMAGE_DIGEST)
+        - name: IMAGE_URL
+          value: $(params.IMAGE_URL)
+        - name: PRE_BUILD_IMAGE_DIGEST
+          value: $(params.PRE_BUILD_IMAGE_DIGEST)
+    - name: deploy
+      image: quay.io/ncross/hacbs-jvm-build-request-processor:dev
+      securityContext:
+        runAsUser: 0
+      computeResources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: 50m
+          memory: 512Mi
+      env:
+        - name: MAVEN_OPTS
+          value: "-Dmaven.wagon.http.ssl.insecure=true"
+        - name: MVN_REPO
+          value: $(params.MVN_REPO)
+        - name: MVN_USERNAME
+          value: $(params.MVN_USERNAME)
+        - name: MAVEN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.MVN_PASSWORD)
+              key: mavenpassword
+        - name: SSL_CERT_DIR
+          value: /tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs
+      args:
+        - deploy
+        - --directory=/var/workdir/artifacts
+        - --mvn-repo=$(params.MVN_REPO)
+        - --mvn-username=$(params.MVN_USERNAME)

--- a/pkg/apis/jvmbuildservice/v1alpha1/jbsconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/jbsconfig_types.go
@@ -33,7 +33,8 @@ const (
 	ConfigArtifactCacheWorkerThreadsDefault = "50"
 	ConfigArtifactCacheStorageDefault       = "10Gi"
 
-	KonfluxBuildDefinitions = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/buildah-oci-ta.yaml"
+	KonfluxBuildDefinitions       = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/buildah-oci-ta.yaml"
+	KonfluxMavenDeployDefinitions = "https://raw.githubusercontent.com/rnc/jvm-build-service/KJB11/deploy/tasks/maven-deployment.yaml"
 )
 
 type JBSConfigSpec struct {

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -61,88 +61,85 @@ var buildEntryScript string
 var buildTrustedArtifacts string
 
 func createDeployPipelineSpec(jbsConfig *v1alpha1.JBSConfig, buildRequestProcessorImage string, gavs string) (*tektonpipeline.PipelineSpec, error) {
-	zero := int64(0)
-	mavenDeployArgs := pipelineDeployCommands(jbsConfig)
-
-	limits, err := memoryLimits(jbsConfig, 0)
-	if err != nil {
-		return nil, err
-	}
 	orasOptions := ""
 	if jbsConfig.Annotations != nil && jbsConfig.Annotations[jbsconfig.TestRegistry] == "true" {
 		orasOptions = "--insecure --plain-http"
 	}
 
-	secretVariables := secretVariables(jbsConfig)
-	pullPolicy := pullPolicy(buildRequestProcessorImage)
-	regUrl := registryArgsWithDefaults(jbsConfig, "")
-
-	tagTask := tektonpipeline.TaskSpec{
-		Workspaces: []tektonpipeline.WorkspaceDeclaration{{Name: WorkspaceTls}, {Name: WorkspaceSource, MountPath: WorkspaceMount}},
-		Params: []tektonpipeline.ParamSpec{
-			{Name: PipelineResultPreBuildImageDigest, Type: tektonpipeline.ParamTypeString},
-			{Name: PipelineResultImageDigest, Type: tektonpipeline.ParamTypeString},
-			{Name: PipelineResultImage, Type: tektonpipeline.ParamTypeString}},
-		Steps: []tektonpipeline.Step{
+	resolver := tektonpipeline.ResolverRef{
+		// We can use either a http or git resolver. Using http as avoids cloning an entire repository.
+		Resolver: "http",
+		Params: []tektonpipeline.Param{
 			{
-				Name:            "restore-post-build-artifacts",
-				Image:           strings.TrimSpace(strings.Split(buildTrustedArtifacts, "FROM")[1]),
-				ImagePullPolicy: v1.PullIfNotPresent,
-				SecurityContext: &v1.SecurityContext{RunAsUser: &zero},
-				Env:             secretVariables,
-				// While the manifest digest is available we need the manifest of the layer within
-				// the archive hence using 'oras manifest fetch' to extract the correct layer.
-				Script: fmt.Sprintf(`echo "Restoring artifacts and source to workspace"
-export ORAS_OPTIONS="%s"
-use-archive $(params.%s)=$(workspaces.source.path)/source
-mv $(workspaces.source.path)/source/.jbs/build.sh $(workspaces.source.path)
-URL=$(params.%s)
-DIGEST=$(params.%s)
-AARCHIVE=$(oras manifest fetch $ORAS_OPTIONS $URL@$DIGEST | jq --raw-output '.layers[0].digest')
-echo "URL $URL DIGEST $DIGEST AARCHIVE $AARCHIVE"
-use-archive oci:$URL@$AARCHIVE=$(workspaces.source.path)/artifacts`, orasOptions, PipelineResultPreBuildImageDigest, PipelineResultImage, PipelineResultImageDigest),
-			},
-			{
-				Name:            "maven-deployment",
-				Image:           buildRequestProcessorImage,
-				ImagePullPolicy: pullPolicy,
-				SecurityContext: &v1.SecurityContext{RunAsUser: &zero},
-				Env:             secretVariables,
-				ComputeResources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultRequestCPU},
-					Limits:   v1.ResourceList{"memory": limits.defaultBuildRequestMemory, "cpu": limits.defaultLimitCPU},
+				Name: "url",
+				Value: tektonpipeline.ParamValue{
+					Type:      tektonpipeline.ParamTypeString,
+					StringVal: v1alpha1.KonfluxMavenDeployDefinitions,
 				},
-				Script: artifactbuild.InstallKeystoreIntoBuildRequestProcessor(mavenDeployArgs),
-			},
-			{
-				Name:            "oras-tag",
-				Image:           strings.TrimSpace(strings.Split(buildTrustedArtifacts, "FROM")[1]),
-				ImagePullPolicy: v1.PullIfNotPresent,
-				SecurityContext: &v1.SecurityContext{RunAsUser: &zero},
-				Env:             secretVariables,
-				// gavs is a comma separated list so split it into spaces
-				Script: fmt.Sprintf(`GAVS=%s
-echo "Tagging for GAVs ($GAVS)"
-oras tag %s --verbose %s@$(params.%s) ${GAVS//,/ }`, gavs, orasOptions, regUrl, PipelineResultImageDigest),
 			},
 		},
 	}
-
 	ps := &tektonpipeline.PipelineSpec{
 		Params: []tektonpipeline.ParamSpec{{Name: PipelineResultImageDigest, Type: tektonpipeline.ParamTypeString}},
 		Tasks: []tektonpipeline.PipelineTask{
 			{
 				Name: TagTaskName,
-				TaskSpec: &tektonpipeline.EmbeddedTask{
-					TaskSpec: tagTask,
+				TaskRef: &tektonpipeline.TaskRef{
+					// Can't specify name and resolver as they clash.
+					ResolverRef: resolver,
 				},
 				Params: []tektonpipeline.Param{
-					{Name: PipelineResultImage, Value: tektonpipeline.ParamValue{Type: tektonpipeline.ParamTypeString, StringVal: "$(params." + PipelineResultImage + ")"}},
-					{Name: PipelineResultImageDigest, Value: tektonpipeline.ParamValue{Type: tektonpipeline.ParamTypeString, StringVal: "$(params." + PipelineResultImageDigest + ")"}},
-					{Name: PipelineResultPreBuildImageDigest, Value: tektonpipeline.ParamValue{Type: tektonpipeline.ParamTypeString, StringVal: "$(params." + PipelineResultPreBuildImageDigest + ")"}},
+					{
+						Name: PipelineResultImage,
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: "$(params." + PipelineResultImage + ")",
+						},
+					},
+					{
+						Name: PipelineResultImageDigest,
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: "$(params." + PipelineResultImageDigest + ")",
+						},
+					},
+					{
+						Name: "MVN_REPO",
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: jbsConfig.Spec.MavenDeployment.Repository,
+						},
+					},
+					{
+						Name: "MVN_USERNAME",
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: jbsConfig.Spec.MavenDeployment.Username,
+						},
+					},
+					{
+						Name: "MVN_PASSWORD",
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: v1alpha1.MavenSecretKey,
+						},
+					},
+					{
+						Name: "ORAS_OPTIONS",
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: orasOptions,
+						},
+					},
+					{
+						Name: "JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE",
+						Value: tektonpipeline.ParamValue{
+							Type:      tektonpipeline.ParamTypeString,
+							StringVal: buildRequestProcessorImage,
+						},
+					},
 				},
 				Workspaces: []tektonpipeline.WorkspacePipelineTaskBinding{
-					{Name: WorkspaceTls, Workspace: WorkspaceTls},
 					{Name: WorkspaceSource, Workspace: WorkspaceSource},
 				},
 			},
@@ -932,25 +929,6 @@ func registryArgsWithDefaults(jbsConfig *v1alpha1.JBSConfig, preBuildImageTag st
 		registryArgs.WriteString(prependTagToImage(preBuildImageTag, imageRegistry.PrependTag))
 	}
 	return registryArgs.String()
-}
-
-func pipelineDeployCommands(jbsConfig *v1alpha1.JBSConfig) []string {
-
-	deployArgs := []string{
-		"deploy",
-		"--directory=$(workspaces.source.path)/artifacts",
-	}
-
-	mavenArgs := make([]string, 0)
-	if jbsConfig.Spec.MavenDeployment.Repository != "" {
-		mavenArgs = append(mavenArgs, "--mvn-repo="+jbsConfig.Spec.MavenDeployment.Repository)
-	}
-	if jbsConfig.Spec.MavenDeployment.Username != "" {
-		mavenArgs = append(mavenArgs, "--mvn-username="+jbsConfig.Spec.MavenDeployment.Username)
-	}
-	deployArgs = append(deployArgs, mavenArgs...)
-
-	return deployArgs
 }
 
 func gitArgs(jbsConfig *v1alpha1.JBSConfig, db *v1alpha1.DependencyBuild) []string {

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -1367,6 +1367,7 @@ func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db 
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	fmt.Printf("### buildRequestProcessorImage %#v \n", buildRequestProcessorImage)
 	pr.Namespace = db.Namespace
 	pr.Name = prName
 	pr.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: db.Name, artifactbuild.PipelineRunLabel: "", PipelineTypeLabel: PipelineTypeDeploy}

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -2,8 +2,6 @@ package dependencybuild
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
@@ -1367,7 +1365,6 @@ func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db 
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	fmt.Printf("### buildRequestProcessorImage %#v \n", buildRequestProcessorImage)
 	pr.Namespace = db.Namespace
 	pr.Name = prName
 	pr.Labels = map[string]string{artifactbuild.DependencyBuildIdLabel: db.Name, artifactbuild.PipelineRunLabel: "", PipelineTypeLabel: PipelineTypeDeploy}
@@ -1383,18 +1380,6 @@ func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db 
 		return reconcile.Result{}, err
 	}
 	attempt := db.Status.BuildAttempts[len(db.Status.BuildAttempts)-1]
-	gavs := ""
-	shaCalc := sha256.New()
-	imageRegistry := jbsConfig.ImageRegistry()
-	for i := range attempt.Build.Results.Gavs {
-		if i != 0 {
-			gavs += ","
-		}
-		// Same as DigestUtils.sha256Hex(String.format(GAV_FORMAT, groupId, artifactId, version))
-		shaCalc.Reset()
-		shaCalc.Write([]byte(attempt.Build.Results.Gavs[i]))
-		gavs += prependTagToImage(hex.EncodeToString(shaCalc.Sum(nil)), imageRegistry.PrependTag)
-	}
 
 	paramValues := []tektonpipeline.Param{
 		{Name: PipelineResultImage, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: attempt.Build.Results.Image}},
@@ -1412,7 +1397,7 @@ func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db 
 		Pipeline: &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 		Tasks:    &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 	}
-	pr.Spec.PipelineSpec, err = createDeployPipelineSpec(jbsConfig, buildRequestProcessorImage, gavs)
+	pr.Spec.PipelineSpec, err = createDeployPipelineSpec(jbsConfig, buildRequestProcessorImage)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
This provides an independent maven deployment task (to run after build) and has also been integrated into JBS.
This also removes the 'tag' task which used to tag the images in quay.io with the sha of the GAVs.