### PR TITLE
Save and copy build.log

### DIFF
--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
@@ -189,7 +189,7 @@ public abstract class AbstractPreprocessor implements Runnable {
             ENV PROXY_URL=$PROXY_URL
             COPY .jbs/run-build.sh /var/workdir
             COPY . /var/workdir/workspace/source/
-            RUN /var/workdir/run-build.sh
+            RUN /var/workdir/run-build.sh | tee /var/workdir/build.log
             """.formatted(recipeImage);
 
         if (type == ToolType.ANT) {
@@ -203,12 +203,14 @@ public abstract class AbstractPreprocessor implements Runnable {
                     RUN /opt/jboss/container/java/run/run-java.sh copy-artifacts --source-path=/var/workdir/workspace/source --deploy-path=/var/workdir/workspace/artifacts
                     FROM scratch
                     COPY --from=1 /var/workdir/workspace/artifacts /deployment/
+                    COPY --from=0 /var/workdir/build.log /log/
                     """.formatted(buildRequestProcessorImage);
         } else {
             containerFile +=
                 """
                     FROM scratch
                     COPY --from=0 /var/workdir/workspace/artifacts /deployment/
+                    COPY --from=0 /var/workdir/build.log /log/
                     """;
         }
 

--- a/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
+++ b/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/build/preprocessor/AbstractPreprocessor.java
@@ -189,7 +189,7 @@ public abstract class AbstractPreprocessor implements Runnable {
             ENV PROXY_URL=$PROXY_URL
             COPY .jbs/run-build.sh /var/workdir
             COPY . /var/workdir/workspace/source/
-            RUN /var/workdir/run-build.sh | tee /var/workdir/build.log
+            RUN /var/workdir/run-build.sh 2>&1 | tee /var/workdir/build.log
             """.formatted(recipeImage);
 
         if (type == ToolType.ANT) {


### PR DESCRIPTION
This is for JBS-70. According to @rnc 's comment that directly changing buildah task would "...affect multiple teams. we should...keeping the changes isolated to only our code base", I move the change here. 