### PR TITLE
Inline Containerfile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ dev-image:
             echo "ERROR: QUAY_USERNAME is not set"; \
             exit 1; \
     fi
-	docker build . -t quay.io/$(QUAY_USERNAME)/hacbs-jvm-controller:dev
-	docker push quay.io/$(QUAY_USERNAME)/hacbs-jvm-controller:dev
+	docker build . -t quay.io/$(QUAY_USERNAME)/hacbs-jvm-controller:"$${JBS_QUAY_IMAGE_TAG:-dev}"
+	docker push quay.io/$(QUAY_USERNAME)/hacbs-jvm-controller:"$${JBS_QUAY_IMAGE_TAG:-dev}"
 
 dev: dev-image
 	cd java-components && mvn clean install -Dlocal -DskipTests -Ddev

--- a/deploy/tasks/pre-build.yaml
+++ b/deploy/tasks/pre-build.yaml
@@ -46,10 +46,13 @@ spec:
       type: string
     - name: RECIPE_IMAGE
       description: The image from the build recipe to use
+    - name: BUILD_TOOL
+      description: The build tool to use.
+    - name: BUILD_PLUGINS
+      description: Comma separated list of build plugins that should be disabled.
+      default: ""
     - name: BUILD_SCRIPT
       description: The build script to embed with the Containerfile
-    - name: PREPROCESSOR_ARGS
-      description: The arguments for the build preprocessor
     - name: ORAS_OPTIONS
       type: string
       description: Optional environment variable string for build-trusted-artifacts
@@ -103,7 +106,7 @@ spec:
           memory: 512Mi
       script: |
         $(params.BUILD_SCRIPT)
-        /opt/jboss/container/java/run/run-java.sh $(params.PREPROCESSOR_ARGS)
+        /opt/jboss/container/java/run/run-java.sh $(params.BUILD_TOOL)-prepare $(workspaces.source.path)/source --recipe-image=$(params.RECIPE_IMAGE) --request-processor-image=$(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE) --disabled-plugins=$(params.BUILD_PLUGINS)
     - name: create-pre-build-source
       image: $(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE)
       securityContext:

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
@@ -1,14 +1,16 @@
 package com.redhat.hacbs.container.build.preprocessor;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
+import io.quarkus.logging.Log;
 import picocli.CommandLine;
 
 /**
- * We keep all the options the same between maven and gradle for now,
- * to keep the pipeline setup simpler.
- *
+ * We keep all the options the same between maven, gradle, sbt and ant for now to keep the pipeline setup simpler.
  * Some of these may be ignored by different processors
  */
 public abstract class AbstractPreprocessor implements Runnable {
@@ -16,6 +18,69 @@ public abstract class AbstractPreprocessor implements Runnable {
     @CommandLine.Parameters(description = "The directory to process")
     protected Path buildRoot;
 
-    @CommandLine.Option(names = { "-dp", "--disable-plugin" }, paramLabel = "<plugin>", description = "The plugin to disable")
+    @CommandLine.Option(names = { "-dp", "--disabled-plugins" }, paramLabel = "<plugin>", description = "The plugin to disable", split=",")
     protected List<String> disabledPlugins;
+
+    @CommandLine.Option(names = "--recipe-image", required = true)
+    String recipeImage;
+
+    @CommandLine.Option(names = "--request-processor-image", required = true)
+    String buildRequestProcessorImage;
+
+    protected enum ToolType {
+        ANT,
+        GRADLE,
+        MAVEN,
+        SBT
+    }
+
+    protected ToolType type;
+
+    @Override
+    public void run() {
+        Path jbsDirectory = Path.of(buildRoot.toString(), ".jbs");
+        //noinspection ResultOfMethodCallIgnored
+        jbsDirectory.toFile().mkdirs();
+
+        String containerFile = """
+            FROM %s
+            USER 0
+            WORKDIR /var/workdir
+            RUN mkdir -p /var/workdir/software/settings /original-content/marker
+            ARG CACHE_URL=""
+            ENV CACHE_URL=$CACHE_URL
+            COPY .jbs/run-build.sh /var/workdir
+            COPY . /var/workdir/workspace/source/
+            RUN /var/workdir/run-build.sh
+            """.formatted(recipeImage);
+
+        // TODO: This is a bit of a hack but as Ant doesn't deploy and the previous implementation relied upon using the
+        //     BuildRequestProcessorImage we need to modify the Containerfile. In future the ant-build.sh should probably
+        //     encapsulate this.
+        if (type == ToolType.ANT) {
+            // Don't think we need to mess with keystore as copy-artifacts is simply calling copy commands.
+            containerFile +=
+                """
+                    FROM %s AS build-request-processor
+                    USER 0
+                    WORKDIR /var/workdir
+                    COPY --from=0 /var/workdir/ /var/workdir/
+                    RUN /opt/jboss/container/java/run/run-java.sh copy-artifacts --source-path=/var/workdir/workspace/source --deploy-path=/var/workdir/workspace/artifacts
+                    FROM scratch
+                    COPY --from=1 /var/workdir/workspace/artifacts /
+                    """.formatted(buildRequestProcessorImage);
+        } else {
+            containerFile +=
+                """
+                    FROM scratch
+                    COPY --from=0 /var/workdir/workspace/artifacts /
+                    """;
+        }
+        try {
+            Files.writeString(Paths.get(jbsDirectory.toString(), "Containerfile"), containerFile);
+        } catch (IOException e) {
+            Log.errorf("Unable to write Containerfile", e);
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/ant/AntPrepareCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/ant/AntPrepareCommand.java
@@ -11,8 +11,13 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(name = "ant-prepare")
 public class AntPrepareCommand extends AbstractPreprocessor {
+
+    public AntPrepareCommand() {
+        type = ToolType.ANT;
+    }
+
     @Override
     public void run() {
-
+        super.run();
     }
 }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/gradle/GradlePrepareCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/gradle/GradlePrepareCommand.java
@@ -40,9 +40,14 @@ public class GradlePrepareCommand extends AbstractPreprocessor {
             "version.gradle"
     };
 
+    public GradlePrepareCommand() {
+        type = ToolType.GRADLE;
+    }
+
     @Override
     public void run() {
         try {
+            super.run();
             setupInitScripts();
             Files.walkFileTree(buildRoot, new SimpleFileVisitor<>() {
 

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/maven/MavenPrepareCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/maven/MavenPrepareCommand.java
@@ -40,8 +40,13 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "maven-prepare")
 public class MavenPrepareCommand extends AbstractPreprocessor {
 
+    public MavenPrepareCommand() {
+        type = ToolType.MAVEN;
+    }
+
     @Override
     public void run() {
+        super.run();
         try {
             Files.walkFileTree(buildRoot, new SimpleFileVisitor<>() {
 

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/sbt/SBTPrepareCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/sbt/SBTPrepareCommand.java
@@ -10,7 +10,12 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "sbt-prepare")
 public class SBTPrepareCommand extends AbstractPreprocessor {
 
+    public SBTPrepareCommand() {
+        type = ToolType.SBT;
+    }
+
     @Override
     public void run() {
+        super.run();
     }
 }

--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/build/GradlePreprocessorTestCase.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/build/GradlePreprocessorTestCase.java
@@ -22,6 +22,8 @@ public class GradlePreprocessorTestCase extends AbstractPreprocessorTestCase {
         var args = buildInfoLocator.lookupDisabledPlugins(GRADLE);
         var command = new ArrayList<String>(1 + 2 * args.size());
         command.add("gradle-prepare");
+        command.add("--recipe-image=foobar");
+        command.add("--request-processor-image=barfoo");
         args.forEach(arg -> {
             command.add("-dp");
             command.add(arg);

--- a/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/build/MavenPreprocessorTestCase.java
+++ b/java-components/build-request-processor/src/test/java/com/redhat/hacbs/container/build/MavenPreprocessorTestCase.java
@@ -22,6 +22,8 @@ public class MavenPreprocessorTestCase extends AbstractPreprocessorTestCase {
         var args = buildInfoLocator.lookupDisabledPlugins(MAVEN);
         var command = new ArrayList<String>(1 + 2 * args.size());
         command.add("maven-prepare");
+        command.add("--recipe-image=foobar");
+        command.add("--request-processor-image=barfoo");
         args.forEach(arg -> {
             command.add("-dp");
             command.add(arg);

--- a/java-components/pom.xml
+++ b/java-components/pom.xml
@@ -71,6 +71,8 @@
         <quarkus-quinoa.version>2.4.7</quarkus-quinoa.version>
 
         <format.skip>false</format.skip>
+
+        <imageTag>dev</imageTag>
     </properties>
 
     <modules>
@@ -452,7 +454,7 @@
                             <configuration>
                                 <systemProperties>
                                     <quarkus.container-image.group>${env.QUAY_USERNAME}</quarkus.container-image.group>
-                                    <quarkus.container-image.tag>dev</quarkus.container-image.tag>
+                                    <quarkus.container-image.tag>${imageTag}</quarkus.container-image.tag>
                                     <quarkus.container-image.build>true</quarkus.container-image.build>
                                     <quarkus.container-image.push>true</quarkus.container-image.push>
                                     <quarkus.package.type>mutable-jar</quarkus.package.type>
@@ -611,5 +613,16 @@
                 <module>management-console</module>
             </modules>
         </profile>
-    </profiles>
+        <profile>
+          <activation>
+            <activeByDefault>true</activeByDefault>
+            <property>
+              <name>env.JBS_QUAY_IMAGE_TAG</name>
+            </property>
+          </activation>
+          <properties>
+            <imageTag>${env.JBS_QUAY_IMAGE_TAG}</imageTag>
+          </properties>
+        </profile>
+      </profiles>
 </project>

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -611,7 +611,7 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, db *
 		Pipeline: &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 		Tasks:    &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 	}
-	pr.Spec.PipelineSpec, diagnosticContainerfile, _, _, err = createPipelineSpec(log, attempt.Recipe.Tool, db.Status.CommitTime, jbsConfig, &systemConfig, attempt.Recipe, db, paramValues, buildRequestProcessorImage, attempt.BuildId, preBuildImages)
+	pr.Spec.PipelineSpec, diagnosticContainerfile, err = createPipelineSpec(log, attempt.Recipe.Tool, db.Status.CommitTime, jbsConfig, &systemConfig, attempt.Recipe, db, paramValues, buildRequestProcessorImage, attempt.BuildId, preBuildImages)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
This moves Containerfile generation from the operator to the Java request-processor (specifically the preprocessor step) so it can be reused outside of JBS.