### PR TITLE
Run prebuild with socksProxyHost

### DIFF
--- a/deploy/tasks/pre-build.yaml
+++ b/deploy/tasks/pre-build.yaml
@@ -56,6 +56,9 @@ spec:
         - --tooling-image=$(params.PNC_KONFLUX_TOOLING_IMAGE)
         - --type=$(params.BUILD_TOOL)
         - $(workspaces.source.path)/source
+      script: |
+        #!/bin/bash
+        JAVA_OPTS="-DsocksProxyHost=does.not.exist $JAVA_OPTS" /opt/jboss/container/java/run/run-java.sh $@
       env:
         - name: BUILD_SCRIPT
           value: $(params.BUILD_SCRIPT)

--- a/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
+++ b/pkg/apis/jvmbuildservice/v1alpha1/systemconfig_types.go
@@ -47,7 +47,7 @@ type SystemConfigList struct {
 
 const (
 	KonfluxGitDefinition          = "https://raw.githubusercontent.com/konflux-ci/build-definitions/refs/heads/main/task/git-clone/0.1/git-clone.yaml"
-	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/pre-build.yaml"
+	KonfluxPreBuildDefinitions    = "https://raw.githubusercontent.com/rnc/jvm-build-service/UNSHARE/deploy/tasks/pre-build.yaml"
 	KonfluxPreBuildGitDefinitions = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/pre-build-git.yaml"
 	KonfluxBuildDefinitions       = "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/tasks/buildah-oci-ta.yaml"
 	KonfluxDeployDefinitions      = "https://raw.githubusercontent.com/ruhan1/jvm-build-service/main-uploadlog/deploy/tasks/push-results.yaml"


### PR DESCRIPTION
This is an experiment to demonstrate whether prebuild needs network access and if not whether it can be isolated via the socksProxyHost using a dummy option as per https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html (thereby avoiding having to use unshare)
