### PR TITLE
Use single pipeline

### DIFF
--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -40,17 +40,11 @@ spec:
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
       script: |
         echo "Restoring artifacts to workspace"
-        ls -laR /var/workdir
-        echo "Root"
-        ls -laR $HOME
-        echo "Restoring artifacts to workspace"
         URL=$IMAGE_URL
         DIGEST=$IMAGE_DIGEST
         AARCHIVE=$(oras manifest fetch $ORAS_OPTIONS $URL@$DIGEST | jq --raw-output '.layers[0].digest')
         echo "URL $URL DIGEST $DIGEST AARCHIVE $AARCHIVE"
         use-archive oci:$URL@$AARCHIVE=/var/workdir/
-        ls -laR /var/workdir
-        echo "DONE"
       env:
         - name: IMAGE_DIGEST
           value: $(params.IMAGE_DIGEST)

--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -33,8 +33,7 @@ spec:
       type: string
       default: "quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:dev"
   workspaces:
-    - description: Workspace.
-      name: source
+    - name: source
       mountPath: /var/workdir
   steps:
     - name: restore-trusted-artifact

--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -32,23 +32,33 @@ spec:
       description: Name of the processor image. Useful to override for development.
       type: string
       default: "quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:dev"
-  volumes:
-    - name: workdir
-      emptyDir: {}
-  stepTemplate:
-    volumeMounts:
-      - mountPath: /var/workdir
-        name: workdir
+  workspaces:
+    - description: Workspace.
+      name: source
+      mountPath: /var/workdir
+#  volumes:
+#    - name: workdir
+#      emptyDir: {}
+#  stepTemplate:
+#    volumeMounts:
+#      - mountPath: /var/workdir
+#        name: workdir
   steps:
     - name: restore-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
       script: |
         echo "Restoring artifacts to workspace"
+        ls -laR /var/workdir
+        echo "Root"
+        ls -laR $HOME
+        echo "Restoring artifacts to workspace"
         URL=$IMAGE_URL
         DIGEST=$IMAGE_DIGEST
         AARCHIVE=$(oras manifest fetch $ORAS_OPTIONS $URL@$DIGEST | jq --raw-output '.layers[0].digest')
         echo "URL $URL DIGEST $DIGEST AARCHIVE $AARCHIVE"
-        use-archive oci:$URL@$AARCHIVE=/var/workdir/artifacts
+        use-archive oci:$URL@$AARCHIVE=/var/workdir/
+        ls -laR /var/workdir
+        echo "DONE"
       env:
         - name: IMAGE_DIGEST
           value: $(params.IMAGE_DIGEST)
@@ -77,6 +87,6 @@ spec:
               key: mavenpassword
       args:
         - deploy
-        - --directory=/var/workdir/artifacts
+        - --directory=/var/workdir/deployment
         - --mvn-repo=$(params.MVN_REPO)
         - --mvn-username=$(params.MVN_USERNAME)

--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -36,13 +36,6 @@ spec:
     - description: Workspace.
       name: source
       mountPath: /var/workdir
-#  volumes:
-#    - name: workdir
-#      emptyDir: {}
-#  stepTemplate:
-#    volumeMounts:
-#      - mountPath: /var/workdir
-#        name: workdir
   steps:
     - name: restore-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac

--- a/deploy/tasks/pre-build.yaml
+++ b/deploy/tasks/pre-build.yaml
@@ -67,7 +67,6 @@ spec:
     - description: The git repo will be cloned onto the volume backing this Workspace.
       name: source
       mountPath: /var/workdir
-    - name: tls
   steps:
     - name: preprocessor
       image: $(params.JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE)

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
@@ -105,7 +105,7 @@ public abstract class AbstractPreprocessor implements Runnable {
             export MAVEN_HOME=${MAVEN_HOME:=/opt/maven/3.8.8}
             export GRADLE_USER_HOME="${JBS_WORKDIR}/software/settings/.gradle"
 
-            mkdir -p ${JBS_WORKDIR}/logs ${JBS_WORKDIR}/packages ${HOME}/.sbt/1.0 ${GRADLE_USER_HOME} ${HOME}/.m2
+            mkdir -p ${JBS_WORKDIR}/logs ${JBS_WORKDIR}/packages ${JBS_WORKDIR}/settings ${HOME}/.sbt/1.0 ${GRADLE_USER_HOME} ${HOME}/.m2
             cd ${JBS_WORKDIR}/source
 
             if [ -n "${JAVA_HOME}" ]; then
@@ -119,6 +119,7 @@ public abstract class AbstractPreprocessor implements Runnable {
         runBuild += getMavenSetup();
 
         runBuild += """
+                cp -a ${HOME}/.m2/*.xml ${JBS_WORKDIR}/settings
             fi
 
             if [ -n "${GRADLE_HOME}" ]; then
@@ -190,7 +191,8 @@ public abstract class AbstractPreprocessor implements Runnable {
                     COPY --from=0 /var/workdir/ /var/workdir/
                     RUN /opt/jboss/container/java/run/run-java.sh copy-artifacts --source-path=/var/workdir/workspace/source --deploy-path=/var/workdir/workspace/artifacts
                     FROM scratch
-                    COPY --from=1 /var/workdir/workspace/artifacts /
+                    COPY --from=1 /var/workdir/workspace/settings /
+                    COPY --from=1 /var/workdir/workspace/artifacts /deployment/
                     """.formatted(buildRequestProcessorImage);
         } else {
             containerFile +=

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
@@ -191,16 +191,19 @@ public abstract class AbstractPreprocessor implements Runnable {
                     COPY --from=0 /var/workdir/ /var/workdir/
                     RUN /opt/jboss/container/java/run/run-java.sh copy-artifacts --source-path=/var/workdir/workspace/source --deploy-path=/var/workdir/workspace/artifacts
                     FROM scratch
-                    COPY --from=1 /var/workdir/workspace/settings /
+                    COPY --from=1 /var/workdir/workspace/settings /settings/
                     COPY --from=1 /var/workdir/workspace/artifacts /deployment/
                     """.formatted(buildRequestProcessorImage);
         } else {
             containerFile +=
                 """
                     FROM scratch
-                    COPY --from=0 /var/workdir/workspace/artifacts /
+                    COPY --from=0 /var/workdir/workspace/settings /settings/
+                    COPY --from=0 /var/workdir/workspace/artifacts /deployment/
                     """;
         }
+
+        Log.warnf("### containerFile is\n%s", containerFile);
 
         return containerFile;
     }

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/BuildVerifyCommand.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/deploy/BuildVerifyCommand.java
@@ -53,9 +53,6 @@ public class BuildVerifyCommand implements Runnable {
     @CommandLine.Option(names = "--task-run-name")
     String taskRun;
 
-    @CommandLine.Option(names = "--logs-path")
-    Path logsPath;
-
     @CommandLine.Option(required = true, names = "--scm-uri")
     String scmUri;
 

--- a/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
@@ -49,5 +49,5 @@ const (
 	KonfluxGitDefinition          = "https://raw.githubusercontent.com/konflux-ci/build-definitions/refs/heads/main/task/git-clone/0.1/git-clone.yaml"
 	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/pre-build.yaml"
 	KonfluxBuildDefinitions       = "https://raw.githubusercontent.com/konflux-ci/build-definitions/refs/heads/main/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml"
-	KonfluxMavenDeployDefinitions = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/maven-deployment.yaml"
+	KonfluxMavenDeployDefinitions = "https://raw.githubusercontent.com/rnc/jvm-build-service/PIPELINE/deploy/tasks/maven-deployment.yaml"
 )

--- a/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
@@ -47,7 +47,7 @@ type SystemConfigList struct {
 
 const (
 	KonfluxGitDefinition          = "https://raw.githubusercontent.com/konflux-ci/build-definitions/refs/heads/main/task/git-clone/0.1/git-clone.yaml"
-	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/pre-build.yaml"
+	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/rnc/jvm-build-service/PIPELINE/deploy/tasks/pre-build.yaml"
 	KonfluxBuildDefinitions       = "https://raw.githubusercontent.com/konflux-ci/build-definitions/refs/heads/main/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml"
 	KonfluxMavenDeployDefinitions = "https://raw.githubusercontent.com/rnc/jvm-build-service/PIPELINE/deploy/tasks/maven-deployment.yaml"
 )

--- a/pkg/reconciler/dependencybuild/buildrecipeyaml.go
+++ b/pkg/reconciler/dependencybuild/buildrecipeyaml.go
@@ -273,7 +273,7 @@ func createPipelineSpec(log logr.Logger, tool string, commitTime int64, jbsConfi
 	runAfterBuild = append(runAfter, BuildTaskName)
 
 	ps := &tektonpipeline.PipelineSpec{
-		Workspaces: []tektonpipeline.PipelineWorkspaceDeclaration{{Name: WorkspaceSource}, {Name: WorkspaceTls}},
+		Workspaces: []tektonpipeline.PipelineWorkspaceDeclaration{{Name: WorkspaceSource}},
 	}
 
 	if preBuildImageRequired {
@@ -345,7 +345,6 @@ func createPipelineSpec(log logr.Logger, tool string, commitTime int64, jbsConfi
 			},
 			Workspaces: []tektonpipeline.WorkspacePipelineTaskBinding{
 				{Name: WorkspaceSource, Workspace: WorkspaceSource},
-				{Name: WorkspaceTls, Workspace: WorkspaceTls},
 			},
 			Params: []tektonpipeline.Param{
 				{
@@ -585,10 +584,6 @@ use-archive oci:$URL@$AARCHIVE=$(workspaces.source.path)/artifacts`, orasOptions
 		},
 		Timeout: &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout},
 		Params:  []tektonpipeline.Param{{Name: PipelineResultPreBuildImageDigest, Value: tektonpipeline.ParamValue{Type: tektonpipeline.ParamTypeString, StringVal: preBuildImage}}},
-		Workspaces: []tektonpipeline.WorkspacePipelineTaskBinding{
-			{Name: WorkspaceSource, Workspace: WorkspaceSource},
-			{Name: WorkspaceTls, Workspace: WorkspaceTls},
-		},
 	}}
 	ps.Tasks = append(pipelineTask, ps.Tasks...)
 	for _, i := range postBuildTask.Results {

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -140,8 +140,8 @@ func (r *ReconcileDependencyBuild) Reconcile(ctx context.Context, request reconc
 			return reconcile.Result{}, nil
 		case v1alpha1.DependencyBuildStateBuilding:
 			return r.handleStateBuilding(ctx, &db)
-		case v1alpha1.DependencyBuildStateDeploying:
-			return r.handleStateDeploying(ctx, &db)
+		//case v1alpha1.DependencyBuildStateDeploying:
+		//	return r.handleStateDeploying(ctx, &db)
 		case v1alpha1.DependencyBuildStateContaminated:
 			return r.handleStateContaminated(ctx, &db)
 		case v1alpha1.DependencyBuildStateComplete:
@@ -168,8 +168,8 @@ func (r *ReconcileDependencyBuild) Reconcile(ctx context.Context, request reconc
 			return r.handleAnalyzeBuildPipelineRunReceived(ctx, &pr)
 		case PipelineTypeBuild:
 			return r.handleBuildPipelineRunReceived(ctx, &pr)
-		case PipelineTypeDeploy:
-			return r.handleDeployPipelineRunReceived(ctx, &pr)
+			//case PipelineTypeDeploy:
+			//	return r.handleDeployPipelineRunReceived(ctx, &pr)
 		}
 	}
 
@@ -849,7 +849,7 @@ func (r *ReconcileDependencyBuild) handleBuildPipelineRunReceived(ctx context.Co
 
 			problemContaminates := db.Status.ProblemContaminates()
 			if len(problemContaminates) == 0 {
-				return reconcile.Result{}, r.updateDependencyBuildState(ctx, db, v1alpha1.DependencyBuildStateDeploying, "build was completed")
+				return reconcile.Result{}, r.updateDependencyBuildState(ctx, db, v1alpha1.DependencyBuildStateComplete, "build was completed")
 			} else {
 				msg := "The DependencyBuild %s/%s was contaminated with community dependencies"
 				log.Info(fmt.Sprintf(msg, db.Namespace, db.Name))
@@ -1364,6 +1364,7 @@ func (r *ReconcileDependencyBuild) removePipelineFinalizer(ctx context.Context, 
 func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db *v1alpha1.DependencyBuild) (reconcile.Result, error) {
 
 	log, _ := logr.FromContext(ctx)
+	log.Info(fmt.Sprintf("### handleStateDeploying %#v", db.Name))
 	//first we check to see if the pipeline exists
 
 	pr := tektonpipeline.PipelineRun{}

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -236,9 +236,9 @@ func (r *ReconcileDependencyBuild) handleStateNew(ctx context.Context, db *v1alp
 		return reconcile.Result{}, err
 	}
 	if !jbsConfig.Spec.CacheSettings.DisableTLS {
-		pr.Spec.Workspaces = []tektonpipeline.WorkspaceBinding{{Name: "tls", ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.TlsConfigMapName}}}}
+		pr.Spec.Workspaces = []tektonpipeline.WorkspaceBinding{{Name: WorkspaceTls, ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.TlsConfigMapName}}}}
 	} else {
-		pr.Spec.Workspaces = []tektonpipeline.WorkspaceBinding{{Name: "tls", EmptyDir: &v1.EmptyDirVolumeSource{}}}
+		pr.Spec.Workspaces = []tektonpipeline.WorkspaceBinding{{Name: WorkspaceTls, EmptyDir: &v1.EmptyDirVolumeSource{}}}
 	}
 	pr.Namespace = db.Namespace
 	pr.Name = fmt.Sprintf("%s-build-discovery-%d", db.Name, db.Status.PipelineRetries)
@@ -644,11 +644,12 @@ func (r *ReconcileDependencyBuild) handleStateBuilding(ctx context.Context, db *
 			},
 		}}
 	}
-	if !jbsConfig.Spec.CacheSettings.DisableTLS {
-		pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: "tls", ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.TlsConfigMapName}}})
-	} else {
-		pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: "tls", EmptyDir: &v1.EmptyDirVolumeSource{}})
-	}
+	// TODO: DisableTLS defaults to true. Further the tls workspace has been removed from the build pipeline so an alternate method would be needed.
+	//if !jbsConfig.Spec.CacheSettings.DisableTLS {
+	//	pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: WorkspaceTls, ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.TlsConfigMapName}}})
+	//} else {
+	//	pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: WorkspaceTls, EmptyDir: &v1.EmptyDirVolumeSource{}})
+	//}
 	pr.Spec.Timeouts = &tektonpipeline.TimeoutFields{Pipeline: &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout}}
 	if err := controllerutil.SetOwnerReference(db, &pr, r.scheme); err != nil {
 		return reconcile.Result{}, err
@@ -1207,7 +1208,7 @@ func (r *ReconcileDependencyBuild) createLookupBuildInfoPipeline(ctx context.Con
 		envVars = append(envVars, v1.EnvVar{Name: "REGISTRY_TOKEN", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: jbsConfig.ImageRegistry().SecretName}, Key: v1alpha1.ImageSecretTokenKey, Optional: &secretOptional}}})
 	}
 	buildInfoTask := tektonpipeline.TaskSpec{
-		Workspaces: []tektonpipeline.WorkspaceDeclaration{{Name: "tls"}},
+		Workspaces: []tektonpipeline.WorkspaceDeclaration{{Name: WorkspaceTls}},
 		Results:    []tektonpipeline.TaskResult{{Name: BuildInfoPipelineResultBuildInfo}},
 		Steps: []tektonpipeline.Step{
 			{
@@ -1237,12 +1238,12 @@ func (r *ReconcileDependencyBuild) createLookupBuildInfoPipeline(ctx context.Con
 	}
 	buildInfoTask.Steps[0].Script = artifactbuild.InstallKeystoreIntoBuildRequestProcessor(args)
 	return &tektonpipeline.PipelineSpec{
-		Workspaces: []tektonpipeline.PipelineWorkspaceDeclaration{{Name: "tls"}},
+		Workspaces: []tektonpipeline.PipelineWorkspaceDeclaration{{Name: WorkspaceTls}},
 		Results:    []tektonpipeline.PipelineResult{{Name: BuildInfoPipelineResultBuildInfo, Value: tektonpipeline.ResultValue{Type: tektonpipeline.ParamTypeString, StringVal: "$(tasks.task.results." + BuildInfoPipelineResultBuildInfo + ")"}}},
 		Tasks: []tektonpipeline.PipelineTask{
 			{
 				Name:       "task",
-				Workspaces: []tektonpipeline.WorkspacePipelineTaskBinding{{Name: "tls", Workspace: "tls"}},
+				Workspaces: []tektonpipeline.WorkspacePipelineTaskBinding{{Name: WorkspaceTls, Workspace: WorkspaceTls}},
 				TaskSpec: &tektonpipeline.EmbeddedTask{
 					TaskSpec: buildInfoTask,
 				},
@@ -1427,9 +1428,9 @@ func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db 
 	pr.Spec.Workspaces = []tektonpipeline.WorkspaceBinding{}
 
 	if !jbsConfig.Spec.CacheSettings.DisableTLS {
-		pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: "tls", ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.TlsConfigMapName}}})
+		pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: WorkspaceTls, ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: v1alpha1.TlsConfigMapName}}})
 	} else {
-		pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: "tls", EmptyDir: &v1.EmptyDirVolumeSource{}})
+		pr.Spec.Workspaces = append(pr.Spec.Workspaces, tektonpipeline.WorkspaceBinding{Name: WorkspaceTls, EmptyDir: &v1.EmptyDirVolumeSource{}})
 	}
 	pr.Spec.Timeouts = &tektonpipeline.TimeoutFields{Pipeline: &v12.Duration{Duration: time.Hour * v1alpha1.DefaultTimeout}}
 	if jbsConfig.Annotations != nil && jbsConfig.Annotations[jbsconfig.TestRegistry] == "true" {

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -1362,10 +1362,9 @@ func (r *ReconcileDependencyBuild) removePipelineFinalizer(ctx context.Context, 
 	return reconcile.Result{}, nil
 }
 
+// TODO: ### Either remove or replace with verification step *but* the contaminants/verification is all tied to the build pipeline in dependencybuild.go
 func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db *v1alpha1.DependencyBuild) (reconcile.Result, error) {
-
 	log, _ := logr.FromContext(ctx)
-	log.Info(fmt.Sprintf("### handleStateDeploying %#v", db.Name))
 	//first we check to see if the pipeline exists
 
 	pr := tektonpipeline.PipelineRun{}

--- a/pkg/reconciler/dependencybuild/dependencybuild.go
+++ b/pkg/reconciler/dependencybuild/dependencybuild.go
@@ -1363,6 +1363,7 @@ func (r *ReconcileDependencyBuild) removePipelineFinalizer(ctx context.Context, 
 }
 
 // TODO: ### Either remove or replace with verification step *but* the contaminants/verification is all tied to the build pipeline in dependencybuild.go
+/*
 func (r *ReconcileDependencyBuild) handleStateDeploying(ctx context.Context, db *v1alpha1.DependencyBuild) (reconcile.Result, error) {
 	log, _ := logr.FromContext(ctx)
 	//first we check to see if the pipeline exists
@@ -1498,6 +1499,7 @@ func (r *ReconcileDependencyBuild) handleDeployPipelineRunReceived(ctx context.C
 	}
 	return reconcile.Result{}, nil
 }
+*/
 
 // This is to remove any '#xxx' fragment from a URI so that git clone commands don't need separate adjustment
 func modifyURLFragment(log logr.Logger, scmURL string) string {


### PR DESCRIPTION
Changes to the task yamls are to allow the settings.xml to be stored in the OCI image as well thereby making it available to the deploy step. This will be useful when deploying to Indy.

`tls` workspace references been removed from the tasks as they aren't required (within JBS we're running with `disableTLS` currently so they are unused and wouldn't work in the new layout anyway).  

For JBS, this normalizes to a single pipeline (note that not all of the code from the secondary pipeline added in #1597 and #1625 has been removed/reverted). I also isolated the storage for the verify step so that any testing does not affect the deploy step.