### PR TITLE
Pass MAVEN_PASSWORD as env var via taskspec

### DIFF
--- a/deploy/tasks/maven-deployment.yaml
+++ b/deploy/tasks/maven-deployment.yaml
@@ -95,11 +95,6 @@ spec:
           name: trusted-ca
           readOnly: true
       env:
-        - name: MAVEN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: $(params.MVN_PASSWORD)
-              key: mavenpassword
         - name: ACCESS_TOKEN
           value: $(params.ACCESS_TOKEN)
       args:


### PR DESCRIPTION
Due to https://www.github.com/tektoncd/pipeline/issues/8249 its not possible to marks the secret as optional in tekton so by removing it from the yaml this makes it easier to reuse that yaml for the pnc pipeline while keeping the env var for the CI