### PR TITLE
Use Konflux Git task

### DIFF
--- a/deploy/tasks/pre-build.yaml
+++ b/deploy/tasks/pre-build.yaml
@@ -20,11 +20,13 @@ spec:
       description: Name of the pipeline run (i.e. unique dependency build name)
       type: string
     - name: GIT_IDENTITY
-      description: Git username
+      description: Git username. If empty, deploy-pre-build-source step will be skipped.
       type: string
+      default: ""
     - name: GIT_URL
-      description: URL to determine whether we're using gitlab or github
+      description: String to determine whether we're using gitlab or github
       type: string
+      default: "github"
     - name: GIT_SSL_VERIFICATION
       description: Whether to disable ssl verification
       type: string
@@ -32,6 +34,7 @@ spec:
     - name: GIT_REUSE_REPOSITORY
       description: Whether to reuse existing git repository or create new one
       type: string
+      default: "false"
     - name: SCM_URL
       description: Reference to the git repository
       type: string
@@ -80,6 +83,7 @@ spec:
       script: |
         $(params.BUILD_SCRIPT)
         /opt/jboss/container/java/run/run-java.sh $(params.BUILD_TOOL)-prepare $(workspaces.source.path)/source --recipe-image=$(params.RECIPE_IMAGE) --request-processor-image=$(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE) --disabled-plugins=$(params.BUILD_PLUGINS)
+    # TODO: Look at making this optional until we know whether we need to store source
     - name: create-pre-build-source
       image: $(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE)
       securityContext:

--- a/deploy/tasks/pre-build.yaml
+++ b/deploy/tasks/pre-build.yaml
@@ -19,17 +19,11 @@ spec:
     - name: NAME
       description: Name of the pipeline run (i.e. unique dependency build name)
       type: string
-    - name: GIT_SCRIPT
-      description: Git clone commands
-      type: string
     - name: GIT_IDENTITY
       description: Git username
       type: string
     - name: GIT_URL
       description: URL to determine whether we're using gitlab or github
-      type: string
-    - name: GIT_DEPLOY_TOKEN
-      description: Name of jvm-build-git-repo-secrets secret containing git password/token to use.
       type: string
     - name: GIT_SSL_VERIFICATION
       description: Whether to disable ssl verification
@@ -72,27 +66,6 @@ spec:
       mountPath: /var/workdir
     - name: tls
   steps:
-    # Should we use our own git clone task? Or embed (somehow) Konflux's version?
-    - name: git-clone
-      image: $(params.RECIPE_IMAGE)
-      computeResources:
-        limits:
-          cpu: 300m
-          memory: 512Mi
-        requests:
-          cpu: 10m
-          memory: 512Mi
-      securityContext:
-        runAsUser: 0
-      env:
-        - name: GIT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              optional: true
-              name: jvm-build-git-secrets
-              key: .git-credentials
-      script: |
-        $(params.GIT_SCRIPT)
     - name: preprocessor
       image: $(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE)
       securityContext:
@@ -123,7 +96,7 @@ spec:
           valueFrom:
             secretKeyRef:
               optional: true
-              name: $(params.GIT_DEPLOY_TOKEN)
+              name: jvm-build-git-repo-secrets
               key: gitdeploytoken
       args:
         - deploy-pre-build-source

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/git/Git.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/git/Git.java
@@ -1,5 +1,6 @@
 package com.redhat.hacbs.container.deploy.git;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -126,6 +127,10 @@ public abstract class Git {
             //var tagNameFromDescribe = jGit.describe().setTags(true).setTarget(commit).call();
             var objectId = ObjectId.fromString(commit);
             var jRepo = jGit.getRepository();
+            if (new File(jGit.getRepository().getDirectory(), "shallow").exists()) {
+                Log.warnf("Git repository is shallow repository - converting.");
+                jGit.fetch().setUnshallow(true).call();
+            }
             @SuppressWarnings("deprecation")
             var tagName = jRepo.getRefDatabase().getRefsByPrefix(Constants.R_TAGS).stream().
                 filter(ref -> objectId.equals(jRepo.peel(ref).getPeeledObjectId()) || objectId.equals(ref.getObjectId())).

--- a/pkg/apis/jvmbuildservice/v1alpha1/jbsconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/jbsconfig_types.go
@@ -33,7 +33,8 @@ const (
 	ConfigArtifactCacheWorkerThreadsDefault = "50"
 	ConfigArtifactCacheStorageDefault       = "10Gi"
 
-	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/pre-build.yaml"
+	KonfluxGitDefinition          = "https://raw.githubusercontent.com/konflux-ci/build-definitions/refs/heads/main/task/git-clone/0.1/git-clone.yaml"
+	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/rnc/jvm-build-service/GIT/deploy/tasks/pre-build.yaml"
 	KonfluxBuildDefinitions       = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/buildah-oci-ta.yaml"
 	KonfluxMavenDeployDefinitions = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/maven-deployment.yaml"
 )

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -375,13 +375,6 @@ func createPipelineSpec(log logr.Logger, tool string, commitTime int64, jbsConfi
 						StringVal: strconv.FormatBool(!recipe.DisableSubmodules),
 					},
 				},
-				{
-					Name: "fetchTags",
-					Value: tektonpipeline.ParamValue{
-						Type:      tektonpipeline.ParamTypeString,
-						StringVal: "true",
-					},
-				},
 			},
 		}}
 		pipelinePreBuildTask := []tektonpipeline.PipelineTask{{

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -375,6 +375,13 @@ func createPipelineSpec(log logr.Logger, tool string, commitTime int64, jbsConfi
 						StringVal: strconv.FormatBool(!recipe.DisableSubmodules),
 					},
 				},
+				{
+					Name: "fetchTags",
+					Value: tektonpipeline.ParamValue{
+						Type:      tektonpipeline.ParamTypeString,
+						StringVal: "true",
+					},
+				},
 			},
 		}}
 		pipelinePreBuildTask := []tektonpipeline.PipelineTask{{

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -358,7 +358,7 @@ func createPipelineSpec(log logr.Logger, tool string, commitTime int64, jbsConfi
 					Name: "url",
 					Value: tektonpipeline.ParamValue{
 						Type:      tektonpipeline.ParamTypeString,
-						StringVal: db.Spec.ScmInfo.SCMURL,
+						StringVal: modifyURLFragment(log, db.Spec.ScmInfo.SCMURL),
 					},
 				},
 				{

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -618,10 +618,18 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, db *
 
 	attempt.Build.DiagnosticDockerFile = diagnosticContainerfile
 
+	qty, _ := resource.ParseQuantity("1Gi")
 	pr.Spec.Params = paramValues
 	pr.Spec.Workspaces = []tektonpipeline.WorkspaceBinding{
 		{Name: WorkspaceBuildSettings, EmptyDir: &v1.EmptyDirVolumeSource{}},
-		{Name: WorkspaceSource, EmptyDir: &v1.EmptyDirVolumeSource{}},
+		{Name: WorkspaceSource, VolumeClaimTemplate: &v1.PersistentVolumeClaim{
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{"storage": qty},
+				},
+			},
+		}},
 	}
 
 	if !jbsConfig.Spec.CacheSettings.DisableTLS {


### PR DESCRIPTION
@matejonnet This is somewhat similar to #2142 except that it fully references the Konflux remote task and integrates with JBS rather than a standalone example. It also makes the following other changes:

- The pre-build task is simplified and more defaults are specified so that the push-pre-build-source step is now optional
- The code to handle git now also handles shallow repositories
- As you found in #2142, using `EmptyDir` doesn't work across tasks (https://tekton.dev/docs/pipelines/workspaces/#emptydir) so switched to using PersistentVolumeClaim inside the golang.
- I've improved/fixed diagnostic dockerfiles to use the OCI image instead which might provide example ideas for future.